### PR TITLE
Add group add to readme

### DIFF
--- a/README
+++ b/README
@@ -123,6 +123,12 @@ Raspberry Pi 4/5:
 	While using the outdated fkms driver still works with this plugin, there might be
 	some problems when viewing interlaced material and displaying the OSD.
 
+	The 'vdr' user needs to be added to 'audio' and 'render' to access /dev/snd/* and
+	/dev/dri/render*:
+
+	usermod -a -G audio vdr
+	usermod -a -G render vdr
+
 Requirements:
 -------------
         No running X!

--- a/README
+++ b/README
@@ -123,7 +123,7 @@ Raspberry Pi 4/5:
 	While using the outdated fkms driver still works with this plugin, there might be
 	some problems when viewing interlaced material and displaying the OSD.
 
-	In case of permission problems under Raspberry Pi OS with VDR installed via apt,
+	In case of permission problems under Raspberry Pi OS 5 with VDR installed via apt,
 	you might need to add the vdr user to the audio and render groups:
 
 	usermod -a -G audio vdr

--- a/README
+++ b/README
@@ -123,8 +123,8 @@ Raspberry Pi 4/5:
 	While using the outdated fkms driver still works with this plugin, there might be
 	some problems when viewing interlaced material and displaying the OSD.
 
-	The 'vdr' user needs to be added to 'audio' and 'render' to access /dev/snd/* and
-	/dev/dri/render*:
+	In case of permission problems under Raspberry Pi OS with VDR installed via apt,
+	you might need to add the vdr user to the audio and render groups:
 
 	usermod -a -G audio vdr
 	usermod -a -G render vdr


### PR DESCRIPTION
Otherwise a warning is logged saying "No such file or directory" when opening the default alsa device and video playback doesn't work.