### PR TITLE
Initialize audio lazily

### DIFF
--- a/audio.cpp
+++ b/audio.cpp
@@ -698,6 +698,8 @@ int cSoftHdAudio::Setup(AVCodecContext *ctx, int samplerate, int channels, int p
 {
 	int err = 0;
 
+	Init();
+
 	if (samplerate != (int)m_hwSampleRate ||
 	   (channels != (int)m_hwNumChannels && !(m_downmix && m_hwNumChannels == 2))) {
 
@@ -1262,14 +1264,16 @@ void cSoftHdAudio::SetAutoAES(int onoff)
 /**
  * Initialize audio output module
  *
- * @param passthrough     passthrough mask
  */
-void cSoftHdAudio::Init(int passthrough)
+void cSoftHdAudio::Init()
 {
-	m_passthrough = passthrough;
-	InitRingbuffer();
-	AlsaInit();
-	m_pAudioThread = new cAudioThread(this);
+	if(!m_initialized) {
+		InitRingbuffer();
+		AlsaInit();
+		m_pAudioThread = new cAudioThread(this);
+
+		m_initialized = true;
+	}
 }
 
 /**

--- a/audio.h
+++ b/audio.h
@@ -43,7 +43,6 @@ public:
 	cSoftHdAudio(cSoftHdDevice *);
 	virtual ~cSoftHdAudio(void);
 
-	void Init(int);
 	void Exit(void);
 	int Setup(AVCodecContext *, int , int , int);
 	void Resume(void);
@@ -86,6 +85,8 @@ public:
 	char AlsaPlayerRunning(void) { return m_alsaPlayerRunning; };
 
 private:
+	void Init();
+
 	cSoftHdDevice *m_pDevice;               ///< pointer to device
 
 	// thread
@@ -94,6 +95,7 @@ private:
 	void StartAudioThread(AVFrame *);       ///< start the audio thread
 
 	// common audio, alsa
+	bool m_initialized = false;             ///< class initialized
 	const int m_bytesPerSample = 2;         ///< number of bytes per sample
 	unsigned int m_hwSampleRate;            ///< hardware sample rate in Hz
 	unsigned int m_hwNumChannels;           ///< number of hardware channels

--- a/softhddevice.cpp
+++ b/softhddevice.cpp
@@ -567,8 +567,6 @@ void cSoftHdDevice::Start(void)
 	if (!m_pAudioDecoder) {
 
 		// audio
-		m_pAudio->Init(m_pAudio->GetPassthrough());
-
 		m_pAudio->SetBufferTimeInMs(m_pConfig->ConfigAudioBufferTime);
 		m_pAudioAvPkt = av_packet_alloc();
 		av_new_packet(m_pAudioAvPkt, AUDIO_BUFFER_SIZE);


### PR DESCRIPTION
When there's no HDMI device connected (aka the TV is off) while VDR is starting on RPI 5 with Raspberry Pi OS 5, opening the ALSA device fails:
```
2025-10-05T21:23:26.445422+0200 raspi vdr[4538]: [4538] [softhddevice] audio: OpenAlsaDevice: could not open device 'hdmi:CARD=vc4hdmi0,DEV=0' error: Unknown error 524
2025-10-05T21:23:26.446421+0200 raspi vdr[4538]: [4538] [softhddevice] audio: OpenAlsaDevice: could not open device 'hdmi:CARD=vc4hdmi1,DEV=0' error: Unknown error 524
2025-10-05T21:23:26.450089+0200 raspi vdr[4538]: [4538] [softhddevice] audio: OpenAlsaDevice: could not open device 'default:CARD=vc4hdmi0' error: Unknown error 524
2025-10-05T21:23:26.450226+0200 raspi vdr[4538]: [4538] [softhddevice] audio: OpenAlsaDevice: could not open device 'sysdefault:CARD=vc4hdmi0' error: Unknown error 524
2025-10-05T21:23:26.451216+0200 raspi vdr[4538]: [4538] [softhddevice] audio: OpenAlsaDevice: could not open device 'default:CARD=vc4hdmi1' error: Unknown error 524
2025-10-05T21:23:26.452895+0200 raspi vdr[4538]: [4538] [softhddevice] audio: OpenAlsaDevice: could not open device 'sysdefault:CARD=vc4hdmi1' error: Unknown error 524
2025-10-05T21:23:26.453013+0200 raspi vdr[4538]: [4538] [softhddevice] audio: OpenAlsaDevice: could not open device 'default' error: Unknown error 524
2025-10-05T21:23:26.453037+0200 raspi vdr[4538]: [4538] [softhddevice] audio: AlsaInitPCMDevice: using device 'null'
```

This PR opens the ALSA device when the first playback is started:
```
2025-10-05T21:28:56.505745+0200 raspi vdr[4766]: [4783] dvbplayer thread started (pid=4766, tid=4783, prio=high)
2025-10-05T21:28:56.505877+0200 raspi vdr[4766]: [4783] resuming replay at index 47984 (0:15:59.34)
2025-10-05T21:28:56.505962+0200 raspi vdr[4766]: [4784] non blocking file reader thread started (pid=4766, tid=4784, prio=high)
2025-10-05T21:28:56.528181+0200 raspi vdr[4766]: [4783] [softhddevice] audio: using device 'hdmi:CARD=vc4hdmi0,DEV=0'
2025-10-05T21:28:56.528382+0200 raspi vdr[4766]: [4788] audio thread thread started (pid=4766, tid=4788, prio=high)
2025-10-05T21:28:56.528774+0200 raspi vdr[4766]: [4783] [softhddevice] audio: alsa set up:
                                                            Channels 2 SampleRate 48000
                                                            HWChannels 2 HWSampleRate 48000 SampleFormat S16_LE
                                                            Supports pause: no mmap: yes
                                                            AlsaBufferTime 100ms m_bufferTimeInMs 450ms Threshold 450ms
2025-10-05T21:28:56.573070+0200 raspi vdr[4766]: [4801] filter thread thread started (pid=4766, tid=4801, prio=high)
```