### PR TITLE
Make logger thread-safe

### DIFF
--- a/logger.cpp
+++ b/logger.cpp
@@ -23,8 +23,6 @@
 
 #include "logger.h"
 
-std::shared_ptr<cSoftHdLogger> cSoftHdLogger::instance;
-
 /*****************************************************************************
  * cSoftHdLogger class
  ****************************************************************************/
@@ -44,9 +42,7 @@ cSoftHdLogger::cSoftHdLogger(void)
  */
 std::shared_ptr<cSoftHdLogger> cSoftHdLogger::GetLogger()
 {
-	if (instance == nullptr)
-		instance = std::shared_ptr<cSoftHdLogger>(new cSoftHdLogger());
-
+	static std::shared_ptr<cSoftHdLogger> instance(new cSoftHdLogger());
 	return instance;
 }
 

--- a/logger.h
+++ b/logger.h
@@ -89,8 +89,7 @@ private:
 	cSoftHdLogger(const cSoftHdLogger &) = delete;
 	cSoftHdLogger& operator=(const cSoftHdLogger &) = delete;
 
-	static std::shared_ptr<cSoftHdLogger> instance; ///< logger instance
-	int logLevel;                                   ///< loglevel (see Logger flags above)
+	int logLevel; ///< loglevel (see Logger flags above)
 };
 
 #endif


### PR DESCRIPTION
I had the following segfault. Don't know if it's related, but there can be a race condition when the logger is first used by two threads simultaneously.
```
#0  0x00000000000201a0 in ?? ()
#1  0x00007fff6a402230 in std::__shared_count<(__gnu_cxx::_Lock_policy)2>::~__shared_count (this=<optimized out>, __in_chrg=<optimized out>) at /usr/include/c++/12/bits/shared_ptr_base.h:1071
#2  std::__shared_ptr<cSoftHdLogger, (__gnu_cxx::_Lock_policy)2>::~__shared_ptr (this=<optimized out>, __in_chrg=<optimized out>) at /usr/include/c++/12/bits/shared_ptr_base.h:1524
#3  std::shared_ptr<cSoftHdLogger>::~shared_ptr (this=<optimized out>, __in_chrg=<optimized out>) at /usr/include/c++/12/bits/shared_ptr.h:175
#4  cVideoRender::WaitForFrames (this=0x5555c7abe410) at videorender.cpp:885
#5  0x00007fff6a4044f4 in __gnu_cxx::__exchange_and_add (__val=-1, __mem=0x7fff6b533b98 <__stack_chk_guard>) at /usr/include/c++/12/ext/atomicity.h:66
#6  __gnu_cxx::__exchange_and_add_dispatch (__val=-1, __mem=0x7fff6b533b98 <__stack_chk_guard>) at /usr/include/c++/12/ext/atomicity.h:101
#7  std::_Sp_counted_base<(__gnu_cxx::_Lock_policy)2>::_M_release (this=0x5555c7abe410) at /usr/include/c++/12/bits/shared_ptr_base.h:350
#8  std::__shared_count<(__gnu_cxx::_Lock_policy)2>::~__shared_count (this=0x7fff5239e7b8, __in_chrg=<optimized out>) at /usr/include/c++/12/bits/shared_ptr_base.h:1071
#9  std::__shared_ptr<cSoftHdLogger, (__gnu_cxx::_Lock_policy)2>::~__shared_ptr (this=0x7fff5239e7b0, __in_chrg=<optimized out>) at /usr/include/c++/12/bits/shared_ptr_base.h:1524
#10 std::shared_ptr<cSoftHdLogger>::~shared_ptr (this=0x7fff5239e7b0, __in_chrg=<optimized out>) at /usr/include/c++/12/bits/shared_ptr.h:175
#11 cVideoRender::DisplayFrame (this=<optimized out>) at videorender.cpp:934
#12 0x00007fff6a3fc104 in cAudioThread::Action (this=0x5555c7a8d960) at threads.cpp:141
#13 0x00005555a0640470 in cThread::StartThread(cThread*) ()
#14 0x00005555c7a8d960 in ?? ()
```