### PR TITLE
Fix playback gets stuck after too many frame drops when starting the playback

### DIFF
--- a/videorender.cpp
+++ b/videorender.cpp
@@ -939,7 +939,7 @@ int cVideoRender::DisplayFrame(void)
 	// sync audio/video
 	cDrmBuffer *buf = NULL;
 
-	if (NeedsSync(frame)) {
+	if (NeedsSync(frame) && !m_flushLastFrame) {
 		ret = Sync(frame);
 
 		if (ret == 2) {


### PR DESCRIPTION
I don't know if that's a good solution, but it is simple and it fixes the problem. So, just a suggestion.

Fixes #34 