### PR TITLE
Fix segfault on playback

### DIFF
--- a/audio.cpp
+++ b/audio.cpp
@@ -698,8 +698,6 @@ int cSoftHdAudio::Setup(AVCodecContext *ctx, int samplerate, int channels, int p
 {
 	int err = 0;
 
-	Init();
-
 	if (samplerate != (int)m_hwSampleRate ||
 	   (channels != (int)m_hwNumChannels && !(m_downmix && m_hwNumChannels == 2))) {
 
@@ -1265,7 +1263,7 @@ void cSoftHdAudio::SetAutoAES(int onoff)
  * Initialize audio output module
  *
  */
-void cSoftHdAudio::Init()
+void cSoftHdAudio::LazyInit()
 {
 	if (!m_initialized) {
 		InitRingbuffer();

--- a/audio.h
+++ b/audio.h
@@ -43,6 +43,7 @@ public:
 	cSoftHdAudio(cSoftHdDevice *);
 	virtual ~cSoftHdAudio(void);
 
+	void LazyInit(void);
 	void Exit(void);
 	int Setup(AVCodecContext *, int , int , int);
 	void Resume(void);
@@ -85,8 +86,6 @@ public:
 	char AlsaPlayerRunning(void) { return m_alsaPlayerRunning; };
 
 private:
-	void Init(void);
-
 	cSoftHdDevice *m_pDevice;               ///< pointer to device
 
 	// thread

--- a/softhddevice.cpp
+++ b/softhddevice.cpp
@@ -1138,6 +1138,8 @@ int cSoftHdDevice::PlayAudio(const uchar *data, int size, uchar id)
 		return size;
 	}
 
+	m_pAudio->LazyInit();
+
 	// hard limit buffer full: don't overrun audio buffers on replay
 	if (m_pAudio->GetFreeBytes() < AUDIO_MIN_BUFFER_FREE){
 //		LOGDEBUG("device: %s: Buffer is Full (%d|%d)!", __FUNCTION__, m_pAudio->GetFreeBytes(), AUDIO_MIN_BUFFER_FREE);
@@ -1403,6 +1405,7 @@ int cSoftHdDevice::PlayVideo(const uchar * data, int size)
 	if (size < 9 || !data || data[0] || data[1] || data[2] != 0x01 || data[3] >> 4 != 0x0e)
 		return size;
 
+	m_pAudio->LazyInit();
 
 	// hard limit buffer full: needed for replay
 	if (m_pVideoStream->GetPacketsFilled() >= VIDEO_PACKET_MAX - 10)
@@ -1844,6 +1847,8 @@ void cSoftHdDevice::SetVideoCodec(enum AVCodecID codecId, AVCodecParameters * pa
  */
 int cSoftHdDevice::PlayAudioPkts(AVPacket * pkt)
 {
+	m_pAudio->LazyInit();
+	
 	if (m_pAudio->GetFreeBytes() < AUDIO_MIN_BUFFER_FREE) {
 //		LOGERROR("device: %s: m_pAudio->GetFreeBytes() < AUDIO_MIN_BUFFER_FREE!", __FUNCTION__);
 		return 0;
@@ -1863,6 +1868,8 @@ int cSoftHdDevice::PlayAudioPkts(AVPacket * pkt)
 int cSoftHdDevice::PlayVideoPkts(AVPacket * pkt)
 {
 	AVPacket *avpkt;
+
+	m_pAudio->LazyInit();
 
 	if (m_pVideoStream->GetPacketsFilled() >= VIDEO_PACKET_MAX - 10) {
 		return 0;


### PR DESCRIPTION
Audio is now initilized on the first audio *or* video packet.

Regression from 8ff3947

Fixes #39 