### PR TITLE
Replace custom ringbuffer in cFilterThread by std function

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -128,7 +128,7 @@ override CFLAGS	  += $(_CFLAGS) $(DEFINES) $(INCLUDES) \
 ### The object files (add further files here):
 
 OBJS = $(PLUGIN).o audio.o buf2rgb.o codec_audio.o codec_video.o config.o drmbuffer.o drmdevice.o drmplane.o grab.o h264parser.o \
-	logger.o mediaplayer.o ringbuffer.o softhddevice.o softhdmenu.o softhdosd.o threads.o videorender.o videostream.o queue.o
+	logger.o mediaplayer.o queue.o ringbuffer.o softhddevice.o softhdmenu.o softhdosd.o threads.o videorender.o videostream.o
 
 ifeq ($(GLES),1)
 OBJS += openglosd.o

--- a/Makefile
+++ b/Makefile
@@ -128,7 +128,7 @@ override CFLAGS	  += $(_CFLAGS) $(DEFINES) $(INCLUDES) \
 ### The object files (add further files here):
 
 OBJS = $(PLUGIN).o audio.o buf2rgb.o codec_audio.o codec_video.o config.o drmbuffer.o drmdevice.o drmplane.o grab.o h264parser.o \
-	logger.o mediaplayer.o ringbuffer.o softhddevice.o softhdmenu.o softhdosd.o threads.o videorender.o videostream.o
+	logger.o mediaplayer.o ringbuffer.o softhddevice.o softhdmenu.o softhdosd.o threads.o videorender.o videostream.o queue.o
 
 ifeq ($(GLES),1)
 OBJS += openglosd.o

--- a/queue.cpp
+++ b/queue.cpp
@@ -33,10 +33,10 @@
  *****************************************************************************/
 
 /**
- * @brief Push an element to the front of the queue
+ * Push an element to the front of the queue
  *
- * @tparam T Element type
- * @param element The element to push
+ * @tparam T       Element type
+ * @param  element The element to push
  * @return true if successfully pushed, false if queue is full
  */
 template <typename T>
@@ -54,10 +54,10 @@ bool cQueue<T>::Push(const T& element)
 }
 
 /**
- * @brief Pop an element from the back of the queue
+ * Pop an element from the back of the queue
  *
- * @tparam T Element type
- * @return T The popped element
+ * @tparam T                  Element type
+ * @return T                  The popped element
  * @throws std::runtime_error if queue is empty
  */
 template <typename T>
@@ -76,10 +76,10 @@ T cQueue<T>::Pop(void)
 }
 
 /**
- * @brief Get a reference to the front element
+ * Get a reference to the front element
  *
- * @tparam T Element type
- * @return T& Reference to the front (most recently pushed) element
+ * @tparam T                  Element type
+ * @return T                  Element at the front (most recently pushed)
  * @throws std::runtime_error if queue is empty
  */
 template <typename T>
@@ -95,10 +95,10 @@ T cQueue<T>::Head(void)
 }
 
 /**
- * @brief Get a reference to the back element
+ * Get a reference to the back element
  *
- * @tparam T Element type
- * @return T& Reference to the back (next to be popped) element
+ * @tparam T                  Element type
+ * @return T                  Element at the back (next to be popped)
  * @throws std::runtime_error if queue is empty
  */
 template <typename T>
@@ -114,7 +114,7 @@ T cQueue<T>::Peek(void)
 }
 
 /**
- * @brief Check if the queue is empty
+ * Check if the queue is empty
  *
  * @tparam T Element type
  * @return true if queue is empty, false otherwise
@@ -123,19 +123,21 @@ template <typename T>
 bool cQueue<T>::Empty(void)
 {
 	std::lock_guard<std::mutex> lock(m_mutex);
+
 	return m_deque.empty();
 }
 
 /**
- * @brief Get the current size of the queue
+ * Get the current size of the queue
  *
  * @tparam T Element type
- * @return size_t Number of elements currently in the queue
+ * @return Number of elements currently in the queue
  */
 template <typename T>
 size_t cQueue<T>::Size(void)
 {
 	std::lock_guard<std::mutex> lock(m_mutex);
+
 	return m_deque.size();
 }
 

--- a/queue.cpp
+++ b/queue.cpp
@@ -1,0 +1,142 @@
+/**
+ * @file queue.cpp
+ * Thread-safe queue class
+ *
+ * This file implements cQueue, which is a thread-safe queue
+ * implementation.
+ *
+ * @license{AGPLv3
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.}
+ */
+
+ #include <libavutil/frame.h>
+ #include <libavcodec/packet.h>
+
+#include "queue.h"
+#include "logger.h"
+
+/******************************************************************************
+ * cQueue class
+ *
+ * Thread-safe queue implementation using std::deque and std::mutex.
+ * Provides FIFO semantics with bounded capacity.
+ *****************************************************************************/
+
+/**
+ * @brief Push an element to the front of the queue
+ *
+ * @tparam T Element type
+ * @param element The element to push
+ * @return true if successfully pushed, false if queue is full
+ */
+template <typename T>
+bool cQueue<T>::Push(const T& element)
+{
+	std::lock_guard<std::mutex> lock(m_mutex);
+
+	if (m_deque.size() >= m_maxSize) {
+		return false;
+	}
+
+	m_deque.push_front(element);
+
+	return true;
+}
+
+/**
+ * @brief Pop an element from the back of the queue
+ *
+ * @tparam T Element type
+ * @return T The popped element
+ * @throws std::runtime_error if queue is empty
+ */
+template <typename T>
+T cQueue<T>::Pop(void)
+{
+	std::lock_guard<std::mutex> lock(m_mutex);
+
+	if (m_deque.empty()) {
+		throw std::runtime_error("Queue is empty");
+	}
+
+	T element = m_deque.back();
+	m_deque.pop_back();
+
+	return element;
+}
+
+/**
+ * @brief Get a reference to the front element
+ *
+ * @tparam T Element type
+ * @return T& Reference to the front (most recently pushed) element
+ * @throws std::runtime_error if queue is empty
+ */
+template <typename T>
+T cQueue<T>::Head(void)
+{
+	std::lock_guard<std::mutex> lock(m_mutex);
+
+	if (m_deque.empty()) {
+		throw std::runtime_error("Queue is empty");
+	}
+
+	return m_deque.front();
+}
+
+/**
+ * @brief Get a reference to the back element
+ *
+ * @tparam T Element type
+ * @return T& Reference to the back (next to be popped) element
+ * @throws std::runtime_error if queue is empty
+ */
+template <typename T>
+T cQueue<T>::Peek(void)
+{
+	std::lock_guard<std::mutex> lock(m_mutex);
+
+	if (m_deque.empty()) {
+		throw std::runtime_error("Queue is empty");
+	}
+
+	return m_deque.back();
+}
+
+/**
+ * @brief Check if the queue is empty
+ *
+ * @tparam T Element type
+ * @return true if queue is empty, false otherwise
+ */
+template <typename T>
+bool cQueue<T>::Empty(void)
+{
+	std::lock_guard<std::mutex> lock(m_mutex);
+	return m_deque.empty();
+}
+
+/**
+ * @brief Get the current size of the queue
+ *
+ * @tparam T Element type
+ * @return size_t Number of elements currently in the queue
+ */
+template <typename T>
+size_t cQueue<T>::Size(void)
+{
+	std::lock_guard<std::mutex> lock(m_mutex);
+	return m_deque.size();
+}
+
+// Explicit template instantiations
+template class cQueue<AVFrame *>;   ///< Queue for AVFrame pointers

--- a/queue.cpp
+++ b/queue.cpp
@@ -18,6 +18,7 @@
  * GNU Affero General Public License for more details.}
  */
 
+ #include <stdexcept>
  #include <libavutil/frame.h>
  #include <libavcodec/packet.h>
 

--- a/queue.h
+++ b/queue.h
@@ -1,0 +1,54 @@
+/**
+ * @file queue.h
+ * Thread-safe queue header file
+ *
+ * @license{AGPLv3
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.}
+ */
+
+#ifndef __SOFTHDQUEUE_H
+#define __SOFTHDQUEUE_H
+
+#include <deque>
+#include <mutex>
+#include <cstdint>
+
+/**
+ * @brief Thread-safe queue class
+ *
+ * This class provides a thread-safe queue implementation using std::deque
+ * and std::mutex for synchronization. It supports both FIFO queue operations
+ * and bounded capacity management.
+ *
+ * @tparam T The type of elements stored in the queue
+ */
+template <typename T>
+class cQueue
+{
+public:
+	cQueue(size_t maxSize) : m_maxSize(maxSize) {};
+	~cQueue(void) {};
+
+	bool Push(const T& element);
+	T Pop(void);
+	T Head(void);
+	T Peek(void);
+	bool Empty(void);
+	size_t Size(void);
+
+private:
+	std::deque<T> m_deque;    ///< Underlying deque container
+	std::mutex m_mutex;       ///< Mutex for thread-safe access
+	size_t m_maxSize;         ///< Maximum queue capacity
+};
+
+#endif

--- a/queue.h
+++ b/queue.h
@@ -23,7 +23,7 @@
 #include <cstdint>
 
 /**
- * @brief Thread-safe queue class
+ * Thread-safe queue class
  *
  * This class provides a thread-safe queue implementation using std::deque
  * and std::mutex for synchronization. It supports both FIFO queue operations

--- a/threads.cpp
+++ b/threads.cpp
@@ -225,10 +225,6 @@ int cFilterThread::Init(const AVCodecContext *videoCtx, AVFrame *frame, int disa
 		return -1;
 	}
 
-	atomic_set(&m_numFramesFilled, 0);
-	m_framesRead = 0;
-	m_framesWrite =  0;
-
 	m_pRender->ClearFramesToFilter();
 	m_filterBug = false;
 	m_filterTrick = false;
@@ -379,13 +375,13 @@ void cFilterThread::Action(void)
 	LOGDEBUG("threads: video filter thread started");
 
 	while (Running()) {
-		if (!GetRbFramesFilled()) {
+		if (m_frames.Empty()) {
 			m_waitIdleCondition.Broadcast();
 			usleep(10000);
 			continue;
 		}
 
-		frame = RbGetFrame();
+		frame = m_frames.Pop();
 
 		int interlaced;
 #if LIBAVUTIL_VERSION_INT < AV_VERSION_INT(58,7,100)
@@ -469,31 +465,17 @@ void cFilterThread::Action(void)
 /**
  * Get the number of frames in the ringbuffer to be filtered
  */
-int cFilterThread::GetRbFramesFilled(void)
+int cFilterThread::GetBufferFrameCount(void)
 {
-	return atomic_read(&m_numFramesFilled);
-}
-
-/**
- * Get the next frame of the ringbuffer to be filtered
- */
-AVFrame *cFilterThread::RbGetFrame(void)
-{
-	AVFrame *frame = m_pFramesRb[m_framesRead];
-	m_framesRead = (m_framesRead + 1) % VIDEO_SURFACES_MAX;
-	atomic_dec(&m_numFramesFilled);
-
-	return frame;
+	return m_frames.Size();
 }
 
 /**
  * Put a frame in the ringbuffer to be filtered
  */
-void cFilterThread::RbPushFrame(AVFrame *frame)
+bool cFilterThread::PushFrame(AVFrame *frame)
 {
-	m_pFramesRb[m_framesWrite] = frame;
-	m_framesWrite = (m_framesWrite + 1) % VIDEO_SURFACES_MAX;
-	atomic_inc(&m_numFramesFilled);
+	return m_frames.Push(frame);
 }
 
 void cFilterThread::Stop(void)
@@ -508,8 +490,8 @@ void cFilterThread::Stop(void)
 	m_filterStill = false;
 	m_pRender->ClearFramesToFilter();
 
-	while (GetRbFramesFilled()) {
-		AVFrame *frame = RbGetFrame();
+	while (!m_frames.Empty()) {
+		AVFrame *frame = m_frames.Pop();
 		av_frame_free(&frame);
 	}
 

--- a/threads.h
+++ b/threads.h
@@ -21,6 +21,7 @@
 #define __THREADS_H
 
 #include "vdr/thread.h"
+#include "queue.h"
 
 #define VIDEO_SURFACES_MAX 3
 
@@ -94,8 +95,8 @@ public:
 	virtual ~cFilterThread(void);
 	int Init(const AVCodecContext *, AVFrame *, int);
 	void Stop(void);
-	int GetRbFramesFilled(void);
-	void RbPushFrame(AVFrame *);
+	int GetBufferFrameCount(void);
+	bool PushFrame(AVFrame *);
 	bool IsInterlaceFilter(void) { return m_isInterlaceFilter; };
 	void WaitForIdle(void);
 
@@ -111,14 +112,9 @@ private:
 	bool m_filterStill;                         ///< the current filter handles stillpicture frames
 	bool m_isInterlaceFilter;                   ///< the current filter is an deinterlace filter
 
-	AVFrame *m_pFramesRb[VIDEO_SURFACES_MAX];   ///< ringbuffer for frames to be filtered
-	int m_numFramesFilled;                      ///< number of frames in the ringbuffer
-	int m_framesWrite;                          ///< ringbuffer write pointer
-	int m_framesRead;                           ///< ringbuffer read pointer
+	cQueue<AVFrame *> m_frames{VIDEO_SURFACES_MAX}; ///< queue for frames to be filtered
 
 	cCondVar m_waitIdleCondition;               ///< condition is triggered, if ringbuffer is empty
-
-	AVFrame *RbGetFrame(void);
 
 protected:
 	virtual void Action(void);

--- a/videorender.cpp
+++ b/videorender.cpp
@@ -470,7 +470,7 @@ int cVideoRender::HandleDropDup(int64_t videoPts, int64_t audioPts)
 
 	if (abs(diff) > 5000) {	// more than 5s
 		LOGDEBUG2(L_AV_SYNC, "More then 5s Pkts %d deint %d, Frames %d UsedBytes %d audio %s video %s Delay %dms diff %dms",
-			m_pDevice->VideoStream()->GetPacketsFilled(), m_pFilterThread->GetRbFramesFilled(),
+			m_pDevice->VideoStream()->GetPacketsFilled(), m_pFilterThread->GetBufferFrameCount(),
 			atomic_read(&m_framesFilled), m_pAudio->GetUsedBytes(), Timestamp2String(audioPts),
 			Timestamp2String(videoPts), m_pDevice->GetVideoAudioDelay(), diff);
 	}
@@ -487,7 +487,7 @@ int cVideoRender::HandleDropDup(int64_t videoPts, int64_t audioPts)
 
 		LOGDEBUG2(L_AV_SYNC, "FrameDropped (drop %d, dup %d) Pkts %d deint %d Frames %d UsedBytes %d audio %s video %s Delay %dms diff %dms",
 			m_framesDropped, m_framesDuped,
-			m_pDevice->VideoStream()->GetPacketsFilled(), m_pFilterThread->GetRbFramesFilled(),
+			m_pDevice->VideoStream()->GetPacketsFilled(), m_pFilterThread->GetBufferFrameCount(),
 			atomic_read(&m_framesFilled), m_pAudio->GetUsedBytes(), Timestamp2String(audioPts),
 			Timestamp2String(videoPts), m_pDevice->GetVideoAudioDelay(), diff);
 
@@ -501,7 +501,7 @@ int cVideoRender::HandleDropDup(int64_t videoPts, int64_t audioPts)
 	if (diff > 35 && !(abs(diff) > 5000)) {	// audio is more than 35ms behind video, duplicate video frame
 		LOGDEBUG2(L_AV_SYNC, "FrameDuped (drop %d, dup %d) Pkts %d deint %d Frames %d UsedBytes %d audio %s video %s Delay %dms diff %dms",
 			m_framesDropped, m_framesDuped,
-			m_pDevice->VideoStream()->GetPacketsFilled(), m_pFilterThread->GetRbFramesFilled(),
+			m_pDevice->VideoStream()->GetPacketsFilled(), m_pFilterThread->GetBufferFrameCount(),
 			atomic_read(&m_framesFilled), m_pAudio->GetUsedBytes(), Timestamp2String(audioPts),
 			Timestamp2String(videoPts), m_pDevice->GetVideoAudioDelay(), diff);
 
@@ -1343,9 +1343,7 @@ int cVideoRender::RenderFrame(AVCodecContext * videoCtx, AVFrame * frame)
 			}
 		}
 
-		if (m_pFilterThread->GetRbFramesFilled() < VIDEO_SURFACES_MAX) {
-			m_pFilterThread->RbPushFrame(frame);
-		} else {
+		if (!m_pFilterThread->PushFrame(frame)) {
 			usleep(10000);
 			return -1;
 		}


### PR DESCRIPTION
I created a thread-safe FIFO buffer, which is essentially a ring buffer, but simply based on `std::deque`. The goal is to re-use it for the other custom made ringbuffers, too. But there needs to be some preparation done at the other places, because there is some weird stuff going on.

The queue could potentially also made synchronous to eliminate the millisecond polling sleeps for thread synchronization.