### PR TITLE
Refactor PES parsing

### DIFF
--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -12,7 +12,7 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
-    
+
     steps:
     - name: Install build dependencies
       run: |
@@ -21,6 +21,8 @@ jobs:
           build-essential \
           pkg-config \
           git \
+          catch2 \
+          lcov \
           gettext \
           libavcodec-dev \
           libavfilter-dev \
@@ -57,9 +59,32 @@ jobs:
         path: vdr/PLUGINS/src/softhddevice-drm-gles/libvdr-softhddevice-drm-gles.so
         if-no-files-found: error
 
+    - name: Run unit tests
+      run: |
+        cd vdr/PLUGINS/src/softhddevice-drm-gles/tests
+        make test
+      continue-on-error: false
+
+    - name: Publish test results
+      uses: EnricoMi/publish-unit-test-result-action@v2
+      with:
+        files: vdr/PLUGINS/src/softhddevice-drm-gles/tests/test-results.xml
+        check_name: Unit Test Results
+
+    - name: Generate coverage report
+      run: |
+        cd vdr/PLUGINS/src/softhddevice-drm-gles/tests
+        make coverage-html
+
+    - name: Upload coverage HTML report
+      uses: actions/upload-artifact@v4
+      with:
+        name: coverage-html-report
+        path: vdr/PLUGINS/src/softhddevice-drm-gles/tests/coverage-html/
+
   build-without-gles:
     runs-on: ubuntu-latest
-    
+
     steps:
     - name: Install build dependencies
       run: |

--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,13 @@ po/*.pot
 .dependencies
 srcdoc
 .vscode
+
+# test coverage files
+*.gcda
+*.gcno
+*.gcov
+
+tests/test_runner
+tests/test-results.xml
+tests/coverage.info
+tests/coverage-html/

--- a/Makefile
+++ b/Makefile
@@ -201,6 +201,12 @@ clean:
 	@-rm -f $(PODIR)/*.mo $(PODIR)/*.pot
 	@-rm -f $(DEPFILE) *.o *.so *.tgz core* *~
 	@-rm -rf srcdoc
+	@$(MAKE) -C tests clean 2>/dev/null || true
+
+# Unit tests:
+.PHONY: test
+test:
+	@$(MAKE) -C tests test
 
 # Source documentation:
 srcdoc:

--- a/Makefile
+++ b/Makefile
@@ -128,7 +128,7 @@ override CFLAGS	  += $(_CFLAGS) $(DEFINES) $(INCLUDES) \
 ### The object files (add further files here):
 
 OBJS = $(PLUGIN).o audio.o buf2rgb.o codec_audio.o codec_video.o config.o drmbuffer.o drmdevice.o drmplane.o grab.o h264parser.o \
-	logger.o mediaplayer.o queue.o ringbuffer.o softhddevice.o softhdmenu.o softhdosd.o threads.o videorender.o videostream.o
+	logger.o mediaplayer.o pes.o queue.o ringbuffer.o softhddevice.o softhdmenu.o softhdosd.o threads.o videorender.o videostream.o
 
 ifeq ($(GLES),1)
 OBJS += openglosd.o

--- a/pes.cpp
+++ b/pes.cpp
@@ -1,0 +1,180 @@
+/**
+ * @file pes.cpp
+ * PES packet parser implementation
+ *
+ * @license{AGPLv3
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.}
+ */
+
+#include "pes.h"
+
+#include "vdr/remux.h"
+
+extern "C"
+{
+#include <libavutil/avutil.h>
+}
+
+/**
+ * Construct a PES packet parser
+ *
+ * @param data Pointer to the raw PES packet data
+ * @param size Size of the PES packet in bytes
+ */
+cPes::cPes(const uint8_t *data, int size)
+	: m_data(data), m_size(size)
+{
+}
+
+/**
+ * Parse the PES packet to detect the video codec
+ *
+ * Analyzes the PES payload to identify the codec type (MPEG2, H.264, or HEVC).
+ * This method looks for codec-specific start codes and stream type identifiers
+ * in the payload. The detected codec can be retrieved using GetCodec().
+ *
+ * Supported codecs:
+ * - MPEG2 (AV_CODEC_ID_MPEG2VIDEO)
+ * - H.264 (AV_CODEC_ID_H264)
+ * - HEVC (AV_CODEC_ID_HEVC)
+ *
+ * @note This method must be called before GetCodec()
+ */
+void cPes::Parse() {
+	int pesPayloadStart = PesPayloadOffset(m_data);
+
+	if (pesPayloadStart + START_CODE_PREFIX_LEN + 1 >= (unsigned int)m_size)
+		return;
+
+	uint32_t firstThreePesPayloadBytes = ReadBytes(pesPayloadStart, START_CODE_PREFIX_LEN);
+	const uint8_t *codecPayload = &m_data[pesPayloadStart + START_CODE_PREFIX_LEN];
+
+	// Looking for the MPEG2 start code and stream type
+	if (firstThreePesPayloadBytes == START_CODE_PREFIX && codecPayload[0] == MPEG2_STREAM_TYPE)
+		m_codec = AV_CODEC_ID_MPEG2VIDEO;
+	// Looking for the H.264/HEVC start code. It can have an optional leading zero byte.
+	else if (ReadBytes(pesPayloadStart + 1, START_CODE_PREFIX_LEN) == START_CODE_PREFIX) {
+		codecPayload++;
+		m_payloadHasLeadingZero = true;
+	} else if (firstThreePesPayloadBytes != START_CODE_PREFIX)
+		return; // no start code found
+
+	if (m_size > &codecPayload[7] - m_data) {
+		if (     codecPayload[0] == H264_STREAM_TYPE && (codecPayload[1] == 0x10 || codecPayload[1] == 0xF0 || codecPayload[7] == 0x64))
+			m_codec = AV_CODEC_ID_H264;
+		else if (codecPayload[0] == HEVC_STREAM_TYPE && (codecPayload[1] == 0x10 || codecPayload[1] == 0x50 || codecPayload[7] == 0x40))
+			m_codec = AV_CODEC_ID_HEVC;
+	}
+}
+
+uint32_t cPes::ReadBytes(int offset, int count)
+{
+	uint32_t value = 0;
+
+	for (int i = 0; i < count; i++) {
+		value <<= 8;
+		value |= m_data[offset + i];
+	}
+
+	return value;
+}
+
+/**
+ * Check if the PES header is valid
+ *
+ * Validates that the PES packet has a valid header by checking:
+ * - The packet is long enough to contain a header
+ * - The start code prefix (0x000001) is present
+ *
+ * @return true if the header is valid, false otherwise
+ */
+bool cPes::IsHeaderValid()
+{
+	return PesLongEnough(m_size) && ReadBytes(0, 3) == START_CODE_PREFIX;
+}
+
+/**
+ * Check if this is a video stream
+ *
+ * Determines if the PES packet contains a video stream based on the stream ID.
+ * Video streams have stream IDs in the range 0xE0-0xEF according to
+ * H.222.0 03/2017 Table 2-22.
+ *
+ * @return true if this is a video stream, false otherwise
+ */
+bool cPes::IsVideoStream()
+{
+	// The low nibble is the stream number
+	return (GetStreamId() & 0xF0) == 0xE0;
+}
+
+/**
+ * Check if this is an audio stream
+ *
+ * Determines if the PES packet contains an audio stream based on the stream ID.
+ * Audio streams have stream IDs in the range 0xC0-0xCF according to
+ * H.222.0 03/2017 Table 2-22.
+ *
+ * @return true if this is an audio stream, false otherwise
+ */
+bool cPes::IsAudioStream()
+{
+	// The low nibble is the stream number
+	return (GetStreamId() & 0xF0) == 0xC0;
+}
+
+/**
+ * Get the Presentation Time Stamp (PTS) from the PES header
+ *
+ * Extracts the PTS value from the PES packet header if present.
+ * The PTS indicates when the decoded content should be presented.
+ *
+ * @return The PTS value in 90 kHz units, or AV_NOPTS_VALUE if no PTS is present
+ */
+int64_t cPes::GetPts()
+{
+	if (!PesHasPts(m_data))
+		return AV_NOPTS_VALUE;
+
+	return PesGetPts(m_data);
+}
+
+/**
+ * Get a pointer to the PES payload data
+ *
+ * Returns a pointer to the start of the payload data, skipping the PES header.
+ * For H.264/HEVC streams with a leading zero byte, the leading zero is also skipped.
+ *
+ * @return Pointer to the payload data
+ */
+const uint8_t *cPes::GetPayload()
+{
+	int headerLen = PesPayloadOffset(m_data);
+
+	if (m_payloadHasLeadingZero)
+		headerLen++; // Skip the leading zero byte for H.264/HEVC
+
+	return &m_data[headerLen];
+}
+
+/**
+ * Get the size of the PES payload
+ *
+ * Calculates the size of the payload by subtracting the header size
+ * (and optional leading zero for H.264/HEVC) from the total packet size.
+ *
+ * @return Size of the payload in bytes
+ */
+int cPes::GetPayloadSize()
+{
+	return m_size - (GetPayload() - m_data);
+}

--- a/pes.h
+++ b/pes.h
@@ -1,0 +1,86 @@
+/**
+ * @file pes.h
+ * PES packet parser header
+ *
+ * @copyright (c) 2025 by Andreas Baierl. All Rights Reserved.
+ *
+ * @license{AGPLv3
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.}
+ */
+
+#ifndef __SOFTHDDEVICE_PES_H
+#define __SOFTHDDEVICE_PES_H
+
+#include <stdint.h>
+#include <stddef.h>
+
+extern "C"
+{
+#include <libavcodec/avcodec.h>
+}
+
+/**
+ * @brief Convert AVCodecID to a human-readable string
+ *
+ * @param c The codec ID to convert
+ * @return A string representation of the codec ID
+ */
+constexpr const char* to_string(AVCodecID c) {
+    switch (c) {
+        case AV_CODEC_ID_NONE: return "None";
+        case AV_CODEC_ID_MPEG2VIDEO: return "MPEG2";
+        case AV_CODEC_ID_H264: return "H.264";
+        case AV_CODEC_ID_HEVC: return "HEVC";
+		default: return "Unknown codec";
+    }
+}
+
+/**
+ * PES packet parser class
+ *
+ * This class parses PES (Packetized Elementary Stream) packets
+ * to extract header information, video codec, PTS, and payload data.
+ */
+class cPes
+{
+public:
+	cPes(const uint8_t *data, int size);
+	void Parse();
+	bool IsHeaderValid();
+	bool IsVideoStream();
+	bool IsAudioStream();
+	AVCodecID GetCodec() { return m_codec; }
+	int64_t GetPts();
+	const uint8_t *GetPayload();
+	int GetPayloadSize();
+
+	private:
+	uint32_t ReadBytes(int offset, int count);
+	uint8_t GetStreamId() { return m_data[3]; }
+	AVCodecID ParseCodec();
+
+	// According to H.222.0 03/2017 Table 2-21 packet_start_code_prefix
+	// And also according to H.264/HEVC payload
+	static constexpr uint32_t START_CODE_PREFIX = 0x00'0001;
+	static constexpr uint32_t START_CODE_PREFIX_LEN = 3;
+
+	static constexpr uint8_t MPEG2_STREAM_TYPE = 0xB3;
+	static constexpr uint8_t H264_STREAM_TYPE = 0x09;
+	static constexpr uint8_t HEVC_STREAM_TYPE = 0x46;
+
+	const uint8_t *m_data;   ///< pointer to the raw PES packet data
+	int m_size;              ///< size of the PES packet
+	bool m_payloadHasLeadingZero = false;   ///< flag indicating if codec payload has leading zero byte for H.264/HEVC
+	AVCodecID m_codec = AV_CODEC_ID_NONE; ///< detected codec ID
+};
+
+#endif

--- a/softhddevice.cpp
+++ b/softhddevice.cpp
@@ -56,6 +56,7 @@ extern "C" {
 #include "videorender.h"
 #include "codec_audio.h"
 #include "codec_video.h"
+#include "pes.h"
 
 #define _(str) gettext(str)                    ///< gettext shortcut
 #define _N(str) str                            ///< gettext_noop shortcut
@@ -226,7 +227,7 @@ static inline int FastLatmCheck(const uint8_t * p)
  *
  * @param data   incomplete PES packet
  * @param size   number of bytes
- * 
+ *
  * @retval <0    possible AAC LATM audio, but need more data
  * @retval 0     no valid AAC LATM audio
  * @retval >0    valid AAC LATM audio
@@ -1055,7 +1056,7 @@ bool cSoftHdDevice::Flush(int timeout)
 
 /**
  * Sets the video display format
- * 
+ *
  * @param videoDisplayFormat      video display format
  * Set it to the given one (only useful if this device has an MPEG decoder).
  */
@@ -1358,99 +1359,65 @@ int cSoftHdDevice::PesHeadLength(const uint8_t *p)
  * @param data        pointer to stream data
  * @param offset      print from here
  */
-static void PrintStreamData10(const uchar *data, int offset)
+static void PrintStreamData10(const uchar *payload)
 {
-	LOGDEBUG2(L_CODEC, "Stream: 0x%x 0x%x 0x%x 0x%x 0x%x 0x%x 0x%x 0x%x 0x%x 0x%x 0x%x",
-		data[offset],
-		data[offset + 1],
-		data[offset + 2],
-		data[offset + 3],
-		data[offset + 4],
-		data[offset + 5],
-		data[offset + 6],
-		data[offset + 7],
-		data[offset + 8],
-		data[offset + 9],
-		data[offset + 10]);
-}
-
-void cSoftHdDevice::SetCodecAndEnqueue(const uchar *data, int offset, int size,
-                                          enum AVCodecID codecId, int64_t pts)
-{
-	PrintStreamData10(data, offset);
-	m_pVideoStream->SetCodecId(codecId);
-	m_pVideoStream->SetTrickpkts(codecId == AV_CODEC_ID_MPEG2VIDEO ? 1 : 2);
-	m_pVideoStream->Open();
-	m_pVideoStream->SetTimebase(1, 90000);
-	m_pVideoStream->EnqueueInRb(pts, data + offset, size - offset);
+	LOGDEBUG2(L_CODEC, "Stream: 0x%x 0x%x 0x%x 0x%x 0x%x 0x%x 0x%x 0x%x 0x%x 0x%x 0x%x 0x%x 0x%x",
+		payload[0],
+		payload[1],
+		payload[2],
+		payload[3],
+		payload[4],
+		payload[5],
+		payload[6],
+		payload[7],
+		payload[8],
+		payload[9],
+		payload[10],
+		payload[11],
+		payload[12]
+	);
 }
 
 /**
  * Play a video packet
  *
- * @param data  exactly one complete PES packet (which is incomplete)
- * @param size  length of PES packet
+ * @param data A PES packet (which can be incomplete)
+ * @param size the length of the PES packet including header
  */
-int cSoftHdDevice::PlayVideo(const uchar * data, int size)
+int cSoftHdDevice::PlayVideo(const uchar *data, int size)
 {
-	//LOGDEBUG("device: %s: %p %d", __FUNCTION__, data, length);
+	//LOGDEBUG("device: %s: %p %d", __FUNCTION__, data, size);
 
-	int64_t pts = AV_NOPTS_VALUE;
-	int i, n;
-
-	if (m_pVideoStream->IsPaused())
+	if (m_pVideoStream->IsPaused() || m_pVideoStream->GetPacketsFilled() >= VIDEO_PACKET_MAX - 10)
 		return 0;
 
-	// must be a PES video start code
-	if (size < 9 || !data || data[0] || data[1] || data[2] != 0x01 || data[3] >> 4 != 0x0e)
+	cPes pesPacket(data, size);
+
+	if (!pesPacket.IsHeaderValid() || !pesPacket.IsVideoStream())
 		return size;
 
-	m_pAudio->LazyInit();
+	pesPacket.Parse();
 
-	// hard limit buffer full: needed for replay
-	if (m_pVideoStream->GetPacketsFilled() >= VIDEO_PACKET_MAX - 10)
-		return 0;
+	if (m_pVideoStream->GetCodecId() == AV_CODEC_ID_NONE) {
+		// The playback has just started. Detect the codec and store it.
+		PrintStreamData10(data);
+		AVCodecID codec = pesPacket.GetCodec();
 
-
-	// get pts
-	if (data[7] & 0x80) {
-		pts = (int64_t) (data[9] & 0x0E) << 29 | data[10] << 22 | (data[11] &
-		       0xFE) << 14 | data[12] << 7 | (data[13] & 0xFE) >> 1;
-	}
-
-	n = PesHeadLength(data);	// PES header size
-
-	for (i = 0; (i < 2) && (i + 4 < size); i++) {
-		int offset = i + n;
-		// ES start code 0x00 0x00 0x01
-		if (!data[offset] && !data[offset + 1] && data[offset + 2] == 0x01) {
-			if (m_pVideoStream->GetCodecId() == AV_CODEC_ID_NONE) {
-				if (data[offset + 3] == 0xb3) {
-					// MPEG2 I-Frame
-					LOGDEBUG("device: %s: mpeg2 detected", __FUNCTION__);
-					SetCodecAndEnqueue(data, offset, size, AV_CODEC_ID_MPEG2VIDEO, pts);
-				} else if (data[offset + 3] == 0x09 && (data[offset + 4] == 0x10 || data[offset + 4] == 0xF0 || data[offset + 10] == 0x64)) {
-					// H264 I-Frame
-					LOGDEBUG("device: %s: H264 detected", __FUNCTION__);
-					SetCodecAndEnqueue(data, offset, size, AV_CODEC_ID_H264, pts);
-				} else if (data[i + n + 3] == 0x46 && (data[offset + 5] == 0x10 || data[offset + 5] == 0x50 || data[offset + 10] == 0x40)) {
-					// HEVC I-Frame
-					LOGDEBUG("device: %s: hevc detected", __FUNCTION__);
-					SetCodecAndEnqueue(data, offset, size, AV_CODEC_ID_HEVC, pts);
-				}
-			} else {
-				m_pVideoStream->EnqueueInRb(pts, data + offset, size - offset);
-			}
+		if (codec == AV_CODEC_ID_NONE)
 			return size;
-		}
+
+		LOGDEBUG("device: %s: %s detected", __FUNCTION__, to_string(codec));
+
+		m_pAudio->LazyInit();
+
+		m_pVideoStream->SetCodecId(codec);
+		m_pVideoStream->SetTrickpkts(codec == AV_CODEC_ID_MPEG2VIDEO ? 1 : 2);
+		m_pVideoStream->Open();
+		m_pVideoStream->SetTimebase(1, 90000);
 	}
 
-	// this happens when vdr sends incomplete packets and no stream is started
-	if (m_pVideoStream->GetCodecId() == AV_CODEC_ID_NONE)
-		return size;
+	m_pVideoStream->EnqueueInRb(pesPacket.GetPts(), pesPacket.GetPayload(), pesPacket.GetPayloadSize());
 
-	// complete last frame
-	m_pVideoStream->EnqueueInRb(pts, data + n, size - n);
 	return size;
 }
 

--- a/softhddevice.h
+++ b/softhddevice.h
@@ -166,7 +166,6 @@ private:
 	void ClearAudio(void);
 	void Exit(void);
 	int PesHeadLength(const uint8_t *);
-	void SetCodecAndEnqueue(const uchar *, int, int, enum AVCodecID, int64_t);
 };
 
 #endif

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -1,0 +1,84 @@
+#
+# Makefile for unit tests using Catch2 and coverage with lcov
+#
+
+# Compiler settings
+CXX = g++
+CXXFLAGS = -std=c++17 -g -Wall -Wextra -I.. -isystem ../../../../include
+LDFLAGS =
+
+# Coverage settings
+COVERAGE_CXXFLAGS = --coverage -fprofile-arcs -ftest-coverage
+COVERAGE_LDFLAGS = --coverage
+
+# Add library dependencies
+CXXFLAGS += $(shell pkg-config --cflags libavcodec libavutil catch2)
+LIBS = $(shell pkg-config --libs libavcodec libavutil catch2-with-main)
+
+# Source files
+TEST_SOURCES = catch_main.cpp test_pes.cpp
+SOURCE_UNDER_TEST = ../pes.cpp
+
+# Object files
+TEST_OBJS = $(TEST_SOURCES:.cpp=.o)
+SOURCE_OBJS = $(SOURCE_UNDER_TEST:.cpp=.o)
+
+# Test executable
+TEST_EXEC = test_runner
+
+# Main target
+all: $(TEST_EXEC)
+
+# Link test executable
+$(TEST_EXEC): $(TEST_OBJS) $(SOURCE_OBJS)
+	$(CXX) $(CXXFLAGS) $(LDFLAGS) -o $@ $^ $(LIBS)
+
+# Compile test sources
+%.o: %.cpp
+	$(CXX) $(CXXFLAGS) -c -o $@ $<
+
+# Compile sources under test
+../%.o: ../%.cpp
+	$(CXX) $(CXXFLAGS) -c -o $@ $<
+
+# Run tests
+.PHONY: test
+test: $(TEST_EXEC)
+	./$(TEST_EXEC) -r console -r junit::out=test-results.xml
+
+# Clean
+.PHONY: clean
+clean:
+	@echo "Cleaning test build artifacts..."
+	rm -f $(TEST_OBJS) $(SOURCE_OBJS) $(TEST_EXEC) test-results.xml
+	@echo "Cleaning coverage data..."
+	rm -f *.gcda *.gcno ../*.gcda ../*.gcno coverage.info
+	rm -rf coverage-html
+
+# Coverage targets
+.PHONY: coverage
+coverage: CXXFLAGS += $(COVERAGE_CXXFLAGS)
+coverage: LDFLAGS += $(COVERAGE_LDFLAGS)
+coverage: clean $(TEST_EXEC)
+	@echo "Running tests with coverage..."
+	./$(TEST_EXEC)
+	@echo "Generating coverage report..."
+	lcov --capture --directory . --directory .. --output-file coverage.info
+	lcov --remove coverage.info '/usr/*' '*/tests/*' --output-file coverage.info
+	lcov --list coverage.info
+
+.PHONY: coverage-html
+coverage-html: coverage
+	@echo "Generating HTML coverage report..."
+	genhtml coverage.info --output-directory coverage-html
+	@echo "Coverage report generated in coverage-html/index.html"
+
+.PHONY: help
+help:
+	@echo "Available targets:"
+	@echo "  all              - Build test executable (default)"
+	@echo "  test             - Build and run tests with console output"
+	@echo "  coverage         - Build with coverage, run tests, and generate coverage report"
+	@echo "  coverage-html    - Generate HTML coverage report (includes coverage)"
+	@echo "  clean            - Remove all build artifacts, test results, and coverage data"
+	@echo "  help             - Show this help message"

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,0 +1,53 @@
+# Unit Tests for softhddevice-drm-gles
+
+This directory contains unit tests for the softhddevice-drm-gles VDR plugin using the Catch2 testing framework.
+
+## Prerequisites
+
+You need to have Catch2 v3 (since Ubuntu 24.04/Debian 13) and lcov installed on your system. On Debian/Ubuntu systems:
+
+```bash
+sudo apt-get install catch2 lcov
+```
+
+## Building and Running Tests
+
+### Run tests
+
+```bash
+make test
+```
+
+### Run specific tests
+
+```bash
+./test_runner "[pes]"          # Run all PES tests
+./test_runner "cPes - MPEG2"   # Run MPEG2-related tests
+```
+
+### List all available tests
+
+```bash
+./test_runner --list-tests
+```
+
+## Code Coverage
+
+### Generate coverage report
+
+```bash
+make coverage
+```
+
+This will:
+1. Build the tests with coverage instrumentation
+2. Run all tests
+3. Generate a coverage report showing which lines of code were executed
+
+### Generate HTML coverage report
+
+```bash
+make coverage-html
+```
+
+This generates an interactive HTML report in `coverage-html/index.html` that you can open in a browser to see detailed coverage information with color-coded source files.

--- a/tests/catch_main.cpp
+++ b/tests/catch_main.cpp
@@ -1,0 +1,21 @@
+/**
+ * @file catch_main.cpp
+ * Catch2 test runner main file
+ *
+ * @copyright (c) 2025 by Andreas Baierl. All Rights Reserved.
+ *
+ * @license{AGPLv3
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.}
+ */
+
+#define CATCH_CONFIG_MAIN
+#include <catch2/catch_all.hpp>

--- a/tests/test_pes.cpp
+++ b/tests/test_pes.cpp
@@ -1,0 +1,414 @@
+/**
+ * @file test_pes.cpp
+ * Unit tests for cPes class
+ *
+ * @license{AGPLv3
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.}
+ */
+
+#include <catch2/catch_test_macros.hpp>
+#include "../pes.h"
+
+extern "C" {
+#include <libavutil/avutil.h>
+}
+
+// Helper function to create a minimal valid PES header
+// PES packet structure:
+// - Start code prefix: 0x000001 (3 bytes)
+// - Stream ID: 1 byte
+// - PES packet length: 2 bytes
+// - Optional PES header fields
+std::vector<uint8_t> createBasicPesHeader(uint8_t streamId, bool withPts = false) {
+    std::vector<uint8_t> data;
+
+    // Start code prefix
+    data.push_back(0x00);
+    data.push_back(0x00);
+    data.push_back(0x01);
+
+    // Stream ID
+    data.push_back(streamId);
+
+    // PES packet length (0 = unspecified)
+    data.push_back(0x00);
+    data.push_back(0x00);
+
+    // PES extension
+    data.push_back(0x80); // '10'xxxxxx (no PES scrambling control, PES priority, data alignment indicator, copyright, original or copy)
+
+    // PES header flags
+    if (withPts) {
+        data.push_back(0x80); // PTS_DTS_flags = '10' (PTS only: no ESCR flag, ES rate flag, DSM trick mode flag, additional copy info flag, PES CRC flag, PES extension flag)
+        data.push_back(0x05); // PES header data length (5 bytes for PTS)
+
+        // PTS value (5 bytes) - example: 9000 (0.1 second at 90kHz)
+        data.push_back(0x21); // '0010' (marker bits) + high 3 bits of PTS + marker bit
+        data.push_back(0x00);
+        data.push_back(0x01); // marker bit
+        data.push_back(0x46);
+        data.push_back(0x51); // marker bit + low 15 bits
+    } else {
+        data.push_back(0x00); // No PTS/DTS, ESCR flag, ES rate flag, DSM trick mode flag, additional copy info flag, PES CRC flag, PES extension flag
+        data.push_back(0x00); // PES header data length = 0
+    }
+
+    return data;
+}
+
+// Helper to create a PES packet with MPEG2 video payload
+std::vector<uint8_t> createMpeg2PesPacket() {
+    auto data = createBasicPesHeader(0xE0, true); // Video stream 0
+
+    // MPEG2 video start code: 0x000001B3
+    data.push_back(0x00);
+    data.push_back(0x00);
+    data.push_back(0x01);
+    data.push_back(0xB3); // MPEG2 sequence header
+
+    // Add some dummy payload
+    for (int i = 0; i < 20; i++) {
+        data.push_back(0x00);
+    }
+
+    return data;
+}
+
+// Helper to create a PES packet with H.264 video payload
+std::vector<uint8_t> createH264PesPacket(bool withLeadingZero = false) {
+    auto data = createBasicPesHeader(0xE0, true); // Video stream 0
+
+    if (withLeadingZero) {
+        data.push_back(0x00); // Leading zero byte
+    }
+
+    // H.264 NAL unit start code: 0x00000109
+    data.push_back(0x00);
+    data.push_back(0x00);
+    data.push_back(0x01);
+    data.push_back(0x09); // H.264 access unit delimiter
+    data.push_back(0x10); // Marker byte
+
+    // Add more data to pass array bounds check
+    for (int i = 0; i < 20; i++) {
+        data.push_back(0x00);
+    }
+
+    return data;
+}
+
+// Helper to create a PES packet with HEVC video payload
+std::vector<uint8_t> createHevcPesPacket(bool withLeadingZero = false) {
+    auto data = createBasicPesHeader(0xE0, true); // Video stream 0
+
+    if (withLeadingZero) {
+        data.push_back(0x00); // Leading zero byte
+    }
+
+    // HEVC NAL unit start code: 0x00000146
+    data.push_back(0x00);
+    data.push_back(0x00);
+    data.push_back(0x01);
+    data.push_back(0x46); // HEVC access unit delimiter
+    data.push_back(0x10); // Marker byte
+
+    // Add more data to pass array bounds check
+    for (int i = 0; i < 20; i++) {
+        data.push_back(0x00);
+    }
+
+    return data;
+}
+
+// Helper to create a PES packet with audio payload
+std::vector<uint8_t> createAudioPesPacket() {
+    auto data = createBasicPesHeader(0xC0, false); // Audio stream 0
+
+    // Add some audio payload
+    for (int i = 0; i < 20; i++) {
+        data.push_back(0xFF);
+    }
+
+    return data;
+}
+
+TEST_CASE("cPes - Basic construction", "[pes]") {
+    SECTION("Construct with valid data") {
+        auto data = createBasicPesHeader(0xE0);
+        cPes pes(data.data(), data.size());
+
+        REQUIRE(pes.GetCodec() == AV_CODEC_ID_NONE);
+    }
+
+    SECTION("Construct with empty data") {
+        uint8_t data[] = {};
+        cPes pes(data, 0);
+
+        REQUIRE(pes.GetCodec() == AV_CODEC_ID_NONE);
+    }
+}
+
+TEST_CASE("cPes - Header validation", "[pes]") {
+    SECTION("Valid PES header") {
+        auto data = createBasicPesHeader(0xE0);
+        cPes pes(data.data(), data.size());
+
+        REQUIRE(pes.IsHeaderValid());
+    }
+
+    SECTION("Invalid PES header - wrong start code") {
+        std::vector<uint8_t> data = {0x00, 0x00, 0x02, 0xE0, 0x00, 0x00};
+        cPes pes(data.data(), data.size());
+
+        REQUIRE(!pes.IsHeaderValid());
+    }
+
+    SECTION("Invalid PES header - missing bytes") {
+        std::vector<uint8_t> data = {0x00, 0x00, 0x01};
+        cPes pes(data.data(), data.size());
+
+        REQUIRE(!pes.IsHeaderValid());
+    }
+}
+
+TEST_CASE("cPes - Stream type detection", "[pes]") {
+    SECTION("Video stream detection") {
+        // Video streams have stream IDs 0xE0-0xEF
+        for (uint8_t id = 0xE0; id <= 0xEF; id++) {
+            auto data = createBasicPesHeader(id);
+            cPes pes(data.data(), data.size());
+
+            REQUIRE(pes.IsVideoStream());
+            REQUIRE(!pes.IsAudioStream());
+        }
+    }
+
+    SECTION("Audio stream detection") {
+        // Audio streams have stream IDs 0xC0-0xCF
+        for (uint8_t id = 0xC0; id <= 0xCF; id++) {
+            auto data = createBasicPesHeader(id);
+            cPes pes(data.data(), data.size());
+
+            REQUIRE(pes.IsAudioStream());
+            REQUIRE(!pes.IsVideoStream());
+        }
+    }
+
+    SECTION("Neither audio nor video") {
+        auto data = createBasicPesHeader(0xBD); // Private stream 1
+        cPes pes(data.data(), data.size());
+
+        REQUIRE(!pes.IsVideoStream());
+        REQUIRE(!pes.IsAudioStream());
+    }
+}
+
+TEST_CASE("cPes - MPEG2 codec detection", "[pes]") {
+    SECTION("Detect MPEG2 video codec") {
+        auto data = createMpeg2PesPacket();
+        cPes pes(data.data(), data.size());
+
+        pes.Parse();
+
+        REQUIRE(pes.GetCodec() == AV_CODEC_ID_MPEG2VIDEO);
+        REQUIRE(pes.IsVideoStream());
+    }
+}
+
+TEST_CASE("cPes - H.264 codec detection", "[pes]") {
+    SECTION("Detect H.264 codec without leading zero") {
+        auto data = createH264PesPacket(false);
+        cPes pes(data.data(), data.size());
+
+        pes.Parse();
+
+        REQUIRE(pes.GetCodec() == AV_CODEC_ID_H264);
+    }
+
+    SECTION("Detect H.264 codec with leading zero") {
+        auto data = createH264PesPacket(true);
+        cPes pes(data.data(), data.size());
+
+        pes.Parse();
+
+        REQUIRE(pes.GetCodec() == AV_CODEC_ID_H264);
+    }
+}
+
+TEST_CASE("cPes - HEVC codec detection", "[pes]") {
+    SECTION("Detect HEVC codec without leading zero") {
+        auto data = createHevcPesPacket(false);
+        cPes pes(data.data(), data.size());
+
+        pes.Parse();
+
+        REQUIRE(pes.GetCodec() == AV_CODEC_ID_HEVC);
+    }
+
+    SECTION("Detect HEVC codec with leading zero") {
+        auto data = createHevcPesPacket(true);
+        cPes pes(data.data(), data.size());
+
+        pes.Parse();
+
+        REQUIRE(pes.GetCodec() == AV_CODEC_ID_HEVC);
+    }
+}
+
+TEST_CASE("cPes - PTS handling", "[pes]") {
+    SECTION("Get PTS from packet with PTS") {
+        auto data = createBasicPesHeader(0xE0, true);
+        cPes pes(data.data(), data.size());
+
+        int64_t pts = pes.GetPts();
+
+        REQUIRE(pts == 9000);
+    }
+
+    SECTION("Get PTS from packet without PTS") {
+        auto data = createBasicPesHeader(0xE0, false);
+        cPes pes(data.data(), data.size());
+
+        int64_t pts = pes.GetPts();
+
+        REQUIRE(pts == AV_NOPTS_VALUE);
+    }
+}
+
+TEST_CASE("cPes - Payload extraction", "[pes]") {
+    SECTION("Get payload from MPEG2 packet") {
+        auto data = createMpeg2PesPacket();
+        cPes pes(data.data(), data.size());
+
+        pes.Parse();
+
+        const uint8_t* payload = pes.GetPayload();
+        int payloadSize = pes.GetPayloadSize();
+
+        // Verify start code is present in payload
+        REQUIRE(payload != nullptr);
+        REQUIRE(payload[0] == 0x00);
+        REQUIRE(payload[1] == 0x00);
+        REQUIRE(payload[2] == 0x01);
+
+        REQUIRE(payloadSize == 24); // 4 bytes start code + 20 bytes dummy payload
+    }
+
+    SECTION("Get payload from H.264 packet without leading zero") {
+        auto data = createH264PesPacket(false);
+        cPes pes(data.data(), data.size());
+
+        pes.Parse();
+
+        const uint8_t* payload = pes.GetPayload();
+        int payloadSize = pes.GetPayloadSize();
+
+
+        // Verify start code is present in payload
+        REQUIRE(payload != nullptr);
+        REQUIRE(payload[0] == 0x00);
+        REQUIRE(payload[1] == 0x00);
+        REQUIRE(payload[2] == 0x01);
+
+        REQUIRE(payloadSize == 25); // 4 bytes start code + 1 marker + 20 bytes dummy payload
+    }
+
+    SECTION("Get payload from H.264 packet with leading zero") {
+        auto data = createH264PesPacket(true);
+        cPes pes(data.data(), data.size());
+
+        pes.Parse();
+
+        const uint8_t* payload = pes.GetPayload();
+        int payloadSize = pes.GetPayloadSize();
+
+        // Leading zero should be skipped
+        REQUIRE(payload != nullptr);
+        REQUIRE(payload[0] == 0x00);
+        REQUIRE(payload[1] == 0x00);
+        REQUIRE(payload[2] == 0x01);
+
+        REQUIRE(payloadSize == 25); // 4 bytes start code + 1 marker + 20 bytes dummy payload
+    }
+
+    SECTION("Payload size consistency") {
+        auto data = createMpeg2PesPacket();
+        cPes pes(data.data(), data.size());
+
+        pes.Parse();
+
+        const uint8_t* payload = pes.GetPayload();
+        int payloadSize = pes.GetPayloadSize();
+
+        // Verify payload + header size equals total size
+        int headerSize = payload - data.data();
+        REQUIRE(headerSize + payloadSize == static_cast<int>(data.size()));
+    }
+}
+
+TEST_CASE("cPes - Audio stream handling", "[pes]") {
+    SECTION("Audio stream without codec parsing") {
+        auto data = createAudioPesPacket();
+        cPes pes(data.data(), data.size());
+
+        REQUIRE(pes.IsAudioStream());
+        REQUIRE(!pes.IsVideoStream());
+
+        pes.Parse();
+
+        // TODO Audio codec detection is not implemented, yet
+        REQUIRE(pes.GetCodec() == AV_CODEC_ID_NONE);
+    }
+}
+
+TEST_CASE("cPes - Edge cases", "[pes]") {
+    SECTION("Parse very short packet") {
+        std::vector<uint8_t> data = {0x00, 0x00, 0x01, 0xE0};
+        cPes pes(data.data(), data.size());
+
+        pes.Parse();
+
+        // Should not crash and codec should remain NONE
+        REQUIRE(pes.GetCodec() == AV_CODEC_ID_NONE);
+    }
+
+    SECTION("Parse packet with no payload") {
+        auto data = createBasicPesHeader(0xE0);
+        cPes pes(data.data(), data.size());
+
+        pes.Parse();
+
+        REQUIRE(pes.GetCodec() == AV_CODEC_ID_NONE);
+    }
+
+    SECTION("Parse packet with invalid start code in payload") {
+        auto data = createBasicPesHeader(0xE0);
+        // Add invalid start code
+        data.push_back(0x00);
+        data.push_back(0x00);
+        data.push_back(0x02); // Wrong start code
+        data.push_back(0xB3);
+
+        cPes pes(data.data(), data.size());
+
+        pes.Parse();
+
+        REQUIRE(pes.GetCodec() == AV_CODEC_ID_NONE);
+    }
+}
+
+TEST_CASE("cPes - to_string utility", "[pes]") {
+    SECTION("Convert unknown codec ID to string") {
+        AVCodecID unknownCodec = static_cast<AVCodecID>(9999);
+        REQUIRE(std::string(to_string(unknownCodec)) == "Unknown codec");
+    }
+}


### PR DESCRIPTION
I refactored the PES parsing, because it was in the way when integrating the new cQueue in cSoftHdDevice::PlayVideo(). There are more ocurrences where the new parser could be used, but this PR is already big enough.

The parser was implemented by me (documented by AI) and the unit tests and coverage report generation were generated by Claude Code. I reviewed and tweaked them.

I did manual tests with H.264.