### PR TITLE
Fix uninitilized access

### DIFF
--- a/audio.h
+++ b/audio.h
@@ -146,8 +146,8 @@ private:
 	const char *m_pMixerChannel;            ///< mixer channel name
 
 	// filter
-	int m_filterChanged;                    ///< filter has changed
-	int m_filterReady;                      ///< filter is ready
+	int m_filterChanged = 0;                ///< filter has changed
+	int m_filterReady = 0;                  ///< filter is ready
 	AVFilterGraph *m_pFilterGraph;
 	AVFilterContext *m_pBuffersrcCtx;
 	AVFilterContext *m_pBuffersinkCtx;

--- a/videorender.cpp
+++ b/videorender.cpp
@@ -1240,7 +1240,7 @@ void cVideoRender::EnqueueFB(AVFrame *inframe)
 
 			int primefd;
 			if (drmPrimeHandleToFD(fdDrm, buf->Handle(0), DRM_CLOEXEC | DRM_RDWR, &primefd))
-				LOGERROR("videorender: %s: Failed to retrieve the Prime FD (%d): %m", __FUNCTION__, errno);
+				LOGERROR("videorender: %s: Failed to retrieve the Prime FD", __FUNCTION__);
 			buf->SetFdPrime(0, primefd);
 		}
 	}

--- a/videorender.cpp
+++ b/videorender.cpp
@@ -1240,7 +1240,7 @@ void cVideoRender::EnqueueFB(AVFrame *inframe)
 
 			int primefd;
 			if (drmPrimeHandleToFD(fdDrm, buf->Handle(0), DRM_CLOEXEC | DRM_RDWR, &primefd))
-				LOGERROR("videorender: %s: Failed to retrieve the Prime FD", __FUNCTION__);
+				LOGERROR("videorender: %s: Failed to retrieve the Prime FD (%d): %m", __FUNCTION__, errno);
 			buf->SetFdPrime(0, primefd);
 		}
 	}

--- a/videorender.h
+++ b/videorender.h
@@ -205,7 +205,7 @@ private:
 
 	int m_numFramesToFilter;            ///< number of frames to be filtered
 	bool m_deintDisabled;               ///< set, if deinterlacer is disabled
-	bool m_configDeintDisabled;         ///< set, if a deinterlacer on/off should be triggered
+	bool m_configDeintDisabled = false; ///< set, if a deinterlacer on/off should be triggered
 	int m_numWrongProgressive;          ///< counter for progressive frames sent in an interlaced stream
 	                                    ///< (only used for logging)
 
@@ -218,8 +218,8 @@ private:
 	cRect m_lastVideoGrab;              ///< crtc rect of the last shown video frame
 
 	int m_startCounter;                 ///< counter for displayed frames, indicates a video start
-	int m_framesDuped;                  ///< number of frames duplicated
-	int m_framesDropped;                ///< number of frames dropped
+	int m_framesDuped = 0;              ///< number of frames duplicated
+	int m_framesDropped = 0;            ///< number of frames dropped
 	AVRational *m_timebase;             ///< pointer to AVCodecContext pkts_timebase
 	int64_t m_pts;                      ///< current video PTS
 
@@ -231,7 +231,7 @@ private:
 	cDrmBuffer *m_pBufOsd;              ///< pointer to osd drm buffer object
 	cDrmBuffer m_bufBlack;              ///< black drm buffer object
 	struct lastFrame *m_pLastFrame;     ///< pointer to last rendered frame struct (for later free)
-	int m_numBuffers;                   ///< numer of framebuffers currently set up
+	int m_numBuffers = 0;               ///< numer of framebuffers currently set up
 	int m_enqueueBufferIdx;             ///< index of the current (sw) framebuffer in the array
 	bool m_osdShown;                    ///< set, if osd is shown currently
 

--- a/videorender.h
+++ b/videorender.h
@@ -231,7 +231,7 @@ private:
 	cDrmBuffer *m_pBufOsd;              ///< pointer to osd drm buffer object
 	cDrmBuffer m_bufBlack;              ///< black drm buffer object
 	struct lastFrame *m_pLastFrame;     ///< pointer to last rendered frame struct (for later free)
-	int m_numBuffers = 0;               ///< numer of framebuffers currently set up
+	int m_numBuffers = 0;               ///< number of framebuffers currently set up
 	int m_enqueueBufferIdx;             ///< index of the current (sw) framebuffer in the array
 	bool m_osdShown;                    ///< set, if osd is shown currently
 


### PR DESCRIPTION
This fixes the Valgrind errors for this class reported in #58. It initializes all members with their default values. I find this solution quite appealing. It could be applied to all classes so we can eliminate these errors once and for all. WDYT?

Fixes https://github.com/rellla/vdr-plugin-softhddevice-drm-gles/issues/58