### PR TITLE
Fix some definite memleaks

### DIFF
--- a/audio.cpp
+++ b/audio.cpp
@@ -68,6 +68,8 @@ cSoftHdAudio::cSoftHdAudio(cSoftHdDevice *device)
 	m_pPassthroughDevice = nullptr;
 	m_pPCMDevice = nullptr;
 
+	m_pFilterGraph = nullptr;
+
 	m_pAlsaMixer = nullptr;
 	m_pMixerDevice = nullptr;
 	m_pMixerChannel = nullptr;
@@ -460,14 +462,22 @@ int cSoftHdAudio::InitFilter(AVCodecContext *audioCtx)
 	avfilter_register_all();
 #endif
 
-	if (!(m_pFilterGraph = avfilter_graph_alloc()))
+	if (!(m_pFilterGraph = avfilter_graph_alloc())) {
 		LOGERROR("audio: %s: Unable to create filter graph.", __FUNCTION__);
+		return -1;
+	}
 
 	// input buffer
-	if (!(abuffer = avfilter_get_by_name("abuffer")))
+	if (!(abuffer = avfilter_get_by_name("abuffer"))) {
 		LOGWARNING("audio: %s: Could not find the abuffer filter.", __FUNCTION__);
-	if (!(m_pBuffersrcCtx = avfilter_graph_alloc_filter(m_pFilterGraph, abuffer, "src")))
+		avfilter_graph_free(&m_pFilterGraph);
+		return -1;
+	}
+	if (!(m_pBuffersrcCtx = avfilter_graph_alloc_filter(m_pFilterGraph, abuffer, "src"))) {
 		LOGWARNING("audio: %s: Could not allocate the m_pBuffersrcCtx instance.", __FUNCTION__);
+		avfilter_graph_free(&m_pFilterGraph);
+		return -1;
+	}
 
 	av_channel_layout_describe(&audioCtx->ch_layout, channelLayout, sizeof(channelLayout));
 
@@ -481,15 +491,24 @@ int cSoftHdAudio::InitFilter(AVCodecContext *audioCtx)
 //	av_opt_set_int(m_pBuffersrcCtx, "channel_counts", audioCtx->channels,                           AV_OPT_SEARCH_CHILDREN);
 
 	// initialize the filter with NULL options, set all options above.
-	if (avfilter_init_str(m_pBuffersrcCtx, NULL) < 0)
+	if (avfilter_init_str(m_pBuffersrcCtx, NULL) < 0) {
 		LOGWARNING("audio: %s: Could not initialize the abuffer filter.", __FUNCTION__);
+		avfilter_graph_free(&m_pFilterGraph);
+		return -1;
+	}
 
 	// superequalizer
 	if (m_useEqualizer) {
-		if (!(eq = avfilter_get_by_name("superequalizer")))
+		if (!(eq = avfilter_get_by_name("superequalizer"))) {
 			LOGWARNING("audio: %s: Could not find the superequalizer filter.", __FUNCTION__);
-		if (!(pfilterCtx[numFilter] = avfilter_graph_alloc_filter(m_pFilterGraph, eq, "superequalizer")))
+			avfilter_graph_free(&m_pFilterGraph);
+			return -1;
+		}
+		if (!(pfilterCtx[numFilter] = avfilter_graph_alloc_filter(m_pFilterGraph, eq, "superequalizer"))) {
 			LOGWARNING("audio: %s: Could not allocate the superequalizer instance.", __FUNCTION__);
+			avfilter_graph_free(&m_pFilterGraph);
+			return -1;
+		}
 		snprintf(optionsStr, sizeof(optionsStr),"1b=%.2f:2b=%.2f:3b=%.2f:4b=%.2f:5b=%.2f"
 			":6b=%.2f:7b=%.2f:8b=%.2f:9b=%.2f:10b=%.2f:11b=%.2f:12b=%.2f:13b=%.2f:14b=%.2f:"
 			"15b=%.2f:16b=%.2f:17b=%.2f:18b=%.2f ", m_equalizerBand[0], m_equalizerBand[1],
@@ -497,8 +516,11 @@ int cSoftHdAudio::InitFilter(AVCodecContext *audioCtx)
 			m_equalizerBand[6], m_equalizerBand[7], m_equalizerBand[8], m_equalizerBand[9],
 			m_equalizerBand[10], m_equalizerBand[11], m_equalizerBand[12], m_equalizerBand[13],
 			m_equalizerBand[14], m_equalizerBand[15], m_equalizerBand[16], m_equalizerBand[17]);
-		if (avfilter_init_str(pfilterCtx[numFilter], optionsStr) < 0)
+		if (avfilter_init_str(pfilterCtx[numFilter], optionsStr) < 0) {
 			LOGWARNING("audio: %s: Could not initialize the superequalizer filter.", __FUNCTION__);
+			avfilter_graph_free(&m_pFilterGraph);
+			return -1;
+		}
 		numFilter++;
 	}
 
@@ -510,24 +532,42 @@ int cSoftHdAudio::InitFilter(AVCodecContext *audioCtx)
 	// should use IN layout if more then 2 ch!?
 	LOGDEBUG2(L_SOUND, "audio: %s: OUT m_downmix %d m_hwNumChannels %d m_hwSampleRate %d channelLayout %s bytes_per_sample %d",
 			  __FUNCTION__, m_downmix, m_hwNumChannels, m_hwSampleRate, channelLayout, av_get_bytes_per_sample(AV_SAMPLE_FMT_S16));
-	if (!(aformat = avfilter_get_by_name("aformat")))
+	if (!(aformat = avfilter_get_by_name("aformat"))) {
 		LOGWARNING("audio: %s: Could not find the aformat filter.", __FUNCTION__);
-	if (!(pfilterCtx[numFilter] = avfilter_graph_alloc_filter(m_pFilterGraph, aformat, "aformat")))
+		avfilter_graph_free(&m_pFilterGraph);
+		return -1;
+	}
+	if (!(pfilterCtx[numFilter] = avfilter_graph_alloc_filter(m_pFilterGraph, aformat, "aformat"))) {
 		LOGWARNING("audio: %s: Could not allocate the aformat instance.", __FUNCTION__);
+		avfilter_graph_free(&m_pFilterGraph);
+		return -1;
+	}
 	snprintf(optionsStr, sizeof(optionsStr),
 		"sample_fmts=%s:sample_rates=%d:channel_layouts=%s",
 		av_get_sample_fmt_name(AV_SAMPLE_FMT_S16), m_hwSampleRate, channelLayout);
-	if (avfilter_init_str(pfilterCtx[numFilter], optionsStr) < 0)
+	if (avfilter_init_str(pfilterCtx[numFilter], optionsStr) < 0) {
 		LOGWARNING("audio: %s: Could not initialize the aformat filter.", __FUNCTION__);
+		avfilter_graph_free(&m_pFilterGraph);
+		return -1;
+	}
 	numFilter++;
 
 	// abuffersink
-	if (!(abuffersink = avfilter_get_by_name("abuffersink")))
+	if (!(abuffersink = avfilter_get_by_name("abuffersink"))) {
 		LOGWARNING("audio: %s: Could not find the abuffersink filter.", __FUNCTION__);
-	if (!(pfilterCtx[numFilter] = avfilter_graph_alloc_filter(m_pFilterGraph, abuffersink, "sink")))
+		avfilter_graph_free(&m_pFilterGraph);
+		return -1;
+	}
+	if (!(pfilterCtx[numFilter] = avfilter_graph_alloc_filter(m_pFilterGraph, abuffersink, "sink"))) {
 		LOGWARNING("audio: %s: Could not allocate the abuffersink instance.", __FUNCTION__);
-	if (avfilter_init_str(pfilterCtx[numFilter], NULL) < 0)
+		avfilter_graph_free(&m_pFilterGraph);
+		return -1;
+	}
+	if (avfilter_init_str(pfilterCtx[numFilter], NULL) < 0) {
 		LOGWARNING("audio: %s: Could not initialize the abuffersink instance.", __FUNCTION__);
+		avfilter_graph_free(&m_pFilterGraph);
+		return -1;
+	}
 	numFilter++;
 
 	// Connect the filters
@@ -538,12 +578,18 @@ int cSoftHdAudio::InitFilter(AVCodecContext *audioCtx)
 			err = avfilter_link(pfilterCtx[i - 1], 0, pfilterCtx[i], 0);
 		}
 	}
-	if (err < 0)
+	if (err < 0) {
 		LOGWARNING("audio: %s: Error connecting audio filters", __FUNCTION__);
+		avfilter_graph_free(&m_pFilterGraph);
+		return -1;
+	}
 
 	// Configure the graph.
-	if (avfilter_graph_config(m_pFilterGraph, NULL) < 0)
+	if (avfilter_graph_config(m_pFilterGraph, NULL) < 0) {
 		LOGWARNING("audio: %s: Error configuring the audio filter graph", __FUNCTION__);
+		avfilter_graph_free(&m_pFilterGraph);
+		return -1;
+	}
 
 	m_pBuffersinkCtx = pfilterCtx[numFilter - 1];
 	m_filterChanged = 0;
@@ -1255,6 +1301,8 @@ void cSoftHdAudio::Exit(void)
 		if (m_pAudioThread->Active())
 			m_pAudioThread->Stop();
 		delete m_pAudioThread;
+
+		avfilter_graph_free(&m_pFilterGraph);
 
 		AlsaExit();
 		ExitRingbuffer();

--- a/audio.cpp
+++ b/audio.cpp
@@ -1520,7 +1520,8 @@ char *cSoftHdAudio::OpenAlsaDevice(const char *device, int passthrough)
  * @param hint             string to compare with device name hints
  * @param passthrough      set, if we want a passthrough device
  *
- * @returns	an opened alsa device if successful, NULL otherwise
+ * @returns	an opened alsa device name if successful, NULL otherwise
+ *              NOTE: Returned string is allocated and must be freed by caller
  */
 char *cSoftHdAudio::FindAlsaDevice(const char *devname, const char *hint, int passthrough)
 {
@@ -1528,7 +1529,6 @@ char *cSoftHdAudio::FindAlsaDevice(const char *devname, const char *hint, int pa
 	int err;
 	char **n;
 	char *name;
-	char *device = NULL;
 
 	err = snd_device_name_hint(-1, devname, (void ***)&hints);
 	if (err != 0) {
@@ -1541,12 +1541,9 @@ char *cSoftHdAudio::FindAlsaDevice(const char *devname, const char *hint, int pa
 		name = snd_device_name_get_hint(*n, "NAME");
 
 		if (name && strstr(name, hint)) {
-			if ((device = OpenAlsaDevice(name, passthrough))) {
-				device = (char *)malloc(sizeof(char) * (strlen(name) + 1));
-				strcpy(device, name);
-				free(name);
+			if (OpenAlsaDevice(name, passthrough)) {
 				snd_device_name_free_hint((void **)hints);
-				return (char *)device;
+				return name;
 			}
 		}
 
@@ -1565,6 +1562,7 @@ char *cSoftHdAudio::FindAlsaDevice(const char *devname, const char *hint, int pa
 void cSoftHdAudio::AlsaInitPCMDevice(void)
 {
 	char *device = NULL;
+	bool freeDevice = false;  // track if device needs to be freed
 	int err;
 	LOGDEBUG2(L_SOUND, "audio: %s: passthrough %d", __FUNCTION__, m_passthrough);
 
@@ -1585,12 +1583,14 @@ void cSoftHdAudio::AlsaInitPCMDevice(void)
 	if (!device) {
 		LOGDEBUG2(L_SOUND, "audio: %s: Try hdmi: devices...", __FUNCTION__);
 		device = FindAlsaDevice("pcm", "hdmi:", m_passthrough);
+		freeDevice = (device != NULL);  // FindAlsaDevice allocates memory
 	}
 
 	// walkthrough default: devices
 	if (!device) {
 		LOGDEBUG2(L_SOUND, "audio: %s: Try default: devices...", __FUNCTION__);
 		device = FindAlsaDevice("pcm", "default:", m_passthrough);
+		freeDevice = (device != NULL);  // FindAlsaDevice allocates memory
 	}
 
 	// try default device
@@ -1614,6 +1614,10 @@ void cSoftHdAudio::AlsaInitPCMDevice(void)
 	else
 		LOGINFO("audio: using %sdevice '%s'",
 			m_passthrough ? "pass-through " : "", device);
+
+	// Free device string if it was allocated by FindAlsaDevice
+	if (freeDevice)
+		free(device);
 
 	if ((err = snd_pcm_nonblock(m_pAlsaPCMHandle, 0)) < 0) {
 		LOGERROR("audio: %s: can't set block mode: %s", __FUNCTION__, snd_strerror(err));

--- a/audio.cpp
+++ b/audio.cpp
@@ -1540,7 +1540,7 @@ char *cSoftHdAudio::FindAlsaDevice(const char *devname, const char *hint, int pa
 	while (*n != NULL) {
 		name = snd_device_name_get_hint(*n, "NAME");
 
-		if (strstr(name, hint)) {
+		if (name && strstr(name, hint)) {
 			if ((device = OpenAlsaDevice(name, passthrough))) {
 				device = (char *)malloc(sizeof(char) * (strlen(name) + 1));
 				strcpy(device, name);
@@ -1550,7 +1550,8 @@ char *cSoftHdAudio::FindAlsaDevice(const char *devname, const char *hint, int pa
 			}
 		}
 
-		if (name && strcmp("null", name)) free(name);
+		if (name)
+			free(name);
 		n++;
 	}
 


### PR DESCRIPTION
The audio code is soo bad.

### Leak avfilter_graph()
```
==213839== 93,754 (88 direct, 93,666 indirect) bytes in 1 blocks are definitely lost in loss record 3,406 of 3,418
==213839==    at 0x488A324: memalign (vg_replace_malloc.c:1516)
==213839==    by 0x488A497: posix_memalign (vg_replace_malloc.c:1688)
==213839==    by 0x7D68AEF: av_malloc (in /usr/lib/aarch64-linux-gnu/libavutil.so.57.28.100)
==213839==    by 0x7D68F6F: av_mallocz (in /usr/lib/aarch64-linux-gnu/libavutil.so.57.28.100)
==213839==    by 0x7233F47: avfilter_graph_alloc (in /usr/lib/aarch64-linux-gnu/libavfilter.so.8.44.100)
==213839==    by 0x5CB1C73: cSoftHdAudio::InitFilter(AVCodecContext*) (audio.cpp:463)
==213839==    by 0x5CB32AF: cSoftHdAudio::CheckForFilterReady(AVCodecContext*) (audio.cpp:787)
==213839==    by 0x5CB3387: cSoftHdAudio::Filter(AVFrame*, AVCodecContext*) (audio.cpp:813)
==213839==    by 0x5CB9437: cAudioDecoder::Decode(AVPacket const*) (codec_audio.cpp:413)
==213839==    by 0x5CCEDD3: cSoftHdDevice::PlayAudio(unsigned char const*, int, unsigned char) (softhddevice.cpp:1243)
==213839==    by 0x2025AB: cDevice::PlayTsAudio(unsigned char const*, int) (device.c:1624)
==213839==    by 0x202A2F: cDevice::PlayTs(unsigned char const*, int, bool) (device.c:1685)
```

### Leak snd_device_name_get_hint()
Doc for snd_device_name_get_hint() https://alsa-project.org/alsa-doc/alsa-lib/group___hint.html#ga8546500ca828392f03f5bba2e7813874 states "The return value should be freed when no longer needed.", i.e., the value should also be freed if it is literally "null".

strstr() has undefined behavior when fed with a null pointer.

```
==214619== 5 bytes in 1 blocks are definitely lost in loss record 18 of 3,350
==214619==    at 0x48850C8: malloc (vg_replace_malloc.c:381)
==214619==    by 0x5D813EB: snd_device_name_get_hint (in /usr/lib/aarch64-linux-gnu/libasound.so.2.0.0)
==214619==    by 0x5CB579B: cSoftHdAudio::FindAlsaDevice(char const*, char const*, int) (audio.cpp:1541)
==214619==    by 0x5CB5A2B: cSoftHdAudio::AlsaInitPCMDevice() (audio.cpp:1586)
==214619==    by 0x5CB6B13: cSoftHdAudio::AlsaInit() (audio.cpp:1838)
==214619==    by 0x5CB4ADB: cSoftHdAudio::LazyInit() (audio.cpp:1286)
==214619==    by 0x5CCF5A7: cSoftHdDevice::PlayVideo(unsigned char const*, int) (softhddevice.cpp:1377)
==214619==    by 0x2024E3: cDevice::PlayTsVideo(unsigned char const*, int) (device.c:1607)
==214619==    by 0x202947: cDevice::PlayTs(unsigned char const*, int, bool) (device.c:1677)
==214619==    by 0x21A7FF: cPlayer::PlayTs(unsigned char const*, int, bool) (player.h:48)
==214619==    by 0x218867: cDvbPlayer::Action() (dvbplayer.c:663)
==214619==    by 0x2DE67B: cThread::StartThread(cThread*) (thread.c:294)
```

### Leak FindAlsaDevice() device/name 
Tested with env variable ALSA_DEVICE set and let it look for hdmi devices through FindAlsaDevice().

```
==216653== 25 bytes in 1 blocks are definitely lost in loss record 282 of 3,348
==216653==    at 0x48850C8: malloc (vg_replace_malloc.c:381)
==216653==    by 0x5CB57FB: cSoftHdAudio::FindAlsaDevice(char const*, char const*, int) (audio.cpp:1545)
==216653==    by 0x5CB5A1F: cSoftHdAudio::AlsaInitPCMDevice() (audio.cpp:1587)
==216653==    by 0x5CB6B07: cSoftHdAudio::AlsaInit() (audio.cpp:1839)
==216653==    by 0x5CB4ADB: cSoftHdAudio::LazyInit() (audio.cpp:1286)
==216653==    by 0x5CCF59B: cSoftHdDevice::PlayVideo(unsigned char const*, int) (softhddevice.cpp:1377)
==216653==    by 0x2024E3: cDevice::PlayTsVideo(unsigned char const*, int) (device.c:1607)
==216653==    by 0x202947: cDevice::PlayTs(unsigned char const*, int, bool) (device.c:1677)
==216653==    by 0x21A7FF: cPlayer::PlayTs(unsigned char const*, int, bool) (player.h:48)
==216653==    by 0x218867: cDvbPlayer::Action() (dvbplayer.c:663)
==216653==    by 0x2DE67B: cThread::StartThread(cThread*) (thread.c:294)
==216653==    by 0x4F4202F: start_thread (pthread_create.c:442)
```
