### PR TITLE
Wait for decoding, filter and display thread to finish before clearing any buffers when stopping

### DIFF
--- a/softhddevice.cpp
+++ b/softhddevice.cpp
@@ -683,11 +683,12 @@ bool cSoftHdDevice::SetPlayMode(ePlayMode play_mode)
 
 	switch (play_mode) {
 	case pmNone:
-		m_pVideoStream->Stop();
+		m_pVideoStream->StopAndWaitDecodingIdle();
+		m_pRender->CleanupAndClose(true);
+
 		m_pVideoStream->ClearPacketQueue();
 		m_pVideoStream->CloseDecoder();
 
-		m_pRender->SetClosing(1);
 		m_skipAudio = false;
 		m_pAudio->Unmute();
 		m_pAudio->Resume();
@@ -696,7 +697,7 @@ bool cSoftHdDevice::SetPlayMode(ePlayMode play_mode)
 			m_newAudioStream = true;
 
 		m_pVideoStream->SetInterlaced(0); // probably not necessary
-		m_pVideoStream->Start();
+		m_pVideoStream->StartDecoding();
 		m_pVideoStream->Resume();
 		break;
 	case pmAudioVideo:
@@ -753,7 +754,7 @@ void cSoftHdDevice::TrickSpeed(int speed, bool forward)
 {
 	LOGDEBUG("device: %s: %d %s", __FUNCTION__, speed, forward ? "forward" : "backward");
 
-	m_pVideoStream->Start();     // start stream if closed
+	m_pVideoStream->StartDecoding();     // start stream if closed
 	m_pVideoStream->Resume();   // start stream if paused
 
 	m_pRender->SetTrickSpeed(speed, forward);
@@ -780,17 +781,17 @@ void cSoftHdDevice::Clear(void)
 	LOGDEBUG("device: %s:", __FUNCTION__);
 	cDevice::Clear();
 
-	m_pVideoStream->Stop();
+	m_pVideoStream->StopAndWaitDecodingIdle();
 	m_pVideoStream->ClearPacketQueue();
 	m_pVideoStream->FlushDecoder();
 
-	m_pRender->SetClosing(0);
+	m_pRender->CleanupAndClose(false);
 
 	ClearAudio();
 
 	// we need a Start() here, because when VDR does SkipSeconds()
 	// it doesn't send a Play() again, if we skip during a playing stream
-	m_pVideoStream->Start();
+	m_pVideoStream->StartDecoding();
 }
 
 /**
@@ -816,7 +817,7 @@ void cSoftHdDevice::Play(void)
 	m_pRender->WaitForFilterIdle();
 	m_pRender->StopFilter();
 
-	m_pVideoStream->Start();
+	m_pVideoStream->StartDecoding();
 	m_pVideoStream->Resume();
 
 	m_skipAudio = false;

--- a/videorender.cpp
+++ b/videorender.cpp
@@ -1213,7 +1213,7 @@ void cVideoRender::ExitDisplayThread(void)
 {
 	LOGDEBUG("videorender: %s", __FUNCTION__);
 
-	SetClosing(1);
+	CleanupAndClose(true);
 	if (m_pDisplayThread->Active()) {
 		m_exitThread = true;
 		m_pDisplayThread->Stop();
@@ -1547,7 +1547,7 @@ void cVideoRender::StartVideo(void)
  * @param black     true, if a black fb should be set and the last rendered buffer should be cleared,
  *                  otherwise don't set a black fb and wait for the clear until the next frame arrives
  */
-void cVideoRender::SetClosing(int black)
+void cVideoRender::CleanupAndClose(bool black)
 {
 	LOGDEBUG("videorender: %s: m_startCounter %d%s", __FUNCTION__, m_startCounter, black ? " closing": " flushing");
 	if (!m_pDisplayThread->Active())

--- a/videorender.h
+++ b/videorender.h
@@ -107,7 +107,7 @@ public:
 	void PauseVideo(void);
 	void ResumeVideo(void);
 	bool VideoIsPaused(void);
-	void SetClosing(int);
+	void CleanupAndClose(bool);
 	bool ShouldClose(void) { return m_closing; };
 	bool ShouldFlush(void) { return m_flushing; };
 

--- a/videostream.cpp
+++ b/videostream.cpp
@@ -76,7 +76,7 @@ cVideoStream::cVideoStream(cSoftHdDevice *device)
 	m_interlaced = 0;
 	m_trickpkts = 1;
 
-	Start();
+	StartDecoding();
 }
 
 /**
@@ -454,7 +454,7 @@ void cVideoStream::SetTimebase(int num, int den)
  *
  * Skips the decoding of the stream until m_closing gets false again (with Start())
  */
-void cVideoStream::Stop(void)
+void cVideoStream::StopAndWaitDecodingIdle(void)
 {
 	int timeoutInMs = 1000;
 	m_closing = true;

--- a/videostream.h
+++ b/videostream.h
@@ -53,8 +53,8 @@ public:
 	void CloseDecoder(void);
 	int DecodeInput(void);
 	void StillPicture(cPesVideo *);
-	void Start(void) { m_closing = false; };
-	void Stop(void);
+	void StartDecoding(void) { m_closing = false; };
+	void StopAndWaitDecodingIdle(void);
 	void Resume(void) { m_paused = false; };
 	void Pause(void);
 	bool IsPaused(void) { return m_paused; };


### PR DESCRIPTION
Depends on #69

Fixes read of freed value when stopping playback:
```
==238147== Thread 2 softhd display:
==238147== Invalid read of size 8
==238147==    at 0x5CD9FC8: cVideoRender::Sync(AVFrame*) (videorender.cpp:565)
==238147==    by 0x5CDB11B: cVideoRender::DisplayFrame() (videorender.cpp:1036)
==238147==    by 0x5CD66A3: cDisplayThread::Action() (threads.cpp:95)
==238147==    by 0x2DE67B: cThread::StartThread(cThread*) (thread.c:294)
==238147==    by 0x4F4202F: start_thread (pthread_create.c:442)
==238147==    by 0x4FABF5B: thread_start (clone.S:79)
==238147==  Address 0x1ff92084 is 724 bytes inside a block of size 944 free'd
==238147==    at 0x4887B40: free (vg_replace_malloc.c:872)
==238147==    by 0x5CBADAF: cVideoDecoder::Close() (codec_video.cpp:363)
==238147==    by 0x5CDF43B: cVideoStream::CloseDecoder() (videostream.cpp:172)
==238147==    by 0x5CCDBDB: cSoftHdDevice::SetPlayMode(ePlayMode) (softhddevice.cpp:688)
==238147==    by 0x2018CB: cDevice::Detach(cPlayer*) (device.c:1425)
==238147==    by 0x280BDF: cPlayer::Detach() (player.c:37)
==238147==    by 0x21710F: cDvbPlayer::~cDvbPlayer() (dvbplayer.c:345)
==238147==    by 0x2171E7: cDvbPlayer::~cDvbPlayer() (dvbplayer.c:351)
==238147==    by 0x219EEB: cDvbPlayerControl::Stop() (dvbplayer.c:1024)
==238147==    by 0x25A73B: cReplayControl::Stop() (menu.c:5811)
==238147==    by 0x25CC1F: cReplayControl::ProcessKey(eKeys) (menu.c:6335)
==238147==    by 0x2F6AE7: main (vdr.c:1420)
==238147==  Block was alloc'd at
==238147==    at 0x488A324: memalign (vg_replace_malloc.c:1516)
==238147==    by 0x488A497: posix_memalign (vg_replace_malloc.c:1688)
==238147==    by 0x7D68AEF: av_malloc (in /usr/lib/aarch64-linux-gnu/libavutil.so.57.28.100)
==238147==    by 0x645C1AF: avcodec_alloc_context3 (in /usr/lib/aarch64-linux-gnu/libavcodec.so.59.37.100)
==238147==    by 0x5CBA56F: cVideoDecoder::Open(AVCodecID, AVCodecParameters*, AVRational*, int, int, int) (codec_video.cpp:247)
==238147==    by 0x5CBAB27: cVideoDecoder::Open(AVCodecID, AVCodecParameters*, AVRational*, int, int, int) (codec_video.cpp:337)
==238147==    by 0x5CDF96B: cVideoStream::DecodeInput() (videostream.cpp:274)
==238147==    by 0x5CD6457: cDecodingThread::Action() (threads.cpp:60)
==238147==    by 0x2DE67B: cThread::StartThread(cThread*) (thread.c:294)
==238147==    by 0x4F4202F: start_thread (pthread_create.c:442)
==238147==    by 0x4FABF5B: thread_start (clone.S:79)
```