### PR TITLE
DecodeInput(): Fix invalid read

### DIFF
--- a/videostream.cpp
+++ b/videostream.cpp
@@ -242,7 +242,7 @@ int cVideoStream::DecodeInput(void)
 	int ret = 0;
 
 	if (m_closing) {
-		m_closeCondition.Signal();
+		m_closeCondition.Broadcast();
 		return -1;
 	}
 
@@ -459,8 +459,9 @@ void cVideoStream::StopAndWaitDecodingIdle(void)
 	int timeoutInMs = 1000;
 	m_closing = true;
 
-	m_closeCondition.Wait(1); // Reset the signal. If the decode thread is idle, the signal is sent periodically.
-	if (!m_closeCondition.Wait(timeoutInMs))
+	cMutex mutex;
+	mutex.Lock();
+	if (!m_closeCondition.TimedWait(mutex, timeoutInMs))
 		LOGERROR("videostream %s: Timeout while closing stream (%d ms)!", __FUNCTION__, timeoutInMs);
 
 	LOGDEBUG2(L_CODEC, "videostream %s: stream is closing", __FUNCTION__);

--- a/videostream.cpp
+++ b/videostream.cpp
@@ -459,6 +459,7 @@ void cVideoStream::StopAndWaitDecodingIdle(void)
 	int timeoutInMs = 1000;
 	m_closing = true;
 
+	m_closeCondition.Wait(1); // Reset the signal. If the decode thread is idle, the signal is sent periodically.
 	if (!m_closeCondition.Wait(timeoutInMs))
 		LOGERROR("videostream %s: Timeout while closing stream (%d ms)!", __FUNCTION__, timeoutInMs);
 

--- a/videostream.h
+++ b/videostream.h
@@ -91,7 +91,7 @@ private:
 	volatile bool m_closing;               ///< flag for closing request
 	volatile bool m_paused;                ///< flag for paused stream
 	bool m_interlaced;                     ///< flag for interlaced stream
-	cCondWait m_closeCondition;            ///< condition object to wait for finishing jobs while closing
+	cCondVar m_closeCondition;             ///< condition object to wait for finishing jobs while closing
 	cCondVar m_pauseCondition;             ///< condition object to wait for pausing the stream
 
 	int RenderTrickspeedFrames(AVFrame *);


### PR DESCRIPTION
The thread synchronization with m_closeCondition don't work as expected: When the decode thread is idling, it periodically calls m_closeCondition.Signal(). But this is not reset when the idling is over (only Wait() resets it). So, cCondWait is always in the signalled state, leading to m_closeCondition.Wait() always return immediately.

This resets the signal before waiting for it.

Fixes:
```
==248034== Invalid read of size 8
==248034==    at 0x5CBB414: cVideoDecoder::SendPacket(AVPacket const*) (codec_video.cpp:502)
==248034==    by 0x5CDFB97: cVideoStream::DecodeInput() (videostream.cpp:291)
==248034==    by 0x5CD65B7: cDecodingThread::Action() (threads.cpp:60)
==248034==    by 0x2DE67B: cThread::StartThread(cThread*) (thread.c:294)
==248034==    by 0x4F4202F: start_thread (pthread_create.c:442)
==248034==    by 0x4FABF5B: thread_start (clone.S:79)
==248034==  Address 0x577e218 is 8 bytes inside a block of size 104 free'd
==248034==    at 0x4887B40: free (vg_replace_malloc.c:872)
==248034==    by 0x5CDF453: cVideoStream::ClearPacketQueue() (videostream.cpp:146)
==248034==    by 0x5CCE0D3: cSoftHdDevice::Clear() (softhddevice.cpp:785)
==248034==    by 0x21A5EF: cPlayer::DeviceClear() (player.h:31)
==248034==    by 0x21748B: cDvbPlayer::Empty() (dvbplayer.c:391)
==248034==    by 0x21901F: cDvbPlayer::Forward() (dvbplayer.c:783)
==248034==    by 0x219F8F: cDvbPlayerControl::Forward() (dvbplayer.c:1043)
==248034==    by 0x25C843: cReplayControl::ProcessKey(eKeys) (menu.c:6278)
==248034==    by 0x2F6AE7: main (vdr.c:1420)
==248034==  Block was alloc'd at
==248034==    at 0x488A324: memalign (vg_replace_malloc.c:1516)
==248034==    by 0x488A497: posix_memalign (vg_replace_malloc.c:1688)
==248034==    by 0x7D68AEF: av_malloc (in /usr/lib/aarch64-linux-gnu/libavutil.so.57.28.100)
==248034==    by 0x6048BC7: av_packet_alloc (in /usr/lib/aarch64-linux-gnu/libavcodec.so.59.37.100)
==248034==    by 0x5CC88EB: CreateAvPacket (misc.cpp:28)
==248034==    by 0x5CDF237: cVideoStream::PushPesPacket(cPes*) (videostream.cpp:101)
==248034==    by 0x5CCF7C7: cSoftHdDevice::PlayVideo(unsigned char const*, int) (softhddevice.cpp:1335)
==248034==    by 0x2024E3: cDevice::PlayTsVideo(unsigned char const*, int) (device.c:1607)
==248034==    by 0x202947: cDevice::PlayTs(unsigned char const*, int, bool) (device.c:1677)
==248034==    by 0x21A7FF: cPlayer::PlayTs(unsigned char const*, int, bool) (player.h:48)
==248034==    by 0x218867: cDvbPlayer::Action() (dvbplayer.c:663)
==248034==    by 0x2DE67B: cThread::StartThread(cThread*) (thread.c:294)

```