### PR TITLE
Fix av_hwdevice_ctx_create() mem leak

### DIFF
--- a/codec_video.cpp
+++ b/codec_video.cpp
@@ -265,7 +265,7 @@ int cVideoDecoder::Open(enum AVCodecID codecId, AVCodecParameters * par,
 		}
 		LOGDEBUG2(L_CODEC, "videocodec: %s: Using %s HW codec", __FUNCTION__,
 			type_name ? type_name : "unknown");
-		m_pVideoCtx->hw_device_ctx = av_buffer_ref(hwDeviceCtx);
+		m_pVideoCtx->hw_device_ctx = hwDeviceCtx;
 		m_pVideoCtx->pix_fmt = AV_PIX_FMT_DRM_PRIME;
 	}
 


### PR DESCRIPTION
According to https://github.com/FFmpeg/FFmpeg/blob/f5f72b4f8a410ac2de7f1040859032e087bc5492/libavutil/hwcontext.h#L282 the returned context is already reference counted. The additional av_buffer_ref() increases the reference count, leading to hw_device_ctx not being freed.

Fixes:
```
==84135== 148 (24 direct, 124 indirect) bytes in 1 blocks are definitely lost in loss record 2,814 of 3,362
==84135==    at 0x488A324: memalign (vg_replace_malloc.c:1516)
==84135==    by 0x488A497: posix_memalign (vg_replace_malloc.c:1688)
==84135==    by 0x7D68AEF: av_malloc (in /usr/lib/aarch64-linux-gnu/libavutil.so.57.28.100)
==84135==    by 0x7D68F6F: av_mallocz (in /usr/lib/aarch64-linux-gnu/libavutil.so.57.28.100)
==84135==    by 0x7D363F3: av_buffer_create (in /usr/lib/aarch64-linux-gnu/libavutil.so.57.28.100)
==84135==    by 0x7D49BE7: av_hwdevice_ctx_alloc (in /usr/lib/aarch64-linux-gnu/libavutil.so.57.28.100)
==84135==    by 0x7D4A3F3: av_hwdevice_ctx_create (in /usr/lib/aarch64-linux-gnu/libavutil.so.57.28.100)
==84135==    by 0x5CBA76B: cVideoDecoder::Open(AVCodecID, AVCodecParameters*, AVRational*, int, int, int) (codec_video.cpp:261)
==84135==    by 0x5CBBC03: cVideoDecoder::ReopenCodec(AVCodecID, AVCodecParameters*, AVRational*, int) (codec_video.cpp:607)
==84135==    by 0x5CDF72B: cVideoStream::FlushDecoder() (videostream.cpp:187)
==84135==    by 0x5CCE0F7: cSoftHdDevice::Clear() (softhddevice.cpp:786)
==84135==    by 0x21A5EF: cPlayer::DeviceClear() (player.h:31) 
```