### PR TITLE
Fix m_sentTrickPkts uninitilized

### DIFF
--- a/videostream.h
+++ b/videostream.h
@@ -85,7 +85,7 @@ private:
 	AVCodecParameters *m_pPar = nullptr;   ///< current codec parameters
 	struct AVRational m_timebase;          ///< current codec timebase
 	int m_trickpkts;                       ///< how many avpkt does the decoder need in trickspeed mode?
-	int m_sentTrickPkts;                   ///< how many avpkt have been sent to the decoder in trickspeed mode?
+	int m_sentTrickPkts = 0;               ///< how many avpkt have been sent to the decoder in trickspeed mode?
 
 	volatile bool m_newStream;             ///< flag for new stream
 	volatile bool m_closing;               ///< flag for closing request


### PR DESCRIPTION
Fixes:
```
==248034== Conditional jump or move depends on uninitialised value(s)
==248034==    at 0x5CDFC2C: cVideoStream::DecodeInput() (videostream.cpp:299)
==248034==    by 0x5CD65B7: cDecodingThread::Action() (threads.cpp:60)
==248034==    by 0x2DE67B: cThread::StartThread(cThread*) (thread.c:294)
==248034==    by 0x4F4202F: start_thread (pthread_create.c:442)
==248034==    by 0x4FABF5B: thread_start (clone.S:79) 
```