### PR TITLE
cDrmBuffer: fix uninitilized

### DIFF
--- a/drmbuffer.h
+++ b/drmbuffer.h
@@ -125,7 +125,7 @@ private:
 	uint32_t m_handle[4];       ///< array of the plane handles
 	uint32_t m_offset[4];       ///< array of the plane offset
 	uint32_t m_pitch[4];        ///< array of the plane pitch
-	uint32_t m_size[4];         ///< array of the plane size
+	uint32_t m_size[4]{0};      ///< array of the plane size
 
 	AVFrame *m_pFrame;
 #ifdef USE_GLES


### PR DESCRIPTION
Fixes #71

I didn't analyze why (because I work on something else in the code), but I previously added some debug output, and m_size was uninitilized when I encounterd this error again.