### PR TITLE
Make thread synchronization consistent and implement state machine

### DIFF
--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -90,139 +90,29 @@ graph TD
 
 ## State Diagram
 
-### Simple Version
+This is the model of the state machine implemented in softhddevice.cpp.
 
 ```mermaid
 stateDiagram-v2
-    PrepareContinuePlay: PREPARE CONTINUE PLAY<br/>• Halt ("pause") decoding thread<br/>• Wait filter thread idle<br/>• Cancel filter thread<br />• Continue ("pause", "close") decoder thread<br/>• Resume audio<br/>• Reset trick speed<br/>• Reset cVideoRender pause flag<br/>• Start filter thread lazily
-
-    PrepareNewPlay: PREPARE NEW PLAYBACK<br/>• Start decoding & display thread<br/>• Start filter thread lazily
-
-    PrepareStop: PREPARE STOP<br/>• Halt ("close") decoding thread<br/>• Clear decoding queue<br/>• Cancel filter thread<br/>• Free FFMPEG context<br/>• Flush audio
-
-    PreparePause: PREPARE PAUSE<br/>• Halt ("pause") decoding thread<br/>• Wait filter thread idle<br/>• Cancel filter thread<br />• Pause audio<br/>• Set cVideoRender pause flag
-
-    PrepareStillPicture: PREPARE STILL PICTURE<br/>• Audio pause<br/>• cVideoStream StillPicture() logic<br/>• Audio clear/resume
-
     [*] --> Stop: Initialize
 
-    PrepareStop --> Stop
-    Stop --> PrepareNewPlay
+    Stop --> Play: PlayEvent
 
-    PrepareNewPlay --> Play
-    PrepareContinuePlay --> Play
-    Play --> PreparePause: Freeze()
-    Play --> TrickSpeed: TrickSpeed()
-    Play --> PrepareStop: PlayMode(pmNone)
-    Play --> PrepareStillPicture: StillPicture()
+    Play --> TrickSpeed: TrickSpeedEvent
+    Play --> Stop: StopEvent
+    Play --> Play: PauseEvent/StillPictureEvent
 
-    PreparePause --> Pause
-    Pause --> PrepareContinuePlay: Play()
-    Pause --> PrepareStop: PlayMode(pmNone)
-    Pause --> TrickSpeed: TrickSpeed()
-    Pause --> PrepareStillPicture: StillPicture()
-
-    TrickSpeed --> PrepareContinuePlay: Play()
-    TrickSpeed --> PreparePause: Freeze()
-    TrickSpeed --> PrepareStop: PlayMode(pmNone)
-    TrickSpeed --> PrepareStillPicture: StillPicture()
-
-    PrepareStillPicture --> StillPicture
-    StillPicture --> PrepareContinuePlay: Play()
-    StillPicture --> PrepareStop: PlayMode(pmNone)
-    StillPicture --> TrickSpeed: TrickSpeed()
+    TrickSpeed --> Play: PlayEvent
+    TrickSpeed --> Stop: StopEvent
+    TrickSpeed --> TrickSpeed: PauseEvent/StillPictureEvent
 
     classDef stopState fill:#e57373,stroke:#d32f2f,stroke-width:2px,color:#000
     classDef playState fill:#81c784,stroke:#388e3c,stroke-width:2px,color:#000
-    classDef pauseState fill:#fff59d,stroke:#fbc02d,stroke-width:2px,color:#000
     classDef trickspeedState fill:#64b5f6,stroke:#1976d2,stroke-width:2px,color:#000
-    classDef stillpictureState fill:#ba68c8,stroke:#7b1fa2,stroke-width:2px,color:#000
 
     class Stop stopState
     class Play playState
-    class Pause pauseState
     class TrickSpeed trickspeedState
-    class StillPicture stillpictureState
-```
-
-### Fat Version
-
-```mermaid
-stateDiagram-v2
-    PrepareContinuePlay: PREPARE CONTINUE PLAY<br/>→ Play()<br/>• Halt ("pause") decoding thread<br/>• Wait filter thread idle<br/>• Cancel filter thread<br />• Continue ("pause", "close") decoder thread<br/>• Resume audio<br/>• Reset trick speed<br/>• Reset cVideoRender pause flag<br/>• Start filter thread lazily
-
-    PrepareNewPlay: PREPARE NEW PLAYBACK<br/>→ SetPlayMode()<br/>• Start decoding & display thread<br/>• Start filter thread lazily
-
-    PrepareStop: PREPARE STOP<br/>→ PlayMode(pmNone)<br/>• Halt ("close") decoding thread<br/>• Cancel filter thread<br/>• Clear decoding queue<br/>• Free FFMPEG context<br/>• Flush audio
-
-    PreparePause: PREPARE PAUSE<br/>→ Freeze()<br/>• Halt ("pause") decoding thread<br/>• Wait filter thread idle<br/>• Cancel filter thread<br />• Pause audio<br/>• Set cVideoRender pause flag
-
-    PrepareStillPicture: PREPARE STILL PICTURE<br/>• Audio pause<br/>• cVideoStream StillPicture() logic<br/>• Audio clear/resume
-
-    FastTrickSpeed: Fast Reverse/Forward
-
-    [*] --> Stop: Initialize
-
-    PrepareStop --> Stop
-    Stop --> PrepareNewPlay
-
-    PrepareNewPlay --> Play
-    PrepareContinuePlay --> Play
-    Play --> PreparePause
-    Play --> FastTrickSpeed: Clear()
-    Play --> PrepareStop
-    Play --> Play: SkipSeconds → Clear()
-    Play --> PrepareStillPicture: Clear()
-
-    PreparePause --> Pause
-    Pause --> PrepareContinuePlay
-    Pause --> PrepareStop
-    Pause --> SlowForward
-    Pause --> SlowReverse
-    Pause --> PrepareContinuePlay: SkipSeconds → Clear()
-    Pause --> PrepareStillPicture: Clear()
-
-    FastTrickSpeed --> PrepareContinuePlay: Clear()
-    FastTrickSpeed --> PreparePause: Clear()
-    FastTrickSpeed --> PrepareStop
-    FastTrickSpeed --> PrepareContinuePlay: SkipSeconds → 2x Clear()
-    FastTrickSpeed --> PrepareStillPicture: Clear()
-
-    SlowForward --> PrepareContinuePlay: [no clear]
-    SlowForward --> PreparePause: [no clear]
-    SlowForward --> PrepareStop
-    SlowForward --> SlowReverse: Clear()
-    SlowForward --> PrepareContinuePlay: Clear()
-    SlowForward --> PrepareStillPicture: Clear()
-
-    SlowReverse --> PrepareContinuePlay: Clear()
-    SlowReverse --> PreparePause: Clear()
-    SlowReverse --> PrepareStop
-    SlowReverse --> SlowForward: Clear()
-    SlowReverse --> PrepareContinuePlay: 1-2x Clear()
-    SlowReverse --> PrepareStillPicture: Clear()
-
-    PrepareStillPicture --> StillPicture
-    StillPicture --> PrepareContinuePlay: Clear()
-    StillPicture --> PrepareStop
-    StillPicture --> SlowForward: [no clear]
-    StillPicture --> SlowReverse: Clear()
-
-    classDef stopState fill:#e57373,stroke:#d32f2f,stroke-width:2px,color:#000
-    classDef playState fill:#81c784,stroke:#388e3c,stroke-width:2px,color:#000
-    classDef pauseState fill:#fff59d,stroke:#fbc02d,stroke-width:2px,color:#000
-    classDef fastTrickspeedState fill:#64b5f6,stroke:#1976d2,stroke-width:2px,color:#000
-        classDef slowForwardState fill:#4dd0e1,stroke:#0097a7,stroke-width:2px,color:#000
-    classDef slowReverseState fill:#ffb74d,stroke:#f57c00,stroke-width:2px,color:#000
-    classDef stillpictureState fill:#ba68c8,stroke:#7b1fa2,stroke-width:2px,color:#000
-
-    class Stop stopState
-    class Play playState
-    class Pause pauseState
-    class FastTrickSpeed fastTrickspeedState
-    class SlowForward slowForwardState
-    class SlowReverse slowReverseState
-    class StillPicture stillpictureState
 ```
 
 ## Video Data Flow Call Graph
@@ -312,3 +202,12 @@ graph TD
     class PktQueue,FilterQueue,RenderRB,EnqFB buffer
     class FormatCheck decThread
 ```
+
+## VDR State Management
+
+When managing the VDR states (play/pause/trick speed/...), the following paradigms are follow:
+
+- On every call of above VDR methods, we wait at a single and central location, that the display and decoding threads finish their currently processing packet/frame. Then, the threads are locked (halted), and the necessary changes are done in a thread-safe and predictable way, until they resume their normal work.
+- What should happen in which state is also handled in a single and central location. Therefore, VDR's state is tracked in a variable. When one of PlayMode()/Freeze()/Clear()/... are invoked (I call it "events"), they are handled according to in which state VDR is currently in (play/stop/trickspeed). So, you can clearly see in the code, what happens in a particular state, when a specific event is received. The state transitions are handled in cSoftHdDevice::OnEventReceived() and what shall be done when entering or leaving a state is done in cSoftHdDevice::OnEnteringState()/cSoftHdDevice::OnLeavingState().
+
+This was introduced in PR #91.

--- a/audio.cpp
+++ b/audio.cpp
@@ -905,10 +905,8 @@ bool cSoftHdAudio::VideoReady(int64_t videoPts)
 	int64_t used;
 	int skip;
 
-	if (m_running) {
-		LOGDEBUG2(L_SOUND, "audio: %s: Audio is already running?", __FUNCTION__);
+	if (m_running)
 		return true;
-	}
 
 	// no valid audio known
 	if (m_pts == AV_NOPTS_VALUE) {
@@ -1143,16 +1141,15 @@ void cSoftHdAudio::Unmute(void)
 /**
  * Resume audio
  *
- * Start audio playback after pause
+ * Resume audio playback, if it is paused.
  */
 void cSoftHdAudio::Resume(void)
 {
 	int err;
 
-	if (!m_paused && !m_alsaCanPause) {
-		LOGDEBUG2(L_SOUND, "audio: %s: not paused, check the code", __FUNCTION__);
+	if (!m_paused && !m_alsaCanPause)
 		return;
-	}
+
 	LOGDEBUG2(L_SOUND, "audio: %s", __FUNCTION__);
 	if (m_alsaCanPause) {
 		snd_pcm_state_t state;
@@ -1179,10 +1176,8 @@ void cSoftHdAudio::Pause(void)
 {
 	int err;
 
-	if (m_paused) {
-		LOGDEBUG2(L_SOUND, "audio: %s: already paused, check the code", __FUNCTION__);
+	if (m_paused)
 		return;
-	}
 
 	LOGDEBUG2(L_SOUND, "audio: %s", __FUNCTION__);
 	if (m_alsaCanPause) {

--- a/softhddevice.cpp
+++ b/softhddevice.cpp
@@ -27,6 +27,8 @@
 #define __USE_GNU
 #endif
 
+#include <variant>
+
 #include <assert.h>
 #include <unistd.h>
 
@@ -507,7 +509,6 @@ cSoftHdDevice::cSoftHdDevice(cSoftHdConfig *config)
 
 	m_pAudioDecoder = nullptr;
 
-	m_skipAudio = false;
 	m_newAudioStream = false;
 }
 
@@ -609,17 +610,13 @@ void cSoftHdDevice::Stop(void)
 
 /**
  * Clear all audio data from the decoder and ringbuffer
- *
- * @note does nothing, if audio is muted
  */
 void cSoftHdDevice::ClearAudio(void)
 {
-	if (!m_skipAudio) {
-		LOGDEBUG("device: %s:", __FUNCTION__);
-		m_pAudioDecoder->FlushBuffers();
-		m_pAudio->FlushBuffers();
-		m_newAudioStream = true;
-	}
+	LOGDEBUG("device: %s:", __FUNCTION__);
+	m_pAudioDecoder->FlushBuffers();
+	m_pAudio->FlushBuffers();
+	m_newAudioStream = true;
 }
 
 /**
@@ -673,6 +670,194 @@ bool cSoftHdDevice::CanReplay(void) const
 }
 
 /**
+ * Handle pause state
+ *
+ * Pauses both video rendering and audio playback.
+ */
+void cSoftHdDevice::HandlePause(void)
+{
+	m_pRender->SetPlaybackPaused(true);
+	m_pAudio->Pause();
+}
+
+/**
+ * Event handler for playback state transitions
+ *
+ * Processes events (Play, Pause, Stop, TrickSpeed, StillPicture) and performs
+ * the appropriate state transitions based on the current state. The method halts
+ * both display and decoding threads before processing the event and resumes them
+ * afterwards to ensure thread-safe state transitions.
+ *
+ * @param event     The event to process (variant type containing specific event data)
+ */
+void cSoftHdDevice::OnEventReceived(const Event& event) {
+	LOGDEBUG("device: received %s", EventToString(event));
+
+	m_pRender->DisplayThreadHalt(); // the display thread needs to be halted first, otherwise a deadlock can occur in WaitForAudioClock()
+	m_pRender->DecodingThreadHalt();
+
+	auto invalid = [this, &event]() {
+		LOGWARNING("device: Invalid event '%s' in state '%s' received", EventToString(event), StateToString(m_state));
+	};
+
+	switch (m_state) {
+		case State::STOP:
+			std::visit(overload{
+				[this](const PlayEvent&) {
+					SetState(PLAY);
+					m_pRender->ResetFrameCounter();
+				},
+				[&invalid](const PauseEvent&) { invalid(); },
+				[&invalid](const StopEvent&) { invalid(); },
+				[&invalid](const TrickSpeedEvent&) { invalid(); },
+				[&invalid](const StillPictureEvent&) { invalid(); },
+			}, event);
+			break;
+		case State::PLAY:
+			std::visit(overload{
+				[this](const PlayEvent&) {
+					// resume from pause
+					m_pAudio->Resume();
+					m_pRender->SetPlaybackPaused(false);
+				},
+				[this](const PauseEvent&) {
+					HandlePause();
+				 },
+				[this](const StopEvent&) {
+					SetState(STOP);
+				},
+				[this](const TrickSpeedEvent& t) {
+					m_pRender->SetTrickSpeed(t.speed, t.forward);
+					SetState(TRICK_SPEED);
+				},
+				[this](const StillPictureEvent& s) {
+					m_pVideoStream->StillPicture(&s.pesPacket);
+				 },
+			}, event);
+			break;
+		case State::TRICK_SPEED:
+			std::visit(overload{
+				[this](const PlayEvent&) {
+					SetState(PLAY);
+				},
+				[this](const PauseEvent&) {
+					HandlePause();
+				 },
+				[this](const StopEvent&) {
+					SetState(STOP);
+				},
+				[this](const TrickSpeedEvent& t) {
+					// resume from pause, or change trick speed direction/speed
+					m_pRender->SetTrickSpeed(t.speed, t.forward);
+					m_pRender->SetPlaybackPaused(false);
+				 },
+				[this](const StillPictureEvent& s) {
+					m_pVideoStream->StillPicture(&s.pesPacket);
+				 },
+			}, event);
+			break;
+	}
+
+	m_pRender->DecodingThreadResume();
+	m_pRender->DisplayThreadResume();
+}
+
+/**
+ * Actions to be performed when entering a state
+ *
+ * These are only executed when the state actually changes.
+ * E.g. a state transition PLAY -> PLAY does not trigger this.
+ *
+ * @param state         state being entered
+ */
+void cSoftHdDevice::OnEnteringState(enum State state) {
+	switch (state) {
+		case PLAY:
+			m_pAudio->Resume();
+			m_pRender->SetPlaybackPaused(false);
+			break;
+		case TRICK_SPEED:
+			m_pAudio->Pause();
+			m_pRender->SetPlaybackPaused(false);
+			break;
+		case STOP:
+			m_pRender->CancelFilterThread();
+
+			m_pRender->Reset();
+			m_pRender->DestroyFrameBuffers();
+			m_pRender->ScheduleDisplayBlackFrame();
+
+			m_pVideoStream->ClearVdrCoreToDecoderQueue();
+			m_pRender->ClearDecoderToDisplayQueue();
+			m_pVideoStream->CloseDecoder();
+
+			m_pAudio->Resume();
+			ClearAudio();
+
+			if (m_pAudioDecoder && m_audioCodecID != AV_CODEC_ID_NONE)
+				m_newAudioStream = true;
+
+			m_pVideoStream->SetInterlaced(0); // probably not necessary
+			break;
+	}
+}
+
+/**
+ * Actions to be performed when leaving a state
+ *
+ * These are only executed when the state actually changes.
+ * E.g. a state transition PLAY -> PLAY does not trigger this.
+ *
+ * @param state         state being left
+ */
+void cSoftHdDevice::OnLeavingState(enum State state) {
+	switch (state) {
+		case PLAY:
+			// nothing
+			break;
+		case TRICK_SPEED:
+			// In case we get a play in slow forward, we need to restart the filter thread.
+			// Because trickspeed doesn't do deinterlacing but can use the scale filter
+			// we need to stop the filter here, to get the deinterlace filter started in normal
+			// playback.
+			if (m_pRender->GetTrickForward())
+				m_pRender->CancelFilterThread(); // filter thread is restarted lazily
+
+			m_pRender->DestroyFrameBuffers();
+
+			m_pRender->SetTrickSpeed(0, 1);
+			m_pRender->ResetFrameCounter();
+			m_pVideoStream->ResetTrickSpeedFramesSentCounter();
+
+			m_pAudio->Resume();
+			break;
+		case STOP:
+			// nothing
+			break;
+	}
+}
+
+
+/**
+ * Sets the device into the given state.
+ *
+ * @param newState       new state
+ */
+void cSoftHdDevice::SetState(enum State newState)
+{
+	// No synchronization needed, because SetState is only called from the VDR main thread.
+
+	if (m_state != newState) {
+		LOGDEBUG("device: Preparing to leave state %s", StateToString(m_state));
+		OnLeavingState(m_state);
+		LOGDEBUG("device: Changing state %s -> %s", StateToString(m_state), StateToString(newState));
+		m_state = newState;
+		OnEnteringState(m_state);
+		LOGDEBUG("device: State changed to %s", StateToString(m_state));
+	}
+}
+
+/**
  * Sets the device into the given play mode.
  *
  * @param play_mode       new play mode (Audio/Video/External...)
@@ -683,39 +868,13 @@ bool cSoftHdDevice::SetPlayMode(ePlayMode play_mode)
 
 	switch (play_mode) {
 	case pmNone:
-		m_pVideoStream->StopAndWaitDecodingIdle();
-		m_pRender->CleanupAndClose(true);
-
-		m_pVideoStream->ClearPacketQueue();
-		m_pVideoStream->CloseDecoder();
-
-		m_skipAudio = false;
-		m_pAudio->Unmute();
-		m_pAudio->Resume();
-		ClearAudio();	// flush all AUDIO buffers
-		if (m_pAudioDecoder && m_audioCodecID != AV_CODEC_ID_NONE)
-			m_newAudioStream = true;
-
-		m_pVideoStream->SetInterlaced(0); // probably not necessary
-		m_pVideoStream->StartDecoding();
-		m_pVideoStream->Resume();
+		OnEventReceived(StopEvent{});
 		break;
 	case pmAudioVideo:
-		m_pRender->WakeupDecodingThread();
-		m_pRender->WakeupDisplayThread();
-		break;
 	case pmAudioOnly:
-		m_pRender->ExitDecodingThread();
-		m_pRender->ExitDisplayThread();
-		break;
 	case pmAudioOnlyBlack:
-		LOGDEBUG("device: %s: FIXME: audio only, silence video errors");
-		m_pRender->WakeupDecodingThread();
-		m_pRender->WakeupDisplayThread();
-		break;
 	case pmVideoOnly:
-		m_pRender->WakeupDecodingThread();
-		m_pRender->WakeupDisplayThread();
+		OnEventReceived(PlayEvent{});
 		break;
 	default:
 		LOGERROR("device: %s: playmode not supported %d", play_mode);
@@ -754,78 +913,54 @@ void cSoftHdDevice::TrickSpeed(int speed, bool forward)
 {
 	LOGDEBUG("device: %s: %d %s", __FUNCTION__, speed, forward ? "forward" : "backward");
 
-	m_pVideoStream->StartDecoding();     // start stream if closed
-	m_pVideoStream->Resume();   // start stream if paused
-
-	m_pRender->SetTrickSpeed(speed, forward);
-	m_pRender->StartVideo();    // start render thread
+	OnEventReceived(TrickSpeedEvent{speed, forward});
 }
 
 /**
  * Clears all video and audio data from the device.
  *
- * This is called by VDR via DeviceClear() in the Empty() call
+ * This is called by VDR via DeviceClear() in the Empty() call.
  *
- * Empty() does clears all VDR internal packets
+ * Empty() does clear all VDR internal packets.
  *
- * DeviceClear() needs to
- *  1. stop the stream and let the decoding thread wait
- *  2. clear the packet buffer (drop packets which are not yet decoded)
- *  3. flush the packets already sent to the decoder
- *  4. stop/finish the renderer thread (this also does stopping the filter thread
- *  5. clear audio data
- *  6. start the stream again
  */
 void cSoftHdDevice::Clear(void)
 {
 	LOGDEBUG("device: %s:", __FUNCTION__);
 	cDevice::Clear();
 
-	m_pVideoStream->StopAndWaitDecodingIdle();
-	m_pVideoStream->ClearPacketQueue();
-	m_pVideoStream->FlushDecoder();
+	m_pRender->DisplayThreadHalt(); // the display thread needs to be halted first, otherwise a deadlock can occur in WaitForAudioClock()
+	m_pRender->DecodingThreadHalt();
 
-	m_pRender->CleanupAndClose(false);
+	m_pRender->CancelFilterThread();
 
+	m_pVideoStream->ClearVdrCoreToDecoderQueue();
+	m_pRender->ClearDecoderToDisplayQueue();
+
+	if (m_pVideoStream->GetCodecId() != AV_CODEC_ID_NONE) // audio only (e.g. radio) has no video codec. So, don't flush the video decoder then.
+		m_pVideoStream->FlushDecoder();
+
+	m_pRender->DestroyFrameBuffers();
+	m_pRender->Reset();
+
+	m_pAudio->Resume();
 	ClearAudio();
 
-	// we need a Start() here, because when VDR does SkipSeconds()
-	// it doesn't send a Play() again, if we skip during a playing stream
-	m_pVideoStream->StartDecoding();
+	m_pRender->DisplayThreadResume();
+	m_pRender->DecodingThreadResume();
 }
 
 /**
- * Sets the device into play mode (after a previous trick mode)
+ * Sets the device into play mode (after a previous trick mode, or pause)
  *
  * This is called by VDR via DevicePlay() in the Play() and Goto() call
  *
- * Play() needs to
- *  1. start and/or resume the stream
- *  2. unmute and resume audio
- *  3. wakeup the renderer
  */
 void cSoftHdDevice::Play(void)
 {
-	LOGDEBUG("device: %s:", __FUNCTION__);
 	cDevice::Play();
 
-	// In case we get a play in slow forward, we need to restart the filter thread.
-	// Because trickspeed doesn't do deinterlacing but can use the scale filter
-	// we need to stop the filter here, to get the deinterlace filter started in normal
-	// playback if needed.
-	m_pVideoStream->Pause();
-	m_pRender->WaitForFilterIdle();
-	m_pRender->StopFilter();
-
-	m_pVideoStream->StartDecoding();
-	m_pVideoStream->Resume();
-
-	m_skipAudio = false;
-	m_pAudio->Unmute();
-	m_pAudio->Resume();
-
-	m_pRender->SetTrickSpeed(0, 1);
-	m_pRender->StartVideo();
+	OnEventReceived(PlayEvent{});
 }
 
 /**
@@ -836,28 +971,7 @@ void cSoftHdDevice::Freeze(void)
 	LOGDEBUG("device: %s:", __FUNCTION__);
 	cDevice::Freeze();
 
-	// pause video stream
-	m_pVideoStream->Pause();
-
-	// wait for the filter thread to have an empty ringbuffer and close the filter
-	m_pRender->WaitForFilterIdle();
-	m_pRender->StopFilter();
-
-	// pause audio playpack
-	m_pAudio->Pause();
-	// pause the renderer
-	m_pRender->PauseVideo();
-}
-
-/**
- * Turns off audio while replaying.
- */
-void cSoftHdDevice::Mute(void)
-{
-	LOGDEBUG("device: %s:", __FUNCTION__);
-	cDevice::Mute();
-
-	m_pAudio->Mute();
+	OnEventReceived(PauseEvent{});
 }
 
 /**
@@ -876,17 +990,10 @@ void cSoftHdDevice::StillPicture(const uchar *data, int size)
 	}
 
 	cPesVideo pesPacket((const uint8_t*)data, size);
-	if (!pesPacket.IsValid()) {
+	if (pesPacket.IsValid()) {
+		OnEventReceived(StillPictureEvent{pesPacket});
+	} else
 		m_pVideoStream->ResetFragmentationBuffer();
-		return;
-	}
-
-	m_pAudio->Pause();
-
-	m_pVideoStream->StillPicture(&pesPacket);
-
-	ClearAudio();
-	m_pAudio->Resume();
 }
 
 /**
@@ -1028,16 +1135,6 @@ int cSoftHdDevice::PlayAudio(const uchar *data, int size, uchar id)
 	timebase.num = 1;
 
 	m_pAudioAvPkt->pts = AV_NOPTS_VALUE;
-
-	if (m_pVideoStream->IsPaused()) {	// stream is paused, don't accept new audio data
-		LOGDEBUG("device: %s: Stream is paused", __FUNCTION__);
-		return 0;
-	}
-
-	if (m_skipAudio) {	// skip audio
-		LOGDEBUG("device: %s: skip audio", __FUNCTION__);
-		return size;
-	}
 
 	m_pAudio->LazyInit();
 
@@ -1300,7 +1397,7 @@ int cSoftHdDevice::PlayVideo(const uchar *data, int size)
 {
 	//LOGDEBUG("device: %s: %p %d", __FUNCTION__, data, size);
 
-	if (m_pVideoStream->IsPaused() || m_pVideoStream->GetAvPacketsFilled() >= VIDEO_PACKET_MAX - 10)
+	if (m_pVideoStream->GetAvPacketsFilled() >= VIDEO_PACKET_MAX - 10)
 		return 0;
 
 	cPesVideo pesPacket((const uint8_t*)data, size);

--- a/softhddevice.h
+++ b/softhddevice.h
@@ -21,6 +21,8 @@
 #ifndef __SOFTHDDEVICE_H
 #define __SOFTHDDEVICE_H
 
+#include <variant>
+
 #include <vdr/dvbspu.h>
 
 extern "C"
@@ -33,6 +35,51 @@ extern "C"
 #include "videostream.h"
 #include "audio.h"
 #include "videorender.h"
+
+// State machine definitions
+// Implementing C++17 visitor pattern
+
+enum State {
+	STOP,
+	PLAY,
+	TRICK_SPEED,
+};
+
+struct PlayEvent {};
+struct PauseEvent {};
+struct StopEvent {};
+struct TrickSpeedEvent {
+	int speed;
+	bool forward;
+};
+struct StillPictureEvent {
+	cPesVideo& pesPacket;
+};
+
+using Event = std::variant<PlayEvent, PauseEvent, StopEvent, TrickSpeedEvent, StillPictureEvent>;
+
+template<class... Ts>
+struct overload : Ts... { using Ts::operator()...; };
+template<class... Ts> overload(Ts...) -> overload<Ts...>;
+
+inline const char* EventToString(const Event& e) {
+    return std::visit(overload{
+        [](const PlayEvent&) -> const char* { return "PlayEvent"; },
+        [](const PauseEvent&) -> const char* { return "PauseEvent"; },
+        [](const StopEvent&) -> const char* { return "StopEvent"; },
+        [](const TrickSpeedEvent&) -> const char* { return "TrickSpeedEvent"; },
+        [](const StillPictureEvent&) -> const char* { return "StillPictureEvent"; },
+    }, e);
+}
+
+inline const char* StateToString(State s) {
+    switch(s) {
+        case State::STOP: return "STOP";
+        case State::PLAY: return "PLAY";
+        case State::TRICK_SPEED: return "TRICK_SPEED";
+    }
+    return "Unknown";
+}
 
 class cAudioDecoder;
 
@@ -77,7 +124,6 @@ public:
 	virtual void Clear(void);
 	virtual void Play(void);
 	virtual void Freeze(void);
-	virtual void Mute(void);
 	virtual void StillPicture(const uchar *, int);
 	virtual bool Poll(cPoller &, int = 0);
 	virtual bool Flush(int = 0);
@@ -145,7 +191,13 @@ public:
 	int PlayAudioPkts(AVPacket *);
 	int PlayVideoPkts(AVPacket *);
 
+	// State machine
+	void SetState(enum State);
+	void OnEnteringState(enum State);
+	void OnLeavingState(enum State);
+
 private:
+	enum State m_state = STOP;       ///< current plugin state
 	cDvbSpuDecoder *m_pSpuDecoder;   ///< pointer to spu decoder
 	cSoftHdConfig *m_pConfig;        ///< pointer to cSoftHdConfig object
 	cVideoRender *m_pRender;         ///< pointer to cVideoRender object
@@ -158,14 +210,15 @@ private:
 	enum AVCodecID m_audioCodecID;   ///< pointer to current audio AVPacket
 	int m_audioChannelID;            ///< current audio channel ID
 	volatile bool m_newAudioStream;  ///< set, if we a new audio stream arrived
-	volatile bool m_skipAudio;       ///< set, if audio should be skipped (mute)
 	int m_videoAudioDelay;           ///< audio/video delay set via setup menu
-	bool m_grabActive;                ///< simple lock variable
+	bool m_grabActive;               ///< simple lock variable
 	                                 ///< skips a new grab request if the last one is still active
 
 	void ClearAudio(void);
 	void Exit(void);
 	int PesHeadLength(const uint8_t *);
+	void OnEventReceived(const Event&);
+	void HandlePause(void);
 };
 
 #endif

--- a/threads.cpp
+++ b/threads.cpp
@@ -57,9 +57,13 @@ void cDecodingThread::Action(void)
 {
 	LOGDEBUG("threads: decoding thread started");
 	while(Running()) {
-		if (m_pDevice->VideoStream()->DecodeInput()) {
-			usleep(10000);
-		}
+		m_mutex.lock();
+
+		m_pDevice->VideoStream()->DecodeInput();
+
+		m_mutex.unlock();
+
+		usleep(1000);
 	}
 	LOGDEBUG("threads: decoding thread stopped");
 }
@@ -92,16 +96,21 @@ void cDisplayThread::Action(void)
 {
 	LOGDEBUG("threads: display thread started");
 	while(Running()) {
-		int ret = m_pRender->DisplayFrame();
+		m_mutex.lock();
 
-		if (ret)
-			usleep(1000);
-		else if (m_pRender->DrmHandleEvent() != 0)
-			LOGERROR("threads: display thread: drmHandleEvent failed!");
+		m_pRender->FramesRbLock();
 
-		if (m_pRender->ShouldClose() || m_pRender->ShouldFlush())
-			m_pRender->CleanUp();
+		AVFrame *frame = nullptr;
+		if (m_pRender->GetFramesFilled() > 0 && !m_pRender->IsPlaybackPaused() && m_pRender->ShallDisplayNextFrame())
+			frame = m_pRender->RbGetFrame();
 
+		m_pRender->FramesRbUnlock();
+
+		m_pRender->DisplayFrame(frame);
+
+		m_mutex.unlock();
+
+		usleep(1000);
 	}
 	LOGDEBUG("threads: display thread stopped");
 }
@@ -370,8 +379,7 @@ void cFilterThread::Action(void)
 
 	while (Running()) {
 		if (m_frames.Empty()) {
-			m_waitIdleCondition.Broadcast();
-			usleep(10000);
+			usleep(1000);
 			continue;
 		}
 
@@ -386,7 +394,7 @@ void cFilterThread::Action(void)
 
 		// add frame to filter
 		if (av_buffersrc_add_frame_flags(m_pBuffersrcCtx, frame, AV_BUFFERSRC_FLAG_KEEP_REF) < 0)
-			LOGWARNING("filter thread: %s: can't add_frame.", __FUNCTION__);
+			LOGWARNING("filter thread: %s: can't add_frame: %s", __FUNCTION__, av_err2str(ret));
 
 		av_frame_free(&frame);
 
@@ -480,16 +488,4 @@ void cFilterThread::Stop(void)
 	}
 
 	avfilter_graph_free(&m_pFilterGraph);
-}
-
-void cFilterThread::WaitForIdle(void)
-{
-	if (!Active())
-		return;
-
-	cMutex mutex;
-	int timeoutInMs = 2000;
-	mutex.Lock();
-	if (!m_waitIdleCondition.TimedWait(mutex, timeoutInMs))
-		LOGERROR("filter thread: %s: timeout (%dms) while waiting for empty filter ringbuffer", __FUNCTION__, timeoutInMs);
 }

--- a/threads.h
+++ b/threads.h
@@ -20,6 +20,8 @@
 #ifndef __THREADS_H
 #define __THREADS_H
 
+#include <mutex>
+
 #include "vdr/thread.h"
 #include "queue.h"
 
@@ -36,8 +38,11 @@ public:
 	cDecodingThread(cSoftHdDevice *);
 	virtual ~cDecodingThread(void);
 	void Stop(void);
+	void Halt(void) { m_mutex.lock(); };
+	void Resume(void) { m_mutex.unlock(); };
 
 private:
+	std::mutex m_mutex;
 	cSoftHdDevice *m_pDevice;
 
 protected:
@@ -55,8 +60,13 @@ public:
 	cDisplayThread(cVideoRender *);
 	virtual ~cDisplayThread(void);
 	void Stop(void);
+	void Halt(void) { m_halt = true; m_mutex.lock(); };
+	void Resume(void) { m_mutex.unlock(); m_halt = false; };
+	bool ShouldHalt(void) { return m_halt; };
 
 private:
+	std::mutex m_mutex;
+	bool m_halt;
 	cVideoRender *m_pRender;
 
 protected:
@@ -98,7 +108,6 @@ public:
 	int GetBufferFrameCount(void);
 	bool PushFrame(AVFrame *);
 	bool IsInterlaceFilter(void) { return m_isInterlaceFilter; };
-	void WaitForIdle(void);
 
 private:
 	cVideoRender *m_pRender;
@@ -113,8 +122,6 @@ private:
 	bool m_isInterlaceFilter;                   ///< the current filter is an deinterlace filter
 
 	cQueue<AVFrame> m_frames{VIDEO_SURFACES_MAX}; ///< queue for frames to be filtered
-
-	cCondVar m_waitIdleCondition;               ///< condition is triggered, if ringbuffer is empty
 
 protected:
 	virtual void Action(void);

--- a/videorender.cpp
+++ b/videorender.cpp
@@ -26,6 +26,8 @@
 #define __USE_GNU
 #endif
 
+#include <algorithm>
+
 #include <stdbool.h>
 #include <unistd.h>
 
@@ -80,13 +82,11 @@ cVideoRender::cVideoRender(cSoftHdDevice *device)
 	m_pDrmDevice = new cDrmDevice(this);
 
 	m_disableOglOsd = false;
-	m_exitThread = false;
 	m_startgrab = false;
 	m_startCounter = 0;
 	m_videoIsScaled = false;
 
 	m_trickSpeed = 0;
-	m_trickCounter = 0;
 	m_trickForward = true;
 
 	m_framesFilled = 0;
@@ -114,7 +114,6 @@ cVideoRender::~cVideoRender(void)
 		delete m_pDisplayThread;
 	if (m_pDecodingThread)
 		delete m_pDecodingThread;
-	free(m_pLastFrame);
 	LOGDEBUG2(L_DRM, "videorender: %s", __FUNCTION__);
 }
 
@@ -127,13 +126,8 @@ void cVideoRender::Prepare(void)
 	m_pFilterThread = new cFilterThread(this);
 
 	atomic_set(&m_framesFilled, 0);
-	m_closing = false;
-	m_flushing = false;
-	m_flushLastFrame = false;
 	m_deintDisabled = m_configDeintDisabled;
 	m_enqueueBufferIdx = 0;
-	m_pLastFrame = (struct lastFrame *)calloc(1, sizeof(struct lastFrame));
-	ResumeVideo();
 }
 
 /**
@@ -161,58 +155,37 @@ void cVideoRender::SetDisplayResolution(const char* resolution)
 }
 
 /**
- * Cleanup the renderer
- *
- * Stop the filter thread, clean the render ringbuffer and destroy the framebuffers
+ * Clear (empty) the decoder to display queue
  */
-void cVideoRender::CleanUp(void)
+void cVideoRender::ClearDecoderToDisplayQueue(void)
 {
-	AVFrame *frame;
-	int i;
-
-	// first wait for m_pFilterThread to be closed
-	if (m_pFilterThread->Active()) {
-		LOGDEBUG("videorender: %s: cancel filter thread", __FUNCTION__);
-		m_pFilterThread->Stop();
-	}
-
 	FramesRbLock();
 	while (atomic_read(&m_framesFilled)) {
-		frame = RbGetFrame();
-		av_frame_free(&frame);
+		AVFrame *frame = RbGetFrame();
+
+		if (!m_pCurrentlyDisplayed || frame != m_pCurrentlyDisplayed->Frame()) // the currently displayed frame (if any) is freed by the display thread
+			av_frame_free(&frame);
 	}
 	FramesRbUnlock();
+}
 
-	if (m_closing && m_pLastFrame->frame) {
-		av_frame_free(&m_pLastFrame->frame);
-		m_pLastFrame->trickspeed = 0;
-		m_pLastFrame->buf = nullptr;
-	}
+/**
+ * Destroy all frame buffers, except the currently displayed one.
+ */
+void cVideoRender::DestroyFrameBuffers(void)
+{
+	for (int i = 0; i < RENDERBUFFERS; ++i) {
+		if (!m_buffer[i].IsDirty() || m_pCurrentlyDisplayed == &m_buffer[i])
+			continue; // let the display thread destroy the currently displayed frame, once the following frame has been displayed
 
-	// Destroy FBs
-	for (i = 0; i < RENDERBUFFERS; ++i) {
-		if (!m_buffer[i].IsDirty())
-			continue;
-
-		// TODO: can m_pLastFrame->buf ever be the black buffer??
-		if (m_closing || (m_buffer[i].Id() != m_pLastFrame->buf->Id())) {
-			m_buffer[i].Destroy();
-		}
+		m_buffer[i].Destroy();
 	}
 
 	m_numBuffers = 0;
 	m_enqueueBufferIdx = 0;
 
-	m_waitCleanCondition.Signal();
-	// m_flushing is set, if we want to keep the last rendered frame during cleanup
-	// m_flushLastFrame signals the rendering thread to clean this frame on the next turn
-	if (m_flushing)
-		m_flushLastFrame = true;
-	m_flushing = false;
-	m_closing = false;
-	m_deintDisabled = m_configDeintDisabled;
-
-	LOGDEBUG("videorender: %s: DRM cleaned (m_framesFilled %d m_numFramesToFilter %d)", __FUNCTION__, atomic_read(&m_framesFilled), atomic_read(&m_numFramesToFilter));
+	if (m_pCurrentlyDisplayed)
+		m_destroyCurrentlyDisplayed = true;
 }
 
 /**
@@ -328,7 +301,7 @@ void cVideoRender::Grab(cDrmBuffer *buf)
 		m_grabOsd.SetBuf(osdBuf);
 	}
 
-	cDrmBuffer *pbuf = buf ? buf : (m_pLastFrame->buf ? m_pLastFrame->buf : NULL);
+	cDrmBuffer *pbuf = buf ? buf : (m_pCurrentlyDisplayed ? m_pCurrentlyDisplayed : NULL);
 	if (pbuf) {
 		LOGDEBUG2(L_GRAB, "videorender: %s: Trigger video grab arrived", __FUNCTION__);
 		cDrmBuffer *videoBuf = new cDrmBuffer(pbuf);
@@ -370,11 +343,11 @@ int cVideoRender::CommitBuffer(cDrmBuffer *buf, int osdOnly)
 		videoPlane->SetPlane(modeReq);
 		dirty += 2;
 //		LOGDEBUG2(L_DRM, "videorender: %s: SetPlane Video (fb = %" PRIu64 ")", __FUNCTION__, videoPlane->GetFbId());
-	} else if (m_pLastFrame && m_pLastFrame->buf) {
+	} else if (m_pCurrentlyDisplayed) {
 		// If no new video is available, set the old buffer again, if available.
 		// This is necessary to recognize a size-change in SetVideoBuffer().
 		// Though this is not expensive, maybe we should only call that, if size really changed.
-		SetVideoBuffer(m_pLastFrame->buf);
+		SetVideoBuffer(m_pCurrentlyDisplayed);
 		videoPlane->SetPlane(modeReq);
 		dirty += 2;
 	}
@@ -422,72 +395,37 @@ int cVideoRender::CommitBuffer(cDrmBuffer *buf, int osdOnly)
  * @param[in] videoPts       video pts
  * @param[in] framePts       AVFrame pts
  *
- * @retval 2                 close requested, show black frame
- * @retval 1                 flush requested, skip video
- * @retval 0                 nothing to sync or paused
  */
-int cVideoRender::WaitForAudioReady(int64_t videoPts, int64_t framePts)
+void cVideoRender::WaitForAudioReady(int64_t videoPts, int64_t framePts)
 {
-	if(!m_startCounter && !m_closing) {
+	if(!m_startCounter) {
 		LOGDEBUG("videorender: %s: start PTS %s", __FUNCTION__, Timestamp2String(videoPts, 1));
 		m_pAudio->Skip(framePts, 0);
 
 		while (!m_pAudio->VideoReady(videoPts)) {
+			if (m_pDisplayThread->ShouldHalt())
+				return;
 			usleep(10000);
-			// check for close/flush request or pause
-			if (m_closing) {
-				LOGDEBUG2(L_DRM, "videorender: %s: closing while sync, set a black FB", __FUNCTION__);
-				return 2;
-			}
-
-			if (m_flushing) {
-				LOGDEBUG2(L_DRM, "videorender: %s: flushing while sync, skip video", __FUNCTION__);
-				return 1;
-			}
-
-			if (VideoIsPaused()) {
-				return 0;
-			}
 		}
 	}
-
-	return 0;
 }
 
 /**
  * Wait for audio clock
  *
  * @param[out] audioPts      audio pts
- *
- * @retval 2                 close requested, show black frame
- * @retval 1                 flush requested, skip video
- * @retval 0                 paused or valid audio clock
  */
-int cVideoRender::WaitForAudioClock(int64_t *audioPts)
+void cVideoRender::WaitForAudioClock(int64_t *audioPts)
 {
 	*audioPts = m_pAudio->GetClock();
 
 	// check for close/flush request or pause
 	while (*audioPts == (int64_t)AV_NOPTS_VALUE) {
-		if (m_closing) {
-			LOGDEBUG2(L_DRM, "videorender: %s: closing while sync, set a black FB", __FUNCTION__);
-			return 2;
-		}
-
-		if (m_flushing) {
-			LOGDEBUG2(L_DRM, "videorender: %s: flushing while sync, skip video", __FUNCTION__);
-			return 1;
-		}
-
-		if (VideoIsPaused()) {
-			return 0;
-		}
-
+		if (m_pDisplayThread->ShouldHalt())
+			return;
 		usleep(20000);
 		*audioPts = m_pAudio->GetClock();
 	};
-
-	return 0;
 }
 
 /**
@@ -496,9 +434,8 @@ int cVideoRender::WaitForAudioClock(int64_t *audioPts)
  * @param videoPts       video pts
  * @param audioPts       AVFrame pts
  *
- * @retval 1             dup a frame
  * @retval -1            drop a frame
- * @retval 0             we are in sync
+ * @retval 0             we are in sync, or frame duped
  */
 int cVideoRender::HandleDropDup(int64_t videoPts, int64_t audioPts)
 {
@@ -512,15 +449,6 @@ int cVideoRender::HandleDropDup(int64_t videoPts, int64_t audioPts)
 	}
 
 	if (diff < -5 && !(abs(diff) > 5000)) {	// video is more than 5ms behind audio, drop video frame
-		// don't drop the frame, if we are waiting for a flush
-		if (m_flushLastFrame) {
-			LOGDEBUG2(L_AV_SYNC, "Video too late, but skip sync (drop %d, dup %d) audio %s video %s Delay %dms diff %dms",
-				m_framesDropped, m_framesDuped,
-				Timestamp2String(audioPts, 1), Timestamp2String(videoPts, 1),
-				m_pDevice->GetVideoAudioDelay(), diff);
-			return 0;
-		}
-
 		LOGDEBUG2(L_AV_SYNC, "FrameDropped (drop %d, dup %d) Pkts %d deint %d Frames %d UsedBytes %d audio %s video %s Delay %dms diff %dms",
 			m_framesDropped, m_framesDuped,
 			m_pDevice->VideoStream()->GetAvPacketsFilled(), m_pFilterThread->GetBufferFrameCount(),
@@ -543,63 +471,10 @@ int cVideoRender::HandleDropDup(int64_t videoPts, int64_t audioPts)
 
 		m_framesDuped++;
 		usleep(20000);
-		return 1;
+		return 0;
 	}
 
 	return 0;
-}
-
-/**
- * Sync the frames
- *
- * @param[in] frame          AVFrame to sync
- *
- * @retval 2                 close requested, show black frame
- * @retval 1                 flush requested, skip video
- * @retval 0                 nothing to sync or paused
- * @retval -1                drop frame
- */
-int cVideoRender::Sync(AVFrame *frame)
-{
-	int64_t audioPts;
-	int64_t videoPts;
-
-	m_timebaseMutex.Lock();
-	videoPts = frame->pts * 1000 * av_q2d(m_timebase);
-	m_timebaseMutex.Unlock();
-	int skipWaiting = WaitForAudioReady(videoPts, frame->pts);
-	if (skipWaiting)
-		return skipWaiting;
-
-	int ret = 1;
-	while (ret == 1) {
-		skipWaiting = WaitForAudioClock(&audioPts);
-		if (skipWaiting)
-			return skipWaiting;
-
-		ret = HandleDropDup(videoPts, audioPts);
-	}
-
-	return ret;
-}
-
-/**
- * Get next video frame from ringbuffer
- *
- * @retval 1     received frame with PTS value
- * @retval 0     received frame without PTS value
- */
-int cVideoRender::GetFrame(AVFrame **frame)
-{
-	AVFrame *pframe = NULL;
-
-	pframe = RbGetFrame();
-	*frame = pframe;
-
-	if (pframe->pts == AV_NOPTS_VALUE)
-		return 0;
-
-	return 1;
 }
 
 /**
@@ -752,9 +627,6 @@ cDrmBuffer *cVideoRender::GetBuffer(AVFrame *frame)
 
 	// search for a made fd / FB combination
 	for (i = 0; i < RENDERBUFFERS; i++) {
-		if (m_flushLastFrame && !m_buffer[i].IsSwBuffer())
-			break;
-
 		if (m_buffer[i].IsTrickspeedBuffer() && !m_buffer[i].IsSwBuffer())
 			break;
 
@@ -820,110 +692,45 @@ bool cVideoRender::ShouldWaitForAudio(void) {
 }
 
 /**
- * Do we need to sync audio/ video
- *
- * @param frame  AVFrame
- *
- * @retval false     skip sync
- * @retval true      sync needed
- */
-bool cVideoRender::NeedsSync(AVFrame *frame)
-{
-	// Stillpicture -> don't sync
-	if (IsStillpictureFrame(frame)) {
-		LOGDEBUG2(L_STILL, "videorender: %s: Stillpicture has AV_NOPTS_VALUE, skip sync ...", __FUNCTION__);
-		return false;
-	}
-
-	// Trickspeed -> don't sync
-	if (IsTrickspeedFrame(frame)) {
-		m_pAudio->Skip(frame->pts, 0);	// skip all old audio data in trickspeed
-		return false;
-	}
-
-	if (m_pLastFrame->frame && m_pLastFrame->trickspeed) {
-		m_pAudio->Skip(frame->pts, 1);	// skip old audio data after trickspeed, keeping one byte
-		return false;
-	}
-
-	return true;
-}
-
-/**
  * Do the pageflip
  *
  * @param frame     AVFrame
  * @param buf       drm buffer
- * @param osdOnly   true, if video should be skipped
- *
- * @retval 0        modesetting and commit was done, need to process outstanding DRM events
- * @retval 1        no new frames or OSD, no modesetting was done, don't process outstanding DRM events
  */
-int cVideoRender::PageFlip(AVFrame *frame, cDrmBuffer *buf, int osdOnly)
+void cVideoRender::PageFlip(AVFrame *frame, cDrmBuffer *buf, int osdOnly)
 {
-	if (CommitBuffer(buf, osdOnly) < 0) {	// no modesetting was done
+	if (CommitBuffer(buf, osdOnly) < 0) {
+		// no modesetting was done
 		if (frame)
 			av_frame_free(&frame);
-		return 1;
-	}
+	} else {
+		if (m_pDrmDevice->HandleEvent() != 0)
+			LOGERROR("threads: display thread: drmHandleEvent failed!");
 
-	// only osd was set (and maybe m_pLastFrame->buf again)
-	if (osdOnly)
-		return 0;
+		// now, that we had a successful commit, set the STC if we have a frame. Skip if only the OSD was updated.
+		if (frame && !osdOnly) {
+			SetVideoClock(frame->pts);
 
-	// now, that we had a successful commit, set the STC if we have a frame
-	if (frame)
-		SetVideoClock(frame->pts);
-
-	if (frame)
-		LOGDEBUG2(L_PACKET, "videorender: %s:                 PTS %s", __FUNCTION__, Timestamp2String(frame->pts, 90));
-
-	// new video frame was sent, rotate the frames
-	if (m_pLastFrame->frame) {
-		// if the m_pLastFrame was a trickframe or a flush is forced, destroy the FB
-		if (m_flushLastFrame || m_pLastFrame->trickspeed) {
-			m_pLastFrame->buf->Destroy();
-			m_pLastFrame->buf = nullptr;
-			m_pLastFrame->trickspeed = 0;
-			m_flushLastFrame = false;
-		}
-		av_frame_free(&m_pLastFrame->frame);
-	}
-
-	if (buf) {
-		if (buf->Id() == m_bufBlack.Id()) {
-			m_pLastFrame->buf = nullptr;
-			m_pLastFrame->trickspeed = 0;
-		} else {
-			m_pLastFrame->frame = buf->Frame();
-			m_pLastFrame->buf = buf;
-			m_pLastFrame->trickspeed = buf->IsTrickspeedBuffer();
+			LOGDEBUG2(L_PACKET, "videorender: %s: ID %d:                 PTS %s", __FUNCTION__, buf->Id(), Timestamp2String(frame->pts, 90));
 		}
 	}
-
-	return 0;
 }
 
 /**
  * Do the pageflip and set a black buffer for the video
  *
- * @retval 0     modesetting and commit was done, need to process outstanding DRM events
- * @retval 1     no new frames or OSD, no modesetting was done, don't process outstanding DRM events
  */
-int cVideoRender::PageFlipBlack(void)
+void cVideoRender::PageFlipBlack(void)
 {
-	return PageFlip(NULL, &m_bufBlack, 0);
+	PageFlip(NULL, &m_bufBlack, 0);
 }
 
 /**
  * Do the pageflip for osd and skip the video
- *
- * @retval 0     modesetting and commit was done, need to process outstanding DRM events
- * @retval 1     no new frames or OSD, no modesetting was done, don't process outstanding DRM events
  */
-int cVideoRender::PageFlipOsd(void)
+void cVideoRender::PageFlipOsd(void)
 {
-	return PageFlip(NULL, NULL, 1);
+	PageFlip(NULL, NULL, 1);
 }
 
 /**
@@ -931,139 +738,116 @@ int cVideoRender::PageFlipOsd(void)
  *
  * @param frame     AVFrame
  * @param buf       drm buffer
- *
- * @retval 0     modesetting and commit was done, need to process outstanding DRM events
- * @retval 1     no new frames or OSD, no modesetting was done, don't process outstanding DRM events
  */
-int cVideoRender::PageFlipVideo(AVFrame *frame, cDrmBuffer *buf)
+void cVideoRender::PageFlipVideo(AVFrame *frame, cDrmBuffer *buf)
 {
-	return PageFlip(frame, buf, 0);
-}
-
-/**
- * Wait for frames in the ringbuffer
- *
- * @retval 2     no frames, but set a black buffer
- * @retval 1     no frames but osd, set osd
- * @retval 0     go on, we have frames
- * @retval -1     exit requested
- */
-int cVideoRender::WaitForFrames(void)
-{
-	int timeoutInMs = 15;
-
-	while (!atomic_read(&m_framesFilled)) {
-		if (m_exitThread) {
-			LOGDEBUG2(L_DRM, "videorender: %s: -> Exit Thread", __FUNCTION__);
-			return -1;
-		}
-
-		if (ShouldClose()) {
-			LOGDEBUG2(L_DRM, "videorender: %s: closing, set a black FB", __FUNCTION__);
-			return 2;
-		}
-
-		if (ShouldFlush()) {
-			LOGDEBUG2(L_DRM, "videorender: %s: flushing, just skip video", __FUNCTION__);
-			return 1;
-		}
-
-		if (VideoIsPaused()) {
-			usleep(10000);
-			// LOGDEBUG2(L_DRM, "videorender: %s: paused, skip video", __FUNCTION__);
-			return 1;
-		}
-
-		// wait max. 15ms in case we have an osd
-		if (m_pBufOsd && m_pBufOsd->IsDirty() && !timeoutInMs--) {
-			LOGDEBUG2(L_DRM, "videorender: %s: no video but osd, skip video", __FUNCTION__);
-			return 1;
-		}
-
-		if (m_startgrab) {
-			LOGDEBUG2(L_DRM, "videorender: %s: grab requested, skip video", __FUNCTION__);
-			return 1;
-		}
-
-		usleep(1000);
-	}
-
-	return 0;
+	PageFlip(frame, buf, 0);
 }
 
 /**
  * Display the frame (video and/or osd)
- *
- * @retval 0     modesetting and commit was done, need to process outstanding DRM events
- * @retval 1     no new frames or OSD, no modesetting was done, don't process outstanding DRM events
  */
-int cVideoRender::DisplayFrame(void)
+void cVideoRender::DisplayFrame(AVFrame *frame)
 {
-	int ret;
-
-	if (ShouldClose()) {
+	if (m_displayBlackFrame) {
 		LOGDEBUG2(L_DRM, "videorender: %s: closing, set a black FB", __FUNCTION__);
-		return PageFlipBlack();
-	}
 
-	if (ShouldFlush()) {
-		LOGDEBUG2(L_DRM, "videorender: %s: flushing, just skip video", __FUNCTION__);
-		return PageFlipOsd();
-	}
+		PageFlipBlack();
 
-	// wait for a frame in the ringbuffer
-	ret = WaitForFrames();
-	if (ret == 2)
-		return PageFlipBlack();
-	else if (ret == 1)
-		return PageFlipOsd();
-	else if (ret == -1)
-		return 1;
+		if (m_pCurrentlyDisplayed) {
+			m_pCurrentlyDisplayed->Destroy();
 
-	// if the video is paused, lets wait all remaining audio
-	// this is necessary for a correct Play() after Pause()
-	if (VideoIsPaused() && ShouldWaitForAudio()) {
-		usleep(10000);
-		return PageFlipOsd();
-	}
-
-	AVFrame *frame = NULL;
-	// advance frame
-	if (!GetFrame(&frame) && !IsStillpictureFrame(frame)) { // we have no valid pts and it's no stillpicture
-		LOGDEBUG2(L_DRM, "videorender: %s: no AV_NOPTS_VALUE, use next frame ...", __FUNCTION__);
-		av_frame_free(&frame);
-		return 1;
-	}
-
-	// sync audio/video
-	cDrmBuffer *buf = NULL;
-
-	if (NeedsSync(frame)) {
-		ret = Sync(frame);
-
-		if (ret == 2) {
+			AVFrame *frame = m_pCurrentlyDisplayed->Frame();
 			av_frame_free(&frame);
-			return PageFlipBlack();
-		} else if (ret == 1) {
-			av_frame_free(&frame);
-			return PageFlipOsd();
-		} else if (ret < 0) {	// drop frame (dup is handled within Sync())
-			av_frame_free(&frame);
-			return 1;
+
+			m_pCurrentlyDisplayed = nullptr;
+			m_destroyCurrentlyDisplayed = false;
 		}
-		m_startCounter++;
+
+		m_displayBlackFrame = false;
 	}
 
-	// get suitable framebuffer
-	buf = GetBuffer(frame);
-	if (!buf) {
-		av_frame_free(&frame);
-		return 1;
+	if (m_framePresentationCounter == 0)
+		m_framePresentationCounter = std::max(1, m_trickSpeed);
+
+	if (frame) {
+		if (frame->pts == AV_NOPTS_VALUE && !IsStillpictureFrame(frame)) {
+			// we have no valid pts and it's no stillpicture
+			LOGDEBUG2(L_DRM, "videorender: %s: no AV_NOPTS_VALUE, use next frame ...", __FUNCTION__);
+			av_frame_free(&frame);
+
+			return;
+		}
+
+		// sync audio/video
+		if (!GetTrickSpeed() && !m_destroyCurrentlyDisplayed && !m_playbackPaused) {
+			int64_t audioPts;
+			int64_t videoPts;
+
+			m_timebaseMutex.Lock();
+			videoPts = frame->pts * 1000 * av_q2d(m_timebase);
+			m_timebaseMutex.Unlock();
+
+			WaitForAudioReady(videoPts, frame->pts);
+			WaitForAudioClock(&audioPts);
+
+			int dropNeeded = HandleDropDup(videoPts, audioPts); // blocks if the frame should be duped
+
+			if (dropNeeded < 0) {	// skip the pageflip
+				av_frame_free(&frame);
+
+				return;
+			}
+			m_startCounter++;
+		}
+
+		if (GetTrickSpeed()) // clear the unplayed samples in the audio buffer in trickspeed to keep it in sync with the video
+			m_pAudio->Skip(frame->pts, 0);
+
+		// get suitable framebuffer
+		cDrmBuffer *buf = GetBuffer(frame);
+		if (!buf) {
+			av_frame_free(&frame);
+
+			return;
+		}
+
+		buf->SetFrame(frame);
+
+		PageFlipVideo(frame, buf);
+
+		if (m_pCurrentlyDisplayed && m_pCurrentlyDisplayed != buf) { // do not destroy the frame, if it is displayed again
+			if (IsTrickspeedFrame(m_pCurrentlyDisplayed->Frame()) || m_destroyCurrentlyDisplayed) {
+				m_pCurrentlyDisplayed->Destroy();
+
+				m_destroyCurrentlyDisplayed = false;
+			}
+
+			AVFrame *frame = m_pCurrentlyDisplayed->Frame();
+			av_frame_free(&frame);
+		}
+
+		m_pCurrentlyDisplayed = buf;
+	} else if (GetTrickSpeed() && !m_playbackPaused && m_pCurrentlyDisplayed) {
+		// display the current frame again in trickspeed mode when no OSD update is pending
+		PageFlipVideo(m_pCurrentlyDisplayed->Frame(), m_pCurrentlyDisplayed);
+	} else if ((m_pBufOsd && m_pBufOsd->IsDirty()) || m_startgrab) {
+		PageFlipOsd();
 	}
 
-	buf->SetFrame(frame);
+	m_framePresentationCounter--;
+}
 
-	return PageFlipVideo(frame, buf);
+/**
+ * Checks, if the next frame shall be displayed. Otherwise, the current frame shall be kept displaying.
+ * In normal playback, this always returns true.
+ *
+ * @retval true      display the next frame
+ * @retval false     let the current frame display one period more
+ */
+bool cVideoRender::ShallDisplayNextFrame(void)
+{
+	return m_framePresentationCounter == 0;
 }
 
 /**
@@ -1203,37 +987,15 @@ void cVideoRender::ExitDecodingThread(void)
 }
 
 /**
- * Start decoding thread
- */
-void cVideoRender::WakeupDecodingThread(void)
-{
-	LOGDEBUG("videorender: %s", __FUNCTION__);
-	if (!m_pDecodingThread->Active())
-		m_pDecodingThread->Start();
-}
-
-/**
  * Stop display thread
  */
 void cVideoRender::ExitDisplayThread(void)
 {
 	LOGDEBUG("videorender: %s", __FUNCTION__);
 
-	CleanupAndClose(true);
-	if (m_pDisplayThread->Active()) {
-		m_exitThread = true;
+	Reset();
+	if (m_pDisplayThread->Active())
 		m_pDisplayThread->Stop();
-	}
-}
-
-/**
- * Start display thread
- */
-void cVideoRender::WakeupDisplayThread(void)
-{
-	LOGDEBUG("videorender: %s", __FUNCTION__);
-	if (!m_pDisplayThread->Active())
-		m_pDisplayThread->Start();
 }
 
 /**
@@ -1286,8 +1048,8 @@ void cVideoRender::EnqueueFB(AVFrame *inframe)
 		buf = &m_buffer[m_enqueueBufferIdx];
 		if (m_numBuffers < VIDEO_SURFACES_MAX + 2) {
 			while (buf->IsDirty()) {
-				// try the next buffer, because it is either referenced by m_pLastFrame or is already setup
-				// this should be safe, because we only have 1 m_pLastFrame, which should be destroyed as soon as
+				// try the next buffer, because it is either referenced by m_pCurrentlyDisplayed or is already setup
+				// this should be safe, because we only have 1 m_pCurrentlyDisplayed, which should be destroyed as soon as
 				// a new buffer arrives in DisplayFrame
 				// after that destroy, we should be able to setup 0, 1, 2, ..., VIDEO_SURFACES_MAX + 2 framebuffers
 				m_enqueueBufferIdx = (m_enqueueBufferIdx + 1) % (VIDEO_SURFACES_MAX + 2);
@@ -1339,12 +1101,6 @@ void cVideoRender::EnqueueFB(AVFrame *inframe)
 	frame->buf[0] = av_buffer_create((uint8_t *)primedata, sizeof(*primedata),
 				ReleaseFrame, NULL, AV_BUFFER_FLAG_READONLY);
 
-	if (m_closing || m_flushing) {
-		av_frame_free(&inframe);
-		av_frame_free(&frame);
-		return;
-	}
-
 	FramesRbLock();
 	RbPushFrame(frame);
 	FramesRbUnlock();
@@ -1380,11 +1136,6 @@ int cVideoRender::RenderFrame(AVCodecContext * videoCtx, AVFrame * frame)
 
 	if (frame->decode_error_flags || frame->flags & AV_FRAME_FLAG_CORRUPT) {
 		LOGWARNING("videorender: %s: error_flag or FRAME_FLAG_CORRUPT", __FUNCTION__);
-	}
-
-	if (m_closing || m_flushing) {
-		av_frame_free(&frame);
-		return 0;
 	}
 
 	bool interlaced = IsInterlacedFrame(frame);
@@ -1435,27 +1186,20 @@ int cVideoRender::RenderFrame(AVCodecContext * videoCtx, AVFrame * frame)
 			}
 		}
 
-		if (!m_pFilterThread->PushFrame(frame)) {
-			usleep(10000);
-			return -1;
-		}
+		if (!m_pFilterThread->PushFrame(frame))
+			LOGFATAL("Filter buffer full. This is a bug.");
 	} else {
 		// don't use deinterlace/scale filter
 		if (frame->format == AV_PIX_FMT_DRM_PRIME) {
 			// AV_PIX_FMT_DRM_PRIME, interlaced, hw deinterlacer not available
 			// AV_PIX_FMT_DRM_PRIME, progressive
 			// -> put the frame directly in render Rb
-			if (m_closing || m_flushing) {
-				av_frame_free(&frame);
-				return 0;
-			}
 			FramesRbLock();
 			if (atomic_read(&m_framesFilled) < VIDEO_SURFACES_MAX && !m_numFramesToFilter) {
 				RbPushFrame(frame);
 				FramesRbUnlock();
 			} else {
 				FramesRbUnlock();
-				usleep(1000);
 				return -1;
 			}
 		} else {
@@ -1467,12 +1211,25 @@ int cVideoRender::RenderFrame(AVCodecContext * videoCtx, AVFrame * frame)
 				EnqueueFB(frame);
 			} else {
 				FramesRbUnlock();
-				usleep(5000);
 				return -1;
 			}
 		}
 	}
+
 	return 0;
+}
+
+
+/**
+ * Check, if the render output buffer is full.
+ * If a filter is used, the render output buffer is the input buffer of the filter thread.
+ * Otherwise, it is its own output buffer.
+ *
+ * @retval true     render output buffer is full
+  */
+bool cVideoRender::IsBufferFull(void)
+{
+	return m_pFilterThread->GetBufferFrameCount() >= VIDEO_SURFACES_MAX || atomic_read(&m_framesFilled) >= VIDEO_SURFACES_MAX;
 }
 
 /**
@@ -1542,82 +1299,20 @@ int64_t cVideoRender::GetVideoClock(void)
 /**
  * Send start condition to video thread
  */
-void cVideoRender::StartVideo(void)
+void cVideoRender::ResetFrameCounter(void)
 {
-	ResumeVideo();
 	m_startCounter = 0;
-	LOGDEBUG("videorender: %s: reset m_startCounter %d Closing %d TrickSpeed %d", __FUNCTION__,
-		m_startCounter, m_closing, GetTrickSpeed());
+	LOGDEBUG("videorender: %s: reset m_startCounter %d TrickSpeed %d", __FUNCTION__, m_startCounter, GetTrickSpeed());
 }
 
-/**
- * Close the renderer wait for the frames and framebuffers to be cleared
- *
- * @param black     true, if a black fb should be set and the last rendered buffer should be cleared,
- *                  otherwise don't set a black fb and wait for the clear until the next frame arrives
- */
-void cVideoRender::CleanupAndClose(bool black)
+void cVideoRender::Reset()
 {
-	LOGDEBUG("videorender: %s: m_startCounter %d%s", __FUNCTION__, m_startCounter, black ? " closing": " flushing");
-	if (!m_pDisplayThread->Active())
-		return;
-
-	if (m_pFilterThread->Active())
-		m_pFilterThread->Stop();
-	m_flushing = !black;
-	m_closing = black;
-
-	if (VideoIsPaused())
-		ResumeVideo();
-
-	LOGDEBUG("videorender: %s: wait for cleanup", __FUNCTION__);
-	if (!m_waitCleanCondition.Wait(2000)) {
-		LOGERROR("videorender: %s: timeout while waiting for cleanup", __FUNCTION__);
-	}
-
 	m_startCounter = 0;
 	m_framesDuped = 0;
 	m_framesDropped = 0;
 	m_numWrongProgressive = 0;
-	if (black)
-		SetTrickSpeed(0, 1);
-}
 
-/**
- * Pause the renderer
- */
-void cVideoRender::PauseVideo(void)
-{
-	LOGDEBUG("videorender: %s:", __FUNCTION__);
-	m_playbackMutex.Lock();
-	m_videoIsPaused = true;
-	m_playbackMutex.Unlock();
-}
-
-/**
- * Resume the renderer after pausing
- */
-void cVideoRender::ResumeVideo(void)
-{
-	LOGDEBUG("videorender: %s:", __FUNCTION__);
-	m_playbackMutex.Lock();
-	m_videoIsPaused = false;
-	m_playbackMutex.Unlock();
-}
-
-/**
- * Check the renderers pausing status
- *
- * @retval 1     if paused
- * @retval 0     if rendering
- */
-bool cVideoRender::VideoIsPaused(void)
-{
-	bool ret;
-	m_playbackMutex.Lock();
-	ret = m_videoIsPaused;
-	m_playbackMutex.Unlock();
-	return ret;
+	m_deintDisabled = m_configDeintDisabled;
 }
 
 /**
@@ -1630,8 +1325,8 @@ void cVideoRender::SetTrickSpeed(int speed, int forward)
 {
 	LOGDEBUG2(L_TRICK, "videorender: %s: set trick speed %d %s", __FUNCTION__, speed, forward ? "forward" : "backward");
 	m_trickspeedMutex.Lock();
+	m_framePresentationCounter = std::max(1, speed); // speed is 0 in normal playback. Set it to 1 to display the frames exactly once.
 	m_trickSpeed = speed;
-	m_trickCounter = speed;
 	m_trickForward = forward;
 	m_trickspeedMutex.Unlock();
 }
@@ -1645,7 +1340,7 @@ int cVideoRender::GetTrickSpeed(void)
 {
 	int speed;
 	m_trickspeedMutex.Lock();
-	speed = m_trickSpeed;
+	speed = m_trickSpeed * (m_pDevice->VideoStream()->IsInterlaced() ? 2 : 1);
 	m_trickspeedMutex.Unlock();
 	return speed;
 }
@@ -1663,47 +1358,6 @@ int cVideoRender::GetTrickForward(void)
 	dir = m_trickForward;
 	m_trickspeedMutex.Unlock();
 	return dir;
-}
-
-/**
- * Get the count of frames, which should still be rendered in trickspeed mode
- *
- * @returns       the count of frames still left to be rendered
- */
-int cVideoRender::GetTrickCounter(void)
-{
-	int counter;
-	m_trickspeedMutex.Lock();
-	counter = m_trickCounter;
-	m_trickspeedMutex.Unlock();
-	return counter;
-}
-
-/**
- * Set the count of frames, which should still be rendered in trickspeed mode
- *
- * @param counter       the count of frames to be rendered
- */
-void cVideoRender::SetTrickCounter(int counter)
-{
-	m_trickspeedMutex.Lock();
-	m_trickCounter = counter;
-	m_trickspeedMutex.Unlock();
-}
-
-/**
- * Decrease the number of frames, which should still be rendered in trickspeed mode
- *
- * @returns       the count of frames left to be rendered
- */
-int cVideoRender::DecTrickCounter(void)
-{
-	int counter;
-	m_trickspeedMutex.Lock();
-	m_trickCounter--;
-	counter = m_trickCounter;
-	m_trickspeedMutex.Unlock();
-	return counter;
 }
 
 /*****************************************************************************
@@ -2076,9 +1730,6 @@ void cVideoRender::Init(void)
 
 	// init variables page flip
 	m_pDrmDevice->InitEvent();
-
-	// Wakeup DisplayHandlerThread
-	WakeupDisplayThread();
 }
 
 /**
@@ -2148,19 +1799,3 @@ void cVideoRender::SetVideoOutputPosition(const cRect &rect)
 bool cVideoRender::DecodingThreadIsActive(void) {
 	return m_pDecodingThread->Active();
 };
-
-/**
- * Stop the filter thread
- */
-void cVideoRender::StopFilter(void)
-{
-	m_pFilterThread->Stop();
-}
-
-/**
- * Let the filter thread run into a state, where no new frames need to be filtered
- */
-void cVideoRender::WaitForFilterIdle(void)
-{
-	m_pFilterThread->WaitForIdle();
-}

--- a/videorender.h
+++ b/videorender.h
@@ -73,12 +73,6 @@ extern "C" {
 #define FRAME_FLAG_TRICKSPEED           1 << 0     ///< mark frame as a trickspeed frame
 #define FRAME_FLAG_STILLPICTURE         1 << 1     ///< mark frame as a stillpicture frame
 
-struct lastFrame {
-	AVFrame *frame;
-	cDrmBuffer *buf;
-	int trickspeed;
-};
-
 class cDrmDevice;
 
 /**
@@ -92,7 +86,6 @@ public:
 
 	void Init(void);
 	void Exit(void);
-	void CleanUp(void);
 	int HardwareQuirks(void) { return m_hardwareQuirks; };
 	void DisableDeint(bool disable) { m_deintDisabled = disable; };
 	void DisableOglOsd(void) { m_disableOglOsd = true; };
@@ -103,13 +96,10 @@ public:
 	void GetScreenSize(int *, int *, double *);
 	int64_t GetVideoClock(void);
 	void GetStats(int *, int *, int *);
-	void StartVideo(void);
-	void PauseVideo(void);
-	void ResumeVideo(void);
-	bool VideoIsPaused(void);
-	void CleanupAndClose(bool);
-	bool ShouldClose(void) { return m_closing; };
-	bool ShouldFlush(void) { return m_flushing; };
+	void ResetFrameCounter(void);
+	void Reset();
+	void SetPlaybackPaused(bool pause) { m_playbackPaused = pause; };
+	bool IsPlaybackPaused(void) { return m_playbackPaused; };
 
 	// OSD
 	void OsdClear(void);
@@ -118,10 +108,8 @@ public:
 	// TrickSpeed
 	void SetTrickSpeed(int, int);
 	int GetTrickSpeed(void);
-	int GetTrickCounter(void);
 	int GetTrickForward(void);
-	void SetTrickCounter(int);
-	int DecTrickCounter(void);
+	bool ShallDisplayNextFrame(void);
 
 	// Grab
 	int TriggerGrab(void);
@@ -134,17 +122,22 @@ public:
 	void Prepare(void);
 	void CreateDecodingThread(void);
 	bool DecodingThreadIsActive(void);
-	void WakeupDecodingThread(void);
-	void WakeupDisplayThread(void);
 	void ExitDecodingThread(void);
 	void ExitDisplayThread(void);
+
+	void DecodingThreadHalt(void) { m_pDecodingThread->Halt(); };
+	void DecodingThreadResume(void) { m_pDecodingThread->Resume(); };
+	void DisplayThreadHalt(void) { m_pDisplayThread->Halt(); };
+	void DisplayThreadResume(void) { m_pDisplayThread->Resume(); };
+
+	void CancelFilterThread(void) { if (m_pFilterThread->Active()) m_pFilterThread->Stop(); };
 
 	// DRM
 	int DrmHandleEvent(void);
 
 	// Frame and buffer
 	int RenderFrame(AVCodecContext *, AVFrame *);
-	int DisplayFrame(void);
+	void DisplayFrame(AVFrame *);
 	void EnqueueFB(AVFrame *);
 	int GetFramesFilled(void) { return atomic_read(&m_framesFilled); };
 	void RbPushFrame(AVFrame *);
@@ -158,13 +151,15 @@ public:
 	void MarkAsTrickspeedFrame(AVFrame *);
 	void MarkAsStillpictureFrame(AVFrame *);
 	bool MarkAsProgressiveFrame(AVFrame *);
+	void ScheduleDisplayBlackFrame(void) { m_displayBlackFrame = true; };
+	void DestroyFrameBuffers(void);
+	void ClearDecoderToDisplayQueue(void);
+	bool IsBufferFull(void);
 
 	// Filter
 	void ClearFramesToFilter(void) { m_numFramesToFilter = 0; };
 	void IncFramesToFilter(void) { m_numFramesToFilter++; };
 	void DecFramesToFilter(void) { m_numFramesToFilter--; };
-	void WaitForFilterIdle(void);
-	void StopFilter(void);
 
 #ifdef USE_GLES
 	// GLES
@@ -180,7 +175,6 @@ private:
 	cDecodingThread *m_pDecodingThread; ///< pointer to decoding thread
 	cDisplayThread *m_pDisplayThread;   ///< pointer to display thread
 	cFilterThread *m_pFilterThread;     ///< pointer to deinterlace filter thread
-	cCondWait m_waitCleanCondition;     ///< condition to wait on while display cleanup
 	cMutex m_waitCleanMutex;            ///< mutex used while display cleanup
 	cMutex m_trickspeedMutex;           ///< mutex used while accessing trickspeed parameters
 	cMutex m_playbackMutex;             ///< mutex used around m_videoIsPaused
@@ -194,17 +188,8 @@ private:
 	int m_framesRead;                   ///< m_framesRb read pointer
 	atomic_t m_framesFilled;            ///< how many of m_framesRb is used
 	int m_trickSpeed;                   ///< current trick speed
-	int m_trickCounter;                 ///< current trick speed counter (handles, how much trickspeed frame are left to be rendered)
 	bool m_trickForward;                ///< true, if trickspeed plays forward
-	bool m_videoIsPaused;               ///< true, if video is paused
-	bool m_closing;                     ///< flag if render thread should be closed()
-	                                    ///< a black frame is set instead of video frame)
-	bool m_flushing;                    ///< flag if render thread should be closed
-	                                    ///< in difference to m_closing, the video frame is untouched,
-	                                    ///< i.e. the last one remains displayed
-	bool m_flushLastFrame;              ///< flag about need to clear the last video frame in next turn
-	                                    ///< i.e. when did m_flushing and the video frame hasn't been freed
-	bool m_exitThread;                  ///< internal flag, which is set, when display thread should be stopped
+	int m_framePresentationCounter = 0; ///< number of times the current frame has to be shown (for slow motion)
 
 	int m_numFramesToFilter;            ///< number of frames to be filtered
 	bool m_deintDisabled;               ///< set, if deinterlacer is disabled
@@ -234,10 +219,13 @@ private:
 	cDrmBuffer m_buffer[RENDERBUFFERS]; ///< array of video drm buffer objects
 	cDrmBuffer *m_pBufOsd;              ///< pointer to osd drm buffer object
 	cDrmBuffer m_bufBlack;              ///< black drm buffer object
-	struct lastFrame *m_pLastFrame;     ///< pointer to last rendered frame struct (for later free)
+	cDrmBuffer *m_pCurrentlyDisplayed = nullptr; ///< pointer to currently displayed DRM buffer
 	int m_numBuffers = 0;               ///< number of framebuffers currently set up
 	int m_enqueueBufferIdx;             ///< index of the current (sw) framebuffer in the array
 	bool m_osdShown;                    ///< set, if osd is shown currently
+	bool m_displayBlackFrame = false;   ///< set, if a black frame shall be displayed
+	bool m_destroyCurrentlyDisplayed = false; ///< set, if the currently displayed buffer shall be destroyed in the display thread
+	bool m_playbackPaused = false;		///< set, if playback is frozen (used for pause)
 
 #ifdef USE_GLES
 	struct gbm_bo *m_bo;                ///< pointer to current gbm buffer object
@@ -248,17 +236,13 @@ private:
 	void SetFrameFlags(AVFrame *, int);
 	void SetVideoClock(int64_t);
 	bool ShouldWaitForAudio(void);
-	int GetFrame(AVFrame **);
-	int WaitForFrames(void);
-	int WaitForAudioReady(int64_t, int64_t);
-	int WaitForAudioClock(int64_t *);
+	void WaitForAudioReady(int64_t, int64_t);
+	void WaitForAudioClock(int64_t *);
 	int HandleDropDup(int64_t, int64_t);
-	int Sync(AVFrame *);
-	bool NeedsSync(AVFrame *);
-	int PageFlip(AVFrame *, cDrmBuffer *, int);
-	int PageFlipBlack(void);
-	int PageFlipOsd(void);
-	int PageFlipVideo(AVFrame *, cDrmBuffer *);
+	void PageFlip(AVFrame *, cDrmBuffer *, int);
+	void PageFlipBlack(void);
+	void PageFlipOsd(void);
+	void PageFlipVideo(AVFrame *, cDrmBuffer *);
 	cDrmBuffer *GetBuffer(AVFrame *);
 	int SetOsdBuffer(drmModeAtomicReqPtr);
 	void SetVideoBuffer(cDrmBuffer *);

--- a/videostream.cpp
+++ b/videostream.cpp
@@ -70,13 +70,10 @@ cVideoStream::cVideoStream(cSoftHdDevice *device)
 
 	m_codecId = AV_CODEC_ID_NONE;
 	m_newStream = false;
-	m_paused = false;
 	m_pPar = nullptr;
 
 	m_interlaced = 0;
 	m_trickpkts = 1;
-
-	StartDecoding();
 }
 
 /**
@@ -131,13 +128,13 @@ void cVideoStream::Exit(void)
 		m_pDecoder = nullptr;
 	}
 
-	ClearPacketQueue();
+	ClearVdrCoreToDecoderQueue();
 }
 
 /**
  * Clears all video stream data, which is buffered to be decoded
  */
-void cVideoStream::ClearPacketQueue(void)
+void cVideoStream::ClearVdrCoreToDecoderQueue(void)
 {
 	LOGDEBUG("videostream %s: packets %d", __FUNCTION__, m_packets.Size());
 
@@ -192,68 +189,15 @@ void cVideoStream::FlushDecoder(void)
 }
 
 /**
- * Render a decoded frame as often as trickspeed mode wants it
- *
- * This functions returns if the requested count of frames (GetTrickCounter) was renderer,
- * if TrickSpeed mode ended or if a stream closing was reqeusted.
- *
- * @retval -1     stream closing was requested or sth went wrong
- * @retval 0      frames have been rendered as expected or no need to render anything
- */
-int cVideoStream::RenderTrickspeedFrames(AVFrame *frame)
-{
-	if (!frame)
-		return -1;
-
-	while (m_pRender->GetTrickSpeed() && m_pRender->GetTrickCounter() > 0) {
-		AVFrame *trickframe = av_frame_clone(frame);
-		if (!trickframe) {
-			LOGERROR("videostream %s: could not clone frame", __FUNCTION__);
-			return -1;
-		}
-		LOGDEBUG2(L_TRICK, "videostream %s: Trickspeed, send another cloned trick frame %d %s %p",
-		          __FUNCTION__, m_pRender->GetTrickCounter(), Timestamp2String(trickframe->pts, 90), trickframe);
-		m_pRender->MarkAsTrickspeedFrame(trickframe);
-		while (m_pRender->RenderFrame(m_pDecoder->GetContext(), trickframe)) {
-			if (m_closing) {
-				av_frame_free(&trickframe);
-				return -1;
-			}
-		}
-		m_pRender->DecTrickCounter();
-
-		if (m_closing)
-			return -1;
-	}
-
-	return 0;
-}
-
-/**
  * Decodes a reassembled codec packet.
- *
- * @retval 0        packet was decoded or more data is needed
- * @retval 1        stream is paused
- * @retval -1       stream is empty or closed
  */
-int cVideoStream::DecodeInput(void)
+void cVideoStream::DecodeInput(void)
 {
 	AVFrame *frame = nullptr;
 	int ret = 0;
 
-	if (m_closing) {
-		m_closeCondition.Broadcast();
-		return -1;
-	}
-
-	if (m_paused) {
-//		LOGDEBUG2(L_CODEC, "videostream %s: stream is paused", __FUNCTION__);
-		m_pauseCondition.Broadcast();
-		return 1;
-	}
-
-	if (m_codecId == AV_CODEC_ID_NONE)
-		return -1;
+	if (m_codecId == AV_CODEC_ID_NONE || m_packets.Empty() || m_pRender->IsBufferFull())
+		return;
 
 	if (m_newStream) {
 		int width = 0;
@@ -261,11 +205,7 @@ int cVideoStream::DecodeInput(void)
 
 		// amlogic h264 decoder needs width an height for correct decoder open
 		if ((m_codecId == AV_CODEC_ID_H264) && (m_pRender->HardwareQuirks() & QUIRK_CODEC_NEEDS_EXT_INIT)) {
-			AVPacket *packet = m_packets.Peek();
-			if (packet == nullptr)
-				return -1;
-
-			cH264Parser h264Parser(packet);
+			cH264Parser h264Parser(m_packets.Peek());
 			h264Parser.GetDimensions(&width, &height);
 
 			LOGDEBUG2(L_CODEC, "videostream %s: Parsed width %d height %d", __FUNCTION__, width, height);
@@ -283,69 +223,41 @@ int cVideoStream::DecodeInput(void)
 	// This guarantees, that we don't drain the decoder too early, but exactly after
 	// m_trickpkts sent packets
 	int minPkts = (m_pRender->GetTrickSpeed() && m_interlaced) ? m_trickpkts : 1;
-	if ((int)m_packets.Size() < minPkts) {
-		return -1;
-	}
 
 	// send packet to decoder
-	ret = m_pDecoder->SendPacket(m_packets.Peek());
-	if (ret != AVERROR(EAGAIN)) { // something went wrong or packet was sent, advance packet
-		AVPacket *avpkt = m_packets.Pop();
-		av_packet_free(&avpkt);
+	AVPacket *avpkt = m_packets.Peek();
+	ret = m_pDecoder->SendPacket(avpkt);
 
-		// in backward trickspeed force the decoder to decode the frame, if minPkts are sent
-		if (ret == 0 && m_pRender->GetTrickSpeed() && !m_pRender->GetTrickForward()) {
-			m_sentTrickPkts++;
-			if (m_sentTrickPkts >= minPkts) {
-				m_pDecoder->SendPacket(NULL);
-				m_sentTrickPkts = 0;
-			}
+	if (ret != AVERROR(EAGAIN)) {
+		avpkt = m_packets.Pop();
+		av_packet_free(&avpkt);
+	}
+
+	// in backward trickspeed force the decoder to decode the frame, if minPkts are sent
+	if (ret == 0 && m_pRender->GetTrickSpeed() && !m_pRender->GetTrickForward()) {
+		m_sentTrickPkts++;
+		if (m_sentTrickPkts >= minPkts) {
+			m_pDecoder->SendPacket(NULL);
+			m_sentTrickPkts = 0;
 		}
 	}
 
 	// receive frame from decoder
-	if (!m_pRender->GetTrickSpeed()) {
-		// this is normal Playback
-		 if (!m_newStream) { // this is for mediaplayer?
-			ret = m_pDecoder->ReceiveFrame(&frame);
-			if (ret == 0) {
-				while (m_pRender->RenderFrame(m_pDecoder->GetContext(), frame)) {
-					if (m_closing) {
-						av_frame_free(&frame);
-						return -1;
-					}
-				}
-			}
-		}
-	} else {
-		// this is TrickSpeed
-		ret = m_pDecoder->ReceiveFrame(&frame);
-		while (ret == 0) {
-			m_pRender->MarkAsProgressiveFrame(frame);
-			// deinterlacer is disabled in trickspeed mode
-			// in order to have the right speed, we double the count of frames to be displayed in trickspeed mode
-			// if we have an interlaced stream - we simply just dup the frame
-			LOGDEBUG2(L_TRICK, "videostream: %s trickspeed %d isInterlaced %d", __FUNCTION__, m_pRender->GetTrickSpeed(), m_interlaced);
-			m_pRender->SetTrickCounter(m_pRender->GetTrickSpeed() * (m_interlaced ? 2 : 1));
-			if (RenderTrickspeedFrames(frame)) { // returns -1 only if stream should be closed
-				av_frame_free(&frame);
-				m_sentTrickPkts = 0;
-				return -1;
+	if (!m_newStream) { // this is for mediaplayer?
+		if (m_pDecoder->ReceiveFrame(&frame) == 0) {
+			if (m_pRender->GetTrickSpeed()) {
+				m_pRender->MarkAsProgressiveFrame(frame);
+				m_pRender->MarkAsTrickspeedFrame(frame);
 			}
 
-			av_frame_free(&frame);
-			m_sentTrickPkts = 0;
-
-			ret = m_pDecoder->ReceiveFrame(&frame);
-		} // try receiving another frame from decoder, should end up with AVERROR_EOF
-
-		if (ret == AVERROR_EOF) { // needs flush / reopen
-			FlushDecoder();
-			m_sentTrickPkts = 0;
+			m_pRender->RenderFrame(m_pDecoder->GetContext(), frame);
 		}
 	}
 
-	return 0;
+	if (m_pRender->GetTrickSpeed() && ret == AVERROR_EOF) { // needs flush / reopen
+		FlushDecoder();
+		m_sentTrickPkts = 0;
+	}
 }
 
 
@@ -357,8 +269,6 @@ int cVideoStream::DecodeInput(void)
 void cVideoStream::StillPicture(cPesVideo *pesPacket)
 {
 	AVPacket *avpkt = CreateAvPacket(pesPacket->GetPayload(), pesPacket->GetPayloadSize(), pesPacket->GetPts());
-
-	Pause();
 
 	// close the decoder if open and another codec id arrives
 	if (Decoder()->GetContext()) {
@@ -395,12 +305,7 @@ void cVideoStream::StillPicture(cPesVideo *pesPacket)
 		LOGDEBUG2(L_STILL, "videostream: %s: frame received", __FUNCTION__);
 		m_pRender->MarkAsProgressiveFrame(frame);
 		m_pRender->MarkAsStillpictureFrame(frame);
-		while (m_pRender->RenderFrame(Decoder()->GetContext(), frame)) {
-			if (m_closing) {
-				av_frame_free(&frame);
-				break;
-			}
-		}
+		while (m_pRender->RenderFrame(Decoder()->GetContext(), frame)) {}
 		// try to get another frame
 		ret = Decoder()->ReceiveFrame(&frame);
 	}
@@ -420,10 +325,7 @@ void cVideoStream::StillPicture(cPesVideo *pesPacket)
 		SetCodecId(AV_CODEC_ID_NONE);
 	}
 
-	ClearPacketQueue();
 	FlushDecoder();
-
-	Resume();
 }
 
 /**
@@ -447,39 +349,4 @@ void cVideoStream::SetTimebase(int num, int den)
 {
 	m_timebase.num = num;
 	m_timebase.den = den;
-}
-
-/**
- * Stop the stream
- *
- * Skips the decoding of the stream until m_closing gets false again (with Start())
- */
-void cVideoStream::StopAndWaitDecodingIdle(void)
-{
-	int timeoutInMs = 1000;
-	m_closing = true;
-
-	cMutex mutex;
-	mutex.Lock();
-	if (!m_closeCondition.TimedWait(mutex, timeoutInMs))
-		LOGERROR("videostream %s: Timeout while closing stream (%d ms)!", __FUNCTION__, timeoutInMs);
-
-	LOGDEBUG2(L_CODEC, "videostream %s: stream is closing", __FUNCTION__);
-}
-
-/**
- * Pause the stream
- *
- * Prevent the stream from decoding new frames and sending them to filter or renderer
- * cCondVar is necessary to finish a decoding loop
- */
-void cVideoStream::Pause(void)
-{
-	int timeoutInMs = 2000;
-
-	m_paused = true;
-	cMutex mutex;
-	mutex.Lock();
-	if (!m_pauseCondition.TimedWait(mutex, timeoutInMs))
-		LOGERROR("videostream %s: Timeout while pausing stream (%d ms)!", __FUNCTION__, timeoutInMs);
 }

--- a/videostream.h
+++ b/videostream.h
@@ -48,16 +48,11 @@ public:
 
 	void Open(void) { m_newStream = true; };
 	void Exit(void);
-	void ClearPacketQueue(void);
+	void ClearVdrCoreToDecoderQueue(void);
 	void FlushDecoder(void);
 	void CloseDecoder(void);
-	int DecodeInput(void);
+	void DecodeInput(void);
 	void StillPicture(cPesVideo *);
-	void StartDecoding(void) { m_closing = false; };
-	void StopAndWaitDecodingIdle(void);
-	void Resume(void) { m_paused = false; };
-	void Pause(void);
-	bool IsPaused(void) { return m_paused; };
 	void PushPesPacket(cPes *pesPacket);
 	bool PushAvPacket(AVPacket *avpkt);
 	void ResetFragmentationBuffer(void);
@@ -70,8 +65,10 @@ public:
 	void SetTimebase(int, int);
 	void SetTrickpkts(int pkts) { m_trickpkts = pkts; };
 	void SetInterlaced(bool interlaced);
+	bool IsInterlaced(void) { return m_interlaced; };
 	size_t GetAvPacketsFilled(void) { return m_packets.Size(); };
 	enum AVCodecID GetCodecId(void) { return m_codecId; };
+	void ResetTrickSpeedFramesSentCounter(void) { m_sentTrickPkts = 0; };
 
 private:
 	cVideoDecoder *m_pDecoder;             ///< video decoder
@@ -88,13 +85,9 @@ private:
 	int m_sentTrickPkts = 0;               ///< how many avpkt have been sent to the decoder in trickspeed mode?
 
 	volatile bool m_newStream;             ///< flag for new stream
-	volatile bool m_closing;               ///< flag for closing request
-	volatile bool m_paused;                ///< flag for paused stream
 	bool m_interlaced;                     ///< flag for interlaced stream
 	cCondVar m_closeCondition;             ///< condition object to wait for finishing jobs while closing
 	cCondVar m_pauseCondition;             ///< condition object to wait for pausing the stream
-
-	int RenderTrickspeedFrames(AVFrame *);
 };
 
 #endif


### PR DESCRIPTION
Please don't be scared of the many lines changed! This makes the code **simpler** :)

The goal of this PR is to make at a a glance visible what happens when VDR calls one of PlayMode()/Freeze()/Clear()/.... So, no more indirections, burried deep inside the call graph, waiting for signals of other threads, depending on flags (closing, flushing, ...) in methods named after what you don't expect.

To solve this, two main changes were done:

1. On every call of above VDR methods, we wait at a *single* and *central* location, that the display and decoding threads finish their currently processing packet/frame. Then, the threads are locked (halted), and the necessary changes are done in a thread-safe and predictable way, until they resume their normal work.
2. What should happen in which state is also handled in a single and central location. Therefore, VDR's state is tracked in a variable. When one of PlayMode()/Freeze()/Clear()/... are invoked (I call it "events"), they are handled according to in which state VDR is currently in (play/stop/trickspeed). So, you can clearly see in the code, what happens in a particular state, when a specific event is received. The state transitions are handled in `cSoftHdDevice::OnEventReceived()` and what shall be done when entering or leaving a state is done in `cSoftHdDevice::OnEnteringState()`/`cSoftHdDevice::OnLeavingState()`.

To make above possible, these changes were done:
- There were many places where flags were checked *during* processing a packet/frame, whether the stream was closed or needs flushing, etc.. These were removed, because the threads now finish their current work, and only then, the stream closes/flushes.
- Waiting for an input buffer to become filled or to have free capacity in an output buffers is now done *beforehand*, and not in a loop, deep inside the method.
- The dedicated struct for the last frame was replaced by a simple reference to cDrmBuffer, because cDrmBuffer already contains all necessary information. I renamed it also to "currently displayed", which I think fits more.
- When the decoder returns EAGAIN, the packet is now presented immediately again, instead of waiting for the next cycle.
- The usleeps are harmonized to 1ms. Eliminating the need of return values deep from inside the call graph (e.g. PageFlip/DRM event handling). My plan is to make cQueue synchronized, so that we get rid of usleeps completely in the thread loops.
- Muting of the audio doesn't seem necessary? Audio is now paused/resumed and if necessary, cleared.
- Copying the frames for trickspeed has been moved to the display thread. The page flip is now simply deferred. The constant of 20ms might need to be adjusted dynamically to the frame rate of the output device. I will do that once I fully understand the mechanics behind the DRM page flip.

Note: I didn't implement pause as a state. I noticed that it makes more sense to keep the current state (play or trickspeed) during pause to clean up explicitly for that particular state (in case the state is left during pause).

I tested the following:
- Material:
  - 576i MPEG2
  - 720p50 H.264
  - 1080i25 H.264
  - 1080p50 HEVC
- Each state and transition in the state diagram.
- All transitions over multiple states (there are many!):
  - Trickspeed -> Pause -> Trickspeed
  - Trickspeed -> Pause -> Play
  - Play -> Trickspeed -> Play
  - ...
- LCARSNG video resizing
- Output device with 25Hz and 60Hz
- Output device with different resolutions (4k does not seem to work well, also before the change)
- Audio only (does not work, also before the change)
- Multispeed

What I did not test:
- Grabbing
- Audio passthrough
- UHD
- Mediaplayer
- Dolby