### PR TITLE
Fix Timestamp2String() displaying AV_NOPTS_VALUE not correctly

### DIFF
--- a/audio.cpp
+++ b/audio.cpp
@@ -1004,9 +1004,9 @@ int cSoftHdAudio::Skip(int64_t videoPts, int full)
 		LOGDEBUG2(L_AV_SYNC, "audio: %s: RB %" PRId64 "ms skip %dms audio %s -> %s video %s", __FUNCTION__,
 			used * 1000 / m_hwSampleRate / m_hwNumChannels / m_bytesPerSample,
 			skip * 1000 / m_hwSampleRate / m_hwNumChannels / m_bytesPerSample,
-			Timestamp2String(audioPts),
-			Timestamp2String(audioPts + skip * 1000 / m_hwSampleRate / m_hwNumChannels / m_bytesPerSample),
-			Timestamp2String(videoPts * 1000 * av_q2d(*m_pTimebase)));
+			Timestamp2String(audioPts, 1),
+			Timestamp2String(audioPts + skip * 1000 / m_hwSampleRate / m_hwNumChannels / m_bytesPerSample, 1),
+			Timestamp2String(videoPts * 1000 * av_q2d(*m_pTimebase), 1));
 
 		m_pRingbuffer->ReadAdvance(skip);
 	}

--- a/codec_audio.cpp
+++ b/codec_audio.cpp
@@ -370,7 +370,7 @@ void cAudioDecoder::Decode(const AVPacket * avpkt)
 				// we remember the avpkt->pts if we have one and could use it for the frame->pts,
 				// if we don't get one after decode. This way, m_lastPts also gets set.
 				LOGDEBUG2(L_CODEC, "audiocodec: %s: New audio stream, set initial pts to avpkt->pts %s", __FUNCTION__,
-					Timestamp2String(avpkt->pts * 1000 * av_q2d(m_pAudioCtx->pkt_timebase)));
+					Timestamp2String(avpkt->pts * 1000 * av_q2d(m_pAudioCtx->pkt_timebase), 1));
 				m_initialAvpktPts = avpkt->pts;
 			}
 		} else {
@@ -380,7 +380,7 @@ void cAudioDecoder::Decode(const AVPacket * avpkt)
 				// If we don't get a valid pts for the decoded frame and also can not set it to m_lastPts, because
 				// this is the first decoded frame, we use the pts of the initial avpkt.
 				LOGWARNING("audiocodec: %s: NO VALID PTS, set frame->pts to last known avpkt->pts %s", __FUNCTION__,
-					Timestamp2String(m_initialAvpktPts * 1000 * av_q2d(m_pAudioCtx->pkt_timebase)));
+					Timestamp2String(m_initialAvpktPts * 1000 * av_q2d(m_pAudioCtx->pkt_timebase), 1));
 				frame->pts = m_initialAvpktPts;
 				m_initialAvpktPts = AV_NOPTS_VALUE;
 			}

--- a/codec_video.cpp
+++ b/codec_video.cpp
@@ -499,7 +499,7 @@ int cVideoDecoder::SendPacket(const AVPacket *avpkt)
 	}
 
 	m_cntPacketsSent++;
-	LOGDEBUG2(L_PACKET, "videocodec: %s:   %6d PTS %s <<---", __FUNCTION__, m_cntPacketsSent, Timestamp2String(avpkt->pts / 90));
+	LOGDEBUG2(L_PACKET, "videocodec: %s:   %6d PTS %s <<---", __FUNCTION__, m_cntPacketsSent, Timestamp2String(avpkt->pts, 90));
 	m_mutex.Unlock();
 	return 0;
 }
@@ -567,7 +567,7 @@ int cVideoDecoder::ReceiveFrame(AVFrame **frame)
 
 	m_cntFramesReceived++;
 	LOGDEBUG2(L_PACKET, "videocodec: %s: %6d PTS %s --->> (%2d)%s", __FUNCTION__,
-		m_cntFramesReceived, Timestamp2String(pFrame->pts / 90), m_cntPacketsSent - m_cntFramesReceived,
+		m_cntFramesReceived, Timestamp2String(pFrame->pts, 90), m_cntPacketsSent - m_cntFramesReceived,
 		m_pRender->IsInterlacedFrame(pFrame) ? " I" : "");
 	m_mutex.Unlock();
 	return 0;

--- a/misc.h
+++ b/misc.h
@@ -65,7 +65,7 @@ static inline const char *Timestamp2String(int64_t ts, uint8_t divisor)
 	static char buf[3][16];
 	static int idx = 0;
 
-	if (ts == AV_NOPTS_VALUE) {
+	if (ts == (int64_t) AV_NOPTS_VALUE) {
 		return "--:--:--.---";
 	}
 

--- a/misc.h
+++ b/misc.h
@@ -60,14 +60,17 @@ static inline const char* av_err2string(int errnum)
  *
  * @param ts       time stamp
  */
-static inline const char *Timestamp2String(int64_t ts)
+static inline const char *Timestamp2String(int64_t ts, uint8_t divisor)
 {
 	static char buf[3][16];
 	static int idx = 0;
 
-	if (ts == (int64_t) AV_NOPTS_VALUE) {
+	if (ts == AV_NOPTS_VALUE) {
 		return "--:--:--.---";
 	}
+
+	ts /= divisor;
+
 	idx = (idx + 1) % 3;
 	snprintf(buf[idx], sizeof(buf[idx]), "%2d:%02d:%02d.%03d",
 		(int)(ts / (3600000)), (int)((ts / (60000)) % 60),

--- a/videorender.cpp
+++ b/videorender.cpp
@@ -429,7 +429,7 @@ int cVideoRender::CommitBuffer(cDrmBuffer *buf, int osdOnly)
 int cVideoRender::WaitForAudioReady(int64_t videoPts, int64_t framePts)
 {
 	if(!m_startCounter && !m_closing) {
-		LOGDEBUG("videorender: %s: start PTS %s", __FUNCTION__, Timestamp2String(videoPts));
+		LOGDEBUG("videorender: %s: start PTS %s", __FUNCTION__, Timestamp2String(videoPts, 1));
 		m_pAudio->Skip(framePts, 0);
 
 		while (!m_pAudio->VideoReady(videoPts)) {
@@ -507,8 +507,8 @@ int cVideoRender::HandleDropDup(int64_t videoPts, int64_t audioPts)
 	if (abs(diff) > 5000) {	// more than 5s
 		LOGDEBUG2(L_AV_SYNC, "More then 5s Pkts %d deint %d, Frames %d UsedBytes %d audio %s video %s Delay %dms diff %dms",
 			m_pDevice->VideoStream()->GetAvPacketsFilled(), m_pFilterThread->GetBufferFrameCount(),
-			atomic_read(&m_framesFilled), m_pAudio->GetUsedBytes(), Timestamp2String(audioPts),
-			Timestamp2String(videoPts), m_pDevice->GetVideoAudioDelay(), diff);
+			atomic_read(&m_framesFilled), m_pAudio->GetUsedBytes(), Timestamp2String(audioPts, 1),
+			Timestamp2String(videoPts, 1), m_pDevice->GetVideoAudioDelay(), diff);
 	}
 
 	if (diff < -5 && !(abs(diff) > 5000)) {	// video is more than 5ms behind audio, drop video frame
@@ -516,7 +516,7 @@ int cVideoRender::HandleDropDup(int64_t videoPts, int64_t audioPts)
 		if (m_flushLastFrame) {
 			LOGDEBUG2(L_AV_SYNC, "Video too late, but skip sync (drop %d, dup %d) audio %s video %s Delay %dms diff %dms",
 				m_framesDropped, m_framesDuped,
-				Timestamp2String(audioPts), Timestamp2String(videoPts),
+				Timestamp2String(audioPts, 1), Timestamp2String(videoPts, 1),
 				m_pDevice->GetVideoAudioDelay(), diff);
 			return 0;
 		}
@@ -524,8 +524,8 @@ int cVideoRender::HandleDropDup(int64_t videoPts, int64_t audioPts)
 		LOGDEBUG2(L_AV_SYNC, "FrameDropped (drop %d, dup %d) Pkts %d deint %d Frames %d UsedBytes %d audio %s video %s Delay %dms diff %dms",
 			m_framesDropped, m_framesDuped,
 			m_pDevice->VideoStream()->GetAvPacketsFilled(), m_pFilterThread->GetBufferFrameCount(),
-			atomic_read(&m_framesFilled), m_pAudio->GetUsedBytes(), Timestamp2String(audioPts),
-			Timestamp2String(videoPts), m_pDevice->GetVideoAudioDelay(), diff);
+			atomic_read(&m_framesFilled), m_pAudio->GetUsedBytes(), Timestamp2String(audioPts, 1),
+			Timestamp2String(videoPts, 1), m_pDevice->GetVideoAudioDelay(), diff);
 
 		if (!m_startCounter)
 			m_startCounter++;
@@ -538,8 +538,8 @@ int cVideoRender::HandleDropDup(int64_t videoPts, int64_t audioPts)
 		LOGDEBUG2(L_AV_SYNC, "FrameDuped (drop %d, dup %d) Pkts %d deint %d Frames %d UsedBytes %d audio %s video %s Delay %dms diff %dms",
 			m_framesDropped, m_framesDuped,
 			m_pDevice->VideoStream()->GetAvPacketsFilled(), m_pFilterThread->GetBufferFrameCount(),
-			atomic_read(&m_framesFilled), m_pAudio->GetUsedBytes(), Timestamp2String(audioPts),
-			Timestamp2String(videoPts), m_pDevice->GetVideoAudioDelay(), diff);
+			atomic_read(&m_framesFilled), m_pAudio->GetUsedBytes(), Timestamp2String(audioPts, 1),
+			Timestamp2String(videoPts, 1), m_pDevice->GetVideoAudioDelay(), diff);
 
 		m_framesDuped++;
 		usleep(20000);
@@ -876,7 +876,7 @@ int cVideoRender::PageFlip(AVFrame *frame, cDrmBuffer *buf, int osdOnly)
 		SetVideoClock(frame->pts);
 
 	if (frame)
-		LOGDEBUG2(L_PACKET, "videorender: %s:                 PTS %s", __FUNCTION__, Timestamp2String(frame->pts / 90));
+		LOGDEBUG2(L_PACKET, "videorender: %s:                 PTS %s", __FUNCTION__, Timestamp2String(frame->pts, 90));
 
 	// new video frame was sent, rotate the frames
 	if (m_pLastFrame->frame) {

--- a/videostream.cpp
+++ b/videostream.cpp
@@ -212,7 +212,7 @@ int cVideoStream::RenderTrickspeedFrames(AVFrame *frame)
 			return -1;
 		}
 		LOGDEBUG2(L_TRICK, "videostream %s: Trickspeed, send another cloned trick frame %d %s %p",
-		          __FUNCTION__, m_pRender->GetTrickCounter(), Timestamp2String(trickframe->pts / 90), trickframe);
+		          __FUNCTION__, m_pRender->GetTrickCounter(), Timestamp2String(trickframe->pts, 90), trickframe);
 		m_pRender->MarkAsTrickspeedFrame(trickframe);
 		while (m_pRender->RenderFrame(m_pDecoder->GetContext(), trickframe)) {
 			if (m_closing) {


### PR DESCRIPTION
When the value is divided by 90 before calling Timestamp2String(), AV_NOPTS_VALUE cannot be detected anymore. This adds the divisor as a separate argument.