### PR TITLE
Fix not resuming audio when receiving Clear() in trick speed

### DIFF
--- a/softhddevice.cpp
+++ b/softhddevice.cpp
@@ -944,7 +944,6 @@ void cSoftHdDevice::Clear(void)
 	m_pRender->DestroyFrameBuffers();
 	m_pRender->Reset();
 
-	m_pAudio->Resume();
 	ClearAudio();
 
 	m_pRender->DisplayThreadResume();


### PR DESCRIPTION
E.g. when switching from forward to reverse with interlaced material. Audio is resumed when leaving trick speed in OnLeavingState().