### PR TITLE
Add still picture state. Handle deinterlacer in trick speed correctly.

### DIFF
--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -218,7 +218,6 @@ flowchart TD
     TrickSpeedDecision --> |Trick Speed|TrickSpeedFormat{Format?}
     TrickSpeedFormat --> |__SW decoded__<br/>YUV420P<br/>_progressive or interlaced_<br/>RPI 4&5: 576i MPEG2<br/>RPI4: 1080p HEVC<br/>RPI5: 1080i H.264<br/>RK3399: __None__|FilterThreadForceProgressive
     TrickSpeedFormat --> |__HW decoded__<br/>DRM_PRIME<br/>_progressive or interlaced_<br/>RPI4: 1080i H.264<br/>RPI5: 1080p HEVC<br/>RK3399: all|Display
-    TrickSpeedFormat --> |__HW decoded__<br/>NV12<br/>_progressive or interlaced_<br/>Not used in practice?|EnqueueFB
     EnqueueFB --> |DRM_PRIME<br/>progressive or interlaced|Display
     FilterThreadForceProgressive --> |NV12<br/>progressive or interlaced|EnqueueFB
 

--- a/codec_video.cpp
+++ b/codec_video.cpp
@@ -263,8 +263,7 @@ int cVideoDecoder::Open(enum AVCodecID codecId, AVCodecParameters * par,
 			m_mutex.Unlock();
 			return -1;
 		}
-		LOGDEBUG2(L_CODEC, "videocodec: %s: Using %s HW codec", __FUNCTION__,
-			type_name ? type_name : "unknown");
+		LOGINFO("videocodec: Using %s hardware video acceleration 🤩", type_name ? type_name : "unknown");
 		m_pVideoCtx->hw_device_ctx = hwDeviceCtx;
 		m_pVideoCtx->pix_fmt = AV_PIX_FMT_DRM_PRIME;
 	}

--- a/softhddevice.cpp
+++ b/softhddevice.cpp
@@ -757,6 +757,24 @@ void cSoftHdDevice::OnEventReceived(const Event& event) {
 				 },
 			}, event);
 			break;
+		case State::STILL_PICTURE:
+			std::visit(overload{
+				[this](const PlayEvent&) {
+					SetState(PLAY);
+				},
+				[&invalid](const PauseEvent&) { invalid(); },
+				[this](const StopEvent&) {
+					SetState(STOP);
+				},
+				[this](const TrickSpeedEvent& t) {
+					m_pRender->SetTrickSpeed(t.speed, t.forward);
+					SetState(TRICK_SPEED);
+				},
+				[this](const StillPictureEvent& s) {
+					HandleStillPicture(s.data, s.size);
+				 },
+			}, event);
+			break;
 	}
 
 	m_pRender->DecodingThreadResume();
@@ -778,8 +796,11 @@ void cSoftHdDevice::OnEnteringState(enum State state) {
 			m_pRender->SetPlaybackPaused(false);
 			break;
 		case TRICK_SPEED:
-			m_pAudio->Pause();
+			// The filter thread needs to be restarted for interlaced streams to be rendered without deinterlacer in trick speed mode. It is started lazily.
+			m_pRender->CancelFilterThread();
 			m_pRender->SetPlaybackPaused(false);
+			m_pRender->SetDeinterlacerDeactivated(true);
+			m_pAudio->Pause();
 			break;
 		case STOP:
 			m_pRender->CancelFilterThread();
@@ -800,6 +821,10 @@ void cSoftHdDevice::OnEnteringState(enum State state) {
 
 			m_pVideoStream->SetInterlaced(0); // probably not necessary
 			break;
+		case STILL_PICTURE:
+			m_pRender->SetDeinterlacerDeactivated(true);
+			m_pVideoStream->SetStillPicture(true);
+			break;
 	}
 }
 
@@ -817,23 +842,24 @@ void cSoftHdDevice::OnLeavingState(enum State state) {
 			// nothing
 			break;
 		case TRICK_SPEED:
-			// In case we get a play in slow forward, we need to restart the filter thread.
-			// Because trickspeed doesn't do deinterlacing but can use the scale filter
-			// we need to stop the filter here, to get the deinterlace filter started in normal
-			// playback.
-			if (m_pRender->GetTrickForward())
-				m_pRender->CancelFilterThread(); // filter thread is restarted lazily
+			// The filter thread needs to be restarted for interlaced streams to be rendered with deinterlacer again. It is started lazily.
+			m_pRender->CancelFilterThread();
 
 			m_pRender->DestroyFrameBuffers();
 
 			m_pRender->SetTrickSpeed(0, 1);
 			m_pRender->ResetFrameCounter();
+			m_pRender->SetDeinterlacerDeactivated(false);
 			m_pVideoStream->ResetTrickSpeedFramesSentCounter();
 
 			m_pAudio->Resume();
 			break;
 		case STOP:
 			// nothing
+			break;
+		case STILL_PICTURE:
+			m_pRender->SetDeinterlacerDeactivated(false);
+			m_pVideoStream->SetStillPicture(false);
 			break;
 	}
 }
@@ -1001,6 +1027,8 @@ void cSoftHdDevice::StillPicture(const uchar *data, int size)
  */
 void cSoftHdDevice::HandleStillPicture(const uchar *data, int size)
 {
+	SetState(STILL_PICTURE);
+
 	const uchar *currentPacketStart = data;
 	while (currentPacketStart < data + size) {
 		cPesVideo pesPacket((const uint8_t*)currentPacketStart, size - (currentPacketStart - data));

--- a/softhddevice.cpp
+++ b/softhddevice.cpp
@@ -818,12 +818,9 @@ void cSoftHdDevice::OnEnteringState(enum State state) {
 
 			if (m_pAudioDecoder && m_audioCodecID != AV_CODEC_ID_NONE)
 				m_newAudioStream = true;
-
-			m_pVideoStream->SetInterlaced(0); // probably not necessary
 			break;
 		case STILL_PICTURE:
 			m_pRender->SetDeinterlacerDeactivated(true);
-			m_pVideoStream->SetStillPicture(true);
 			break;
 	}
 }
@@ -859,7 +856,6 @@ void cSoftHdDevice::OnLeavingState(enum State state) {
 			break;
 		case STILL_PICTURE:
 			m_pRender->SetDeinterlacerDeactivated(false);
-			m_pVideoStream->SetStillPicture(false);
 			break;
 	}
 }

--- a/softhddevice.h
+++ b/softhddevice.h
@@ -43,6 +43,7 @@ enum State {
 	STOP,
 	PLAY,
 	TRICK_SPEED,
+	STILL_PICTURE
 };
 
 struct PlayEvent {};
@@ -78,6 +79,7 @@ inline const char* StateToString(State s) {
         case State::STOP: return "STOP";
         case State::PLAY: return "PLAY";
         case State::TRICK_SPEED: return "TRICK_SPEED";
+		case State::STILL_PICTURE: return "STILL_PICTURE";
     }
     return "Unknown";
 }

--- a/threads.cpp
+++ b/threads.cpp
@@ -214,65 +214,37 @@ cFilterThread::~cFilterThread(void)
 }
 
 /**
- * Init the video filter
+ * Init and start the video filter thread
  *
- * @param videoCtx                     codec context
- * @param frame                        AVFrame to take init parameters from
- * @param userDisabledDeinterlacer     true, if the deinterlacer was disabled by the user
- * @param forceDeinterlacerDisabled    true, if deinterlacer shall be forced disabled (trick speed or still picture)
- *
- ** @returns 0           on success
- * @return 1            on failure, filter was not initiated
+ * @param videoCtx               codec context
+ * @param frame                  AVFrame to take init parameters from
+ * @param enableDeinterlacer     true, if the deinterlacer should be used
  */
-int cFilterThread::Init(const AVCodecContext *videoCtx, AVFrame *frame, int userDisabledDeinterlacer, bool forceDeinterlacerDisabled)
+void cFilterThread::InitAndStart(const AVCodecContext *videoCtx, AVFrame *frame, bool enableDeinterlacer)
 {
 	int ret;
 	char args[512];
 	const char *filterDescr = NULL;
 	m_pFilterGraph = avfilter_graph_alloc();
-	if (!m_pFilterGraph) {
-		LOGERROR("filter thread: %s: Cannot alloc filter graph", __FUNCTION__);
-		return -1;
-	}
+	if (!m_pFilterGraph)
+		LOGFATAL("filter thread: %s: Cannot alloc filter graph", __FUNCTION__);
 
 	m_pRender->ClearFramesToFilter();
 	m_filterBug = false;
-	m_filterTrick = false;
-	m_filterStill = false;
-	m_isInterlaceFilter = false;
 
 	const AVFilter *buffersrc  = avfilter_get_by_name("buffer");
 	const AVFilter *buffersink = avfilter_get_by_name("buffersink");
-
-	bool interlaced = m_pRender->IsInterlacedFrame(frame);
-	if (videoCtx->framerate.num > 0) {
-		if (videoCtx->framerate.num / videoCtx->framerate.den > 30)
-			interlaced = false;
-		else
-			interlaced = true;
-	}
-
-	if (videoCtx->codec_id == AV_CODEC_ID_HEVC)
-		interlaced = false;
-
-	if (userDisabledDeinterlacer) {
-		if (interlaced)
-			LOGDEBUG2(L_CODEC, "filter thread: %s: Deinterlacer wanted, but disabled in setup!", __FUNCTION__);
-		interlaced = false;
-	}
 
 	// interlaced and non-trickspeed AV_PIX_FMT_DRM_PRIME (hardware decoded) -> hardware deinterlacer
 	// interlaced and non-trickspeed AV_PIX_FMT_YUV420P (software decoded) -> software deinterlacer
 	// progressive and trickspeed AV_PIX_FMT_YUV420P (software decoded) -> scale filter (for NV12 output)
 	// progressive and trickspeed AV_PIX_FMT_DRM_PRIME (hardware decoded) doesn't get to the FilterHandlerThread
-	if (interlaced && !forceDeinterlacerDisabled) {
+	if (enableDeinterlacer) {
 		if (frame->format == AV_PIX_FMT_DRM_PRIME) {
 			filterDescr = "deinterlace_v4l2m2m";
-			m_isInterlaceFilter = true;
 		} else if (frame->format == AV_PIX_FMT_YUV420P) {
 			filterDescr = "bwdif=1:-1:0";
 			m_filterBug = true;
-			m_isInterlaceFilter = true;
 		}
 	} else if (frame->format == AV_PIX_FMT_YUV420P) {
 		filterDescr = "scale";
@@ -297,41 +269,28 @@ int cFilterThread::Init(const AVCodecContext *videoCtx, AVFrame *frame, int user
 	LOGDEBUG2(L_CODEC, "filter thread: %s: filter=\"%s\" args=\"%s\"", __FUNCTION__, filterDescr, args);
 
 	ret = avfilter_graph_create_filter(&m_pBuffersrcCtx, buffersrc, "in", args, NULL, m_pFilterGraph);
-	if (ret < 0) {
-		LOGERROR("filter thread: %s: Cannot create buffer source (%d)", __FUNCTION__, ret);
-		avfilter_graph_free(&m_pFilterGraph);
-		return -1;
-	}
+	if (ret < 0)
+		LOGFATAL("filter thread: %s: Cannot create buffer source (%d)", __FUNCTION__, ret);
 
 	AVBufferSrcParameters *par = av_buffersrc_parameters_alloc();
 	memset(par, 0, sizeof(*par));
 	par->format = AV_PIX_FMT_NONE;
 	par->hw_frames_ctx = frame->hw_frames_ctx;
 	ret = av_buffersrc_parameters_set(m_pBuffersrcCtx, par);
-	if (ret < 0) {
-		LOGERROR("filter thread: %s: Cannot av_buffersrc_parameters_set (%d)", __FUNCTION__, ret);
-		av_free(par);
-		avfilter_graph_free(&m_pFilterGraph);
-		return -1;
-	}
+	if (ret < 0)
+		LOGFATAL("filter thread: %s: Cannot av_buffersrc_parameters_set (%d)", __FUNCTION__, ret);
 
 	av_free(par);
 
 	ret = avfilter_graph_create_filter(&m_pBuffersinkCtx, buffersink, "out", NULL, NULL, m_pFilterGraph);
-	if (ret < 0) {
-		LOGERROR("filter thread: %s: Cannot create buffer sink (%d)", __FUNCTION__, ret);
-		avfilter_graph_free(&m_pFilterGraph);
-		return -1;
-	}
+	if (ret < 0)
+		LOGFATAL("filter thread: %s: Cannot create buffer sink (%d)", __FUNCTION__, ret);
 
 	if (frame->format != AV_PIX_FMT_DRM_PRIME) {
 		enum AVPixelFormat pixFmts[] = { AV_PIX_FMT_NV12, AV_PIX_FMT_NONE };
 		ret = av_opt_set_int_list(m_pBuffersinkCtx, "pix_fmts", pixFmts, AV_PIX_FMT_NONE, AV_OPT_SEARCH_CHILDREN);
-		if (ret < 0) {
-			LOGERROR("filter thread: %s: Cannot set output pixel format (%d)", __FUNCTION__, ret);
-			avfilter_graph_free(&m_pFilterGraph);
-			return -1;
-		}
+		if (ret < 0)
+			LOGFATAL("filter thread: %s: Cannot set output pixel format (%d)", __FUNCTION__, ret);
 	}
 
 	AVFilterInOut *outputs = avfilter_inout_alloc();
@@ -352,19 +311,14 @@ int cFilterThread::Init(const AVCodecContext *videoCtx, AVFrame *frame, int user
 	avfilter_inout_free(&outputs);
 
 	if (ret < 0) {
-		LOGERROR("filter thread: %s: avfilter_graph_parse_ptr failed (%d)", __FUNCTION__, ret);
-		avfilter_graph_free(&m_pFilterGraph);
-		return -1;
+		LOGFATAL("filter thread: %s: avfilter_graph_parse_ptr failed (%d)", __FUNCTION__, ret);
 	}
 
 	ret = avfilter_graph_config(m_pFilterGraph, NULL);
-	if (ret < 0) {
-		LOGERROR("filter thread: %s: avfilter_graph_config failed (%d)", __FUNCTION__, ret);
-		avfilter_graph_free(&m_pFilterGraph);
-		return -1;
-	}
+	if (ret < 0)
+		LOGFATAL("filter thread: %s: avfilter_graph_config failed (%d)", __FUNCTION__, ret);
 
-	return 0;
+	Start();
 }
 
 void cFilterThread::Action(void)
@@ -470,8 +424,6 @@ void cFilterThread::Stop(void)
 	LOGDEBUG("threads: stopping filter thread");
 	Cancel(2);
 	m_filterBug = false;
-	m_filterTrick = false;
-	m_filterStill = false;
 	m_pRender->ClearFramesToFilter();
 
 	while (!m_frames.Empty()) {

--- a/threads.cpp
+++ b/threads.cpp
@@ -216,14 +216,15 @@ cFilterThread::~cFilterThread(void)
 /**
  * Init the video filter
  *
- * @param videoCtx      codec context
- * @param frame         AVFrame to take init parameters from
- * @param disabled      true, if deinterlacer is disabled
+ * @param videoCtx                     codec context
+ * @param frame                        AVFrame to take init parameters from
+ * @param userDisabledDeinterlacer     true, if the deinterlacer was disabled by the user
+ * @param forceDeinterlacerDisabled    true, if deinterlacer shall be forced disabled (trick speed or still picture)
  *
- * @returns 0           on success
+ ** @returns 0           on success
  * @return 1            on failure, filter was not initiated
  */
-int cFilterThread::Init(const AVCodecContext *videoCtx, AVFrame *frame, int disabled)
+int cFilterThread::Init(const AVCodecContext *videoCtx, AVFrame *frame, int userDisabledDeinterlacer, bool forceDeinterlacerDisabled)
 {
 	int ret;
 	char args[512];
@@ -254,7 +255,7 @@ int cFilterThread::Init(const AVCodecContext *videoCtx, AVFrame *frame, int disa
 	if (videoCtx->codec_id == AV_CODEC_ID_HEVC)
 		interlaced = false;
 
-	if (disabled) {
+	if (userDisabledDeinterlacer) {
 		if (interlaced)
 			LOGDEBUG2(L_CODEC, "filter thread: %s: Deinterlacer wanted, but disabled in setup!", __FUNCTION__);
 		interlaced = false;
@@ -264,7 +265,7 @@ int cFilterThread::Init(const AVCodecContext *videoCtx, AVFrame *frame, int disa
 	// interlaced and non-trickspeed AV_PIX_FMT_YUV420P (software decoded) -> software deinterlacer
 	// progressive and trickspeed AV_PIX_FMT_YUV420P (software decoded) -> scale filter (for NV12 output)
 	// progressive and trickspeed AV_PIX_FMT_DRM_PRIME (hardware decoded) doesn't get to the FilterHandlerThread
-	if (interlaced && !(m_pRender->IsTrickspeedFrame(frame) || m_pRender->IsStillpictureFrame(frame))) {
+	if (interlaced && !forceDeinterlacerDisabled) {
 		if (frame->format == AV_PIX_FMT_DRM_PRIME) {
 			filterDescr = "deinterlace_v4l2m2m";
 			m_isInterlaceFilter = true;
@@ -275,11 +276,8 @@ int cFilterThread::Init(const AVCodecContext *videoCtx, AVFrame *frame, int disa
 		}
 	} else if (frame->format == AV_PIX_FMT_YUV420P) {
 		filterDescr = "scale";
-		if (m_pRender->IsTrickspeedFrame(frame))
-			m_filterTrick = true;
-		if (m_pRender->IsStillpictureFrame(frame))
-			m_filterStill = true;
-	}
+	} else
+		LOGFATAL("filter thread: %s: Unexpected pixel format: %d", __FUNCTION__, frame->format);
 #if LIBAVFILTER_VERSION_INT < AV_VERSION_INT(7,16,100)
 	avfilter_register_all();
 #endif
@@ -411,12 +409,6 @@ void cFilterThread::Action(void)
 				av_frame_free(&filtFrame);
 				break;
 			}
-
-			// set flag of the filtered frame (scale filter and AV_PIX_FMT_YUV420P)
-			if (m_filterTrick)
-				m_pRender->MarkAsTrickspeedFrame(filtFrame);
-			if (m_filterStill)
-				m_pRender->MarkAsStillpictureFrame(filtFrame);
 
 			// put frame into display queue
 			enqueued = 0;

--- a/threads.h
+++ b/threads.h
@@ -103,11 +103,10 @@ class cFilterThread : public cThread
 public:
 	cFilterThread(cVideoRender *);
 	virtual ~cFilterThread(void);
-	int Init(const AVCodecContext *, AVFrame *, int, bool);
+	void InitAndStart(const AVCodecContext *, AVFrame *, bool);
 	void Stop(void);
 	int GetBufferFrameCount(void);
 	bool PushFrame(AVFrame *);
-	bool IsInterlaceFilter(void) { return m_isInterlaceFilter; };
 
 private:
 	cVideoRender *m_pRender;
@@ -116,10 +115,7 @@ private:
 	AVFilterContext *m_pBuffersrcCtx;
 	AVFilterContext *m_pBuffersinkCtx;
 
-	bool m_filterBug;                           ///< flag for a ffmpeg bug
-	bool m_filterTrick;                         ///< the current filter handles trickspeed frames
-	bool m_filterStill;                         ///< the current filter handles stillpicture frames
-	bool m_isInterlaceFilter;                   ///< the current filter is an deinterlace filter
+	bool m_filterBug;                             ///< flag for a ffmpeg bug
 
 	cQueue<AVFrame> m_frames{VIDEO_SURFACES_MAX}; ///< queue for frames to be filtered
 

--- a/threads.h
+++ b/threads.h
@@ -103,7 +103,7 @@ class cFilterThread : public cThread
 public:
 	cFilterThread(cVideoRender *);
 	virtual ~cFilterThread(void);
-	int Init(const AVCodecContext *, AVFrame *, int);
+	int Init(const AVCodecContext *, AVFrame *, int, bool);
 	void Stop(void);
 	int GetBufferFrameCount(void);
 	bool PushFrame(AVFrame *);

--- a/videorender.cpp
+++ b/videorender.cpp
@@ -514,30 +514,6 @@ void cVideoRender::SetFrameFlags(AVFrame *frame, int flags)
 }
 
 /**
- * Check, if this is a trickspeed frame
- *
- * @param frame    AVFrame
- *
- * @return         true, if this frame is marked as a trickspeed frame
- */
-bool cVideoRender::IsTrickspeedFrame(AVFrame *frame)
-{
-	return GetFrameFlags(frame) & FRAME_FLAG_TRICKSPEED;
-}
-
-/**
- * Check, if this is a stillpicture frame
- *
- * @param frame    AVFrame
- *
- * @return         true, if this frame is marked as a stillpicture frame
- */
-bool cVideoRender::IsStillpictureFrame(AVFrame *frame)
-{
-	return GetFrameFlags(frame) & FRAME_FLAG_STILLPICTURE;
-}
-
-/**
  * Check, if this is an interlaced frame
  *
  * @param frame    AVFrame
@@ -566,43 +542,6 @@ bool cVideoRender::IsKeyFrame(AVFrame *frame)
 	return frame->key_frame;
 #else
 	return frame->flags & AV_FRAME_FLAG_KEY;
-#endif
-}
-
-/**
- * Mark this frame as a trickspeed frame
- *
- * @param frame      AVFrame
- */
-void cVideoRender::MarkAsTrickspeedFrame(AVFrame *frame)
-{
-	SetFrameFlags(frame, FRAME_FLAG_TRICKSPEED);
-	MarkAsProgressiveFrame(frame);
-}
-
-/**
- * Mark this frame as a stillpicture frame
- *
- * @param frame     AVFrame
- */
-void cVideoRender::MarkAsStillpictureFrame(AVFrame *frame)
-{
-	SetFrameFlags(frame, FRAME_FLAG_STILLPICTURE);
-	frame->pts = AV_NOPTS_VALUE;
-	MarkAsProgressiveFrame(frame);
-}
-
-/**
- * Force this frame to be a progressive frame
- *
- * @param frame     AVFrame
- */
-void cVideoRender::MarkAsProgressiveFrame(AVFrame *frame)
-{
-#if LIBAVUTIL_VERSION_INT < AV_VERSION_INT(58,7,100)
-	frame->interlaced_frame = 0;
-#else
-	frame->flags &= ~AV_FRAME_FLAG_INTERLACED;
 #endif
 }
 
@@ -661,7 +600,7 @@ cDrmBuffer *cVideoRender::GetBuffer(AVFrame *frame)
 		return nullptr;
 	}
 
-	buf->SetTrickspeed(IsTrickspeedFrame(frame));
+	buf->SetTrickspeed(GetTrickSpeed());
 
 	return buf;
 }
@@ -807,7 +746,7 @@ void cVideoRender::DisplayFrame(AVFrame *frame)
 		PageFlipVideo(frame, buf);
 
 		if (m_pCurrentlyDisplayed && m_pCurrentlyDisplayed != buf) { // do not destroy the frame, if it is displayed again
-			if (IsTrickspeedFrame(m_pCurrentlyDisplayed->Frame()) || m_destroyCurrentlyDisplayed) {
+			if (GetTrickSpeed() || m_destroyCurrentlyDisplayed) {
 				m_pCurrentlyDisplayed->Destroy();
 
 				m_destroyCurrentlyDisplayed = false;
@@ -1015,7 +954,7 @@ void cVideoRender::EnqueueFB(AVFrame *inframe)
 	AVFrame *frame;
 	int i;
 
-	if (IsTrickspeedFrame(inframe)) {	// if we have trickspeed, always use a free buffer, because its destroyed in DisplayFrame after rendering
+	if (GetTrickSpeed()) {	// if we have trickspeed, always use a free buffer, because its destroyed in DisplayFrame after rendering
 		for (i = 0; i < RENDERBUFFERS; i++) {
 			if (!m_buffer[i].IsDirty())
 				break;
@@ -1080,11 +1019,6 @@ void cVideoRender::EnqueueFB(AVFrame *inframe)
 	frame->sample_aspect_ratio.num = inframe->sample_aspect_ratio.num;
 	frame->sample_aspect_ratio.den = inframe->sample_aspect_ratio.den;
 
-	if (IsTrickspeedFrame(inframe))
-		MarkAsTrickspeedFrame(frame);
-	if (IsStillpictureFrame(inframe))
-		MarkAsStillpictureFrame(frame);
-
 	primedata = (AVDRMFrameDescriptor *)av_mallocz(sizeof(AVDRMFrameDescriptor));
 	primedata->objects[0].fd = buf->FdPrime(0);
 	frame->data[0] = (uint8_t *)primedata;
@@ -1095,7 +1029,7 @@ void cVideoRender::EnqueueFB(AVFrame *inframe)
 	RbPushFrame(frame);
 	FramesRbUnlock();
 
-	if (!(IsTrickspeedFrame(inframe)))
+	if (!GetTrickSpeed())
 		m_enqueueBufferIdx = (m_enqueueBufferIdx + 1) % (VIDEO_SURFACES_MAX + 2);
 
 	av_frame_free(&inframe);
@@ -1126,9 +1060,11 @@ void cVideoRender::RenderFrame(AVCodecContext * videoCtx, AVFrame * frame)
 	}
 
 	bool interlaced = IsInterlacedFrame(frame);
-	// we can't trust frame->interlaced_frame ...
-	// do some tricks in normal playback
-	if (!(IsTrickspeedFrame(frame) || IsStillpictureFrame(frame))) {
+	if (m_deinterlacerDeactivated) {
+		interlaced = false;
+	} else {
+		// we can't trust frame->interlaced_frame ...
+		// do some tricks in normal playback
 
 		// framerate available -> set the interlaced switch depending on the framerate
 		if ((videoCtx->framerate.num > 0) &&
@@ -1165,7 +1101,7 @@ void cVideoRender::RenderFrame(AVCodecContext * videoCtx, AVFrame * frame)
 		// -> put the frame into filter Rb
 		if (!m_pFilterThread->Active()) {
 			LOGDEBUG("videorender: %s: wakeup filter thread", __FUNCTION__);
-			if (m_pFilterThread->Init(videoCtx, frame, m_deintDisabled)) {
+			if (m_pFilterThread->Init(videoCtx, frame, m_deintDisabled, m_deinterlacerDeactivated)) {
 				av_frame_free(&frame);
 				return;
 			} else {

--- a/videorender.cpp
+++ b/videorender.cpp
@@ -769,16 +769,8 @@ void cVideoRender::DisplayFrame(AVFrame *frame)
 		m_framePresentationCounter = std::max(1, GetTrickSpeed());
 
 	if (frame) {
-		if (frame->pts == AV_NOPTS_VALUE && !IsStillpictureFrame(frame)) {
-			// we have no valid pts and it's no stillpicture
-			LOGDEBUG2(L_DRM, "videorender: %s: no AV_NOPTS_VALUE, use next frame ...", __FUNCTION__);
-			av_frame_free(&frame);
-
-			return;
-		}
-
 		// sync audio/video
-		if (!GetTrickSpeed() && !m_destroyCurrentlyDisplayed && !m_playbackPaused) {
+		if (!GetTrickSpeed() && !m_destroyCurrentlyDisplayed && !m_playbackPaused && frame->pts != AV_NOPTS_VALUE) {
 			int64_t audioPts;
 			int64_t videoPts;
 

--- a/videorender.cpp
+++ b/videorender.cpp
@@ -126,7 +126,6 @@ void cVideoRender::Prepare(void)
 	m_pFilterThread = new cFilterThread(this);
 
 	atomic_set(&m_framesFilled, 0);
-	m_deintDisabled = m_configDeintDisabled;
 	m_enqueueBufferIdx = 0;
 }
 
@@ -926,6 +925,15 @@ void cVideoRender::ExitDisplayThread(void)
 	if (m_pDisplayThread->Active())
 		m_pDisplayThread->Stop();
 }
+/**
+ * Stop filter thread
+ */
+void cVideoRender::CancelFilterThread(void) {
+	if (m_pFilterThread->Active())
+		m_pFilterThread->Stop();
+
+	m_checkFilterThreadNeeded = true;
+}
 
 /**
  * Callback free primedata if av_buffer is unreferenced
@@ -1043,76 +1051,59 @@ void cVideoRender::EnqueueFB(AVFrame *inframe)
  * - are pushed directly in the render ringbuffer or
  * - go via EnqueueFB to the render ringbuffer if the buffer has to be prepared before.
  *
- * @param videoCtx   ffmpeg video codec context
- * @param frame       frame to render
+ * @param videoCtx      ffmpeg video codec context
+ * @param frame         frame to render
  */
 void cVideoRender::RenderFrame(AVCodecContext * videoCtx, AVFrame * frame)
 {
-	if (!m_startCounter) {
-		m_timebaseMutex.Lock();
-		m_timebase.num = videoCtx->pkt_timebase.num;
-		m_timebase.den = videoCtx->pkt_timebase.den;
-		m_timebaseMutex.Unlock();
-	}
-
-	if (frame->decode_error_flags || frame->flags & AV_FRAME_FLAG_CORRUPT) {
+	if (frame->decode_error_flags || frame->flags & AV_FRAME_FLAG_CORRUPT)
 		LOGWARNING("videorender: %s: error_flag or FRAME_FLAG_CORRUPT", __FUNCTION__);
+
+	if (m_checkFilterThreadNeeded) {
+		m_timebaseMutex.Lock();
+		m_timebase = videoCtx->pkt_timebase;
+		m_timebaseMutex.Unlock();
+
+		// Enable the deinterlacer only if:
+		// - The user did not disable the deinterlacer
+		// - The deinterlacer is not temporarily deactivated (trickspeed and still picture)
+		// - A hardware quirk does not forbid using the deinterlacer
+		// - It is an interlaced stream, determined by:
+		//   - The codec is different from HEVC (always progressive)
+		//   - The framerate is lower or equal to 30fps
+		//   - Or, if the frame's interlaced flag is set
+		// We cannot solely rely on the frame's interlaced flag, because the deinterlacer shall also be enabled with mixed progressive/interlaced streams (e.g. TV station "ProSieben").
+
+		bool interlacedStream =
+			(videoCtx->codec_id != AV_CODEC_ID_HEVC &&
+			videoCtx->framerate.num > 0 &&
+			av_q2d(videoCtx->framerate) < 30.1) || IsInterlacedFrame(frame); // account for rounding errors when comparing double
+
+		bool useDeinterlacer =
+			!m_userDisabledDeinterlacer &&
+			!m_deinterlacerDeactivated &&
+			!(m_hardwareQuirks & QUIRK_NO_HW_DEINT) &&
+			interlacedStream;
+
+		m_pDevice->VideoStream()->SetInterlaced(interlacedStream);
+
+		if (m_userDisabledDeinterlacer)
+			LOGDEBUG("videorender: %s: deinterlacer disabled by user configuration", __FUNCTION__);
+
+		// Use the filter thread if:
+		// - AV_PIX_FMT_YUV420P, interlaced -> software deinterlacer (bwdif filter)
+		// - AV_PIX_FMT_YUV420P, progressive -> scale filter to get NV12 frames
+		// - AV_PIX_FMT_DRM_PRIME, interlaced, hw deinterlacer available -> hw deinterlacer
+		if (frame->format == AV_PIX_FMT_YUV420P || (frame->format == AV_PIX_FMT_DRM_PRIME && useDeinterlacer))
+			m_pFilterThread->InitAndStart(videoCtx, frame, useDeinterlacer);
+
+		m_checkFilterThreadNeeded = false;
 	}
 
-	bool interlaced = IsInterlacedFrame(frame);
-	if (m_deinterlacerDeactivated) {
-		interlaced = false;
-	} else {
-		// we can't trust frame->interlaced_frame ...
-		// do some tricks in normal playback
-
-		// framerate available -> set the interlaced switch depending on the framerate
-		if ((videoCtx->framerate.num > 0) &&
-		    (videoCtx->framerate.num / videoCtx->framerate.den > 30)) {    // framerate > 30fps -> progressive stream
-			interlaced = false;
-		} else if (videoCtx->framerate.num > 0 && !interlaced) {           // framerate <= 30fps -> interlaced stream
-//			LOGWARNING("videorender: %s: WARNING!!! progressive frame arrived in interlaced stream (P %d)!",
-//				__FUNCTION__, ++m_numWrongProgressive);
-			interlaced = true;
-		}
-
-		// framerate not available -> set the interlaced switch depending on an active deinterlace filter
-		// this doesn't work, if the first frame is wrong, because it should init the filter!
-		if ((videoCtx->framerate.num == 0) && !interlaced &&
-		     m_pFilterThread->Active() && m_pFilterThread->IsInterlaceFilter()) {
-//			LOGWARNING("videorender: %s: WARNING!!! frame without interlaced flag arrived while deinterlace filter is active (P %d)!",
-//				__FUNCTION__, ++m_numWrongProgressive);
-			interlaced = true;
-		}
-
-		// hevc is always progressive
-		if (videoCtx->codec_id == AV_CODEC_ID_HEVC)
-			interlaced = false;
-
-		m_pDevice->VideoStream()->SetInterlaced(interlaced);
-	}
-
-	if (frame->format == AV_PIX_FMT_YUV420P ||
-	   (frame->format == AV_PIX_FMT_DRM_PRIME && interlaced && !((m_hardwareQuirks & QUIRK_NO_HW_DEINT) || m_deintDisabled))) {
-		// use deinterlace/scale filter
-		// AV_PIX_FMT_YUV420P, interlaced -> software deinterlacer (bwdif filter)
-		// AV_PIX_FMT_YUV420P, progressive -> scale filter to get NV12 frames
-		// AV_PIX_FMT_DRM_PRIME, interlaced, hw deinterlacer available -> hw deinterlacer
-		// -> put the frame into filter Rb
-		if (!m_pFilterThread->Active()) {
-			LOGDEBUG("videorender: %s: wakeup filter thread", __FUNCTION__);
-			if (m_pFilterThread->Init(videoCtx, frame, m_deintDisabled, m_deinterlacerDeactivated)) {
-				av_frame_free(&frame);
-				return;
-			} else {
-				m_pFilterThread->Start();
-			}
-		}
-
+	if (m_pFilterThread->Active()) {
 		if (!m_pFilterThread->PushFrame(frame))
 			LOGFATAL("Filter buffer full. This is a bug.");
 	} else {
-		// don't use deinterlace/scale filter
 		if (frame->format == AV_PIX_FMT_DRM_PRIME) {
 			// AV_PIX_FMT_DRM_PRIME, interlaced, hw deinterlacer not available
 			// AV_PIX_FMT_DRM_PRIME, progressive
@@ -1125,18 +1116,8 @@ void cVideoRender::RenderFrame(AVCodecContext * videoCtx, AVFrame * frame)
 				FramesRbUnlock();
 				return;
 			}
-		} else {
-			// AV_PIX_FMT_DRM_NV12 ?
-			// -> go through EnqueueFB
-			FramesRbLock();
-			if (atomic_read(&m_framesFilled) < VIDEO_SURFACES_MAX) {
-				FramesRbUnlock();
-				EnqueueFB(frame);
-			} else {
-				FramesRbUnlock();
-				return;
-			}
-		}
+		} else
+			LOGFATAL("videorender: %s: unsupported pixel format %d", __FUNCTION__, frame->format);
 	}
 }
 
@@ -1223,6 +1204,7 @@ int64_t cVideoRender::GetVideoClock(void)
 void cVideoRender::ResetFrameCounter(void)
 {
 	m_startCounter = 0;
+	m_checkFilterThreadNeeded = true;
 	LOGDEBUG("videorender: %s: reset m_startCounter %d TrickSpeed %d", __FUNCTION__, m_startCounter, GetTrickSpeed());
 }
 
@@ -1232,8 +1214,6 @@ void cVideoRender::Reset()
 	m_framesDuped = 0;
 	m_framesDropped = 0;
 	m_numWrongProgressive = 0;
-
-	m_deintDisabled = m_configDeintDisabled;
 }
 
 /**

--- a/videorender.h
+++ b/videorender.h
@@ -83,7 +83,7 @@ public:
 	void Init(void);
 	void Exit(void);
 	int HardwareQuirks(void) { return m_hardwareQuirks; };
-	void DisableDeint(bool disable) { m_configDeintDisabled = disable; };
+	void DisableDeint(bool disable) { m_userDisabledDeinterlacer = disable; };
 	void DisableOglOsd(void) { m_disableOglOsd = true; };
 	bool OglOsdDisabled(void) { return m_disableOglOsd; };
 
@@ -128,7 +128,7 @@ public:
 	void DisplayThreadHalt(void) { m_pDisplayThread->Halt(); };
 	void DisplayThreadResume(void) { m_pDisplayThread->Resume(); };
 
-	void CancelFilterThread(void) { if (m_pFilterThread->Active()) m_pFilterThread->Stop(); };
+	void CancelFilterThread(void);
 
 	// DRM
 	int DrmHandleEvent(void);
@@ -185,13 +185,12 @@ private:
 	int m_framePresentationCounter = 0; ///< number of times the current frame has to be shown (for slow motion)
 
 	int m_numFramesToFilter;            ///< number of frames to be filtered
-	bool m_deintDisabled;               ///< set, if deinterlacer is disabled - used in RenderFrame()
-	bool m_configDeintDisabled = false; ///< set, if a deinterlacer on/off should be triggered
-	                                    ///< Prepare() and Cleanup() sets m_deintDisabled depending upon m_configDeintDisabled
+	bool m_userDisabledDeinterlacer = false; ///< set, if the user configured the deinterlace to be disabled
 	                                    ///< That way, we don't change the current render pipeline (RenderFrame())
 	int m_numWrongProgressive;          ///< counter for progressive frames sent in an interlaced stream
 	                                    ///< (only used for logging)
 	bool m_deinterlacerDeactivated;		///< set, if the deinterlacer shall be deactivated temporarily (used for trick speed and still picture)
+	bool m_checkFilterThreadNeeded;     ///< set, if we have to check, if filter thread is needed at start of playback
 
 	bool m_disableOglOsd;               ///< set, if ogl osd is disabled
 

--- a/videorender.h
+++ b/videorender.h
@@ -69,10 +69,6 @@ extern "C" {
 #define QUIRK_CODEC_DISABLE_MPEG_HW     1 << 4     ///< set, if disable mpeg hardware decoder
 #define QUIRK_CODEC_DISABLE_H264_HW     1 << 5     ///< set, if disable h264 hardware decoder
 
-// frame flags
-#define FRAME_FLAG_TRICKSPEED           1 << 0     ///< mark frame as a trickspeed frame
-#define FRAME_FLAG_STILLPICTURE         1 << 1     ///< mark frame as a stillpicture frame
-
 class cDrmDevice;
 
 /**
@@ -100,6 +96,8 @@ public:
 	void Reset();
 	void SetPlaybackPaused(bool pause) { m_playbackPaused = pause; };
 	bool IsPlaybackPaused(void) { return m_playbackPaused; };
+	void SetDeinterlacerDeactivated(bool deactivate) { m_deinterlacerDeactivated = deactivate; };
+	bool IsDeinterlacerDeactivated(void) { return m_deinterlacerDeactivated; };
 
 	// OSD
 	void OsdClear(void);
@@ -144,12 +142,8 @@ public:
 	AVFrame *RbGetFrame(void);
 	void FramesRbLock(void);
 	void FramesRbUnlock(void);
-	bool IsTrickspeedFrame(AVFrame *);
-	bool IsStillpictureFrame(AVFrame *);
 	bool IsInterlacedFrame(AVFrame *);
 	bool IsKeyFrame(AVFrame *);
-	void MarkAsTrickspeedFrame(AVFrame *);
-	void MarkAsStillpictureFrame(AVFrame *);
 	void ScheduleDisplayBlackFrame(void) { m_displayBlackFrame = true; };
 	void DestroyFrameBuffers(void);
 	void ClearDecoderToDisplayQueue(void);
@@ -197,6 +191,7 @@ private:
 	                                    ///< That way, we don't change the current render pipeline (RenderFrame())
 	int m_numWrongProgressive;          ///< counter for progressive frames sent in an interlaced stream
 	                                    ///< (only used for logging)
+	bool m_deinterlacerDeactivated;		///< set, if the deinterlacer shall be deactivated temporarily (used for trick speed and still picture)
 
 	bool m_disableOglOsd;               ///< set, if ogl osd is disabled
 
@@ -235,7 +230,6 @@ private:
 #endif
 	int GetFrameFlags(AVFrame *);
 	void SetFrameFlags(AVFrame *, int);
-	void MarkAsProgressiveFrame(AVFrame *);
 	void SetVideoClock(int64_t);
 	bool ShouldWaitForAudio(void);
 	void WaitForAudioReady(int64_t, int64_t);

--- a/videostream.cpp
+++ b/videostream.cpp
@@ -261,8 +261,6 @@ void cVideoStream::DecodeInput(void)
 	// send packet to decoder
 	AVPacket *avpkt = m_packets.Peek();
 
-	bool flushStillPictureImmediately = avpkt == nullptr;
-
 	ret = m_pDecoder->SendPacket(avpkt);
 
 	if (ret != AVERROR(EAGAIN)) {
@@ -281,15 +279,8 @@ void cVideoStream::DecodeInput(void)
 
 	// receive frame from decoder
 	if (!m_newStream) { // this is for mediaplayer?
-		if (m_pDecoder->ReceiveFrame(&frame) == 0) {
-			if (m_pRender->GetTrickSpeed())
-				m_pRender->MarkAsTrickspeedFrame(frame);
-
-			if (flushStillPictureImmediately)
-				m_pRender->MarkAsStillpictureFrame(frame);
-
+		if (m_pDecoder->ReceiveFrame(&frame) == 0)
 			m_pRender->RenderFrame(m_pDecoder->GetContext(), frame);
-		}
 	}
 
 	if (m_pRender->GetTrickSpeed() && ret == AVERROR_EOF) { // needs flush / reopen

--- a/videostream.h
+++ b/videostream.h
@@ -70,7 +70,6 @@ public:
 	size_t GetAvPacketsFilled(void) { return m_packets.Size(); };
 	enum AVCodecID GetCodecId(void) { return m_codecId; };
 	void ResetTrickSpeedFramesSentCounter(void) { m_sentTrickPkts = 0; };
-	void SetStillPicture(bool still) { m_stillPicture = still; };
 
 private:
 	cVideoDecoder *m_pDecoder;             ///< video decoder
@@ -88,7 +87,6 @@ private:
 
 	volatile bool m_newStream;             ///< flag for new stream
 	bool m_interlaced;                     ///< flag for interlaced stream
-	bool m_stillPicture;                   ///< flag for still picture
 };
 
 #endif

--- a/videostream.h
+++ b/videostream.h
@@ -70,6 +70,7 @@ public:
 	size_t GetAvPacketsFilled(void) { return m_packets.Size(); };
 	enum AVCodecID GetCodecId(void) { return m_codecId; };
 	void ResetTrickSpeedFramesSentCounter(void) { m_sentTrickPkts = 0; };
+	void SetStillPicture(bool still) { m_stillPicture = still; };
 
 private:
 	cVideoDecoder *m_pDecoder;             ///< video decoder
@@ -87,8 +88,7 @@ private:
 
 	volatile bool m_newStream;             ///< flag for new stream
 	bool m_interlaced;                     ///< flag for interlaced stream
-	cCondVar m_closeCondition;             ///< condition object to wait for finishing jobs while closing
-	cCondVar m_pauseCondition;             ///< condition object to wait for pausing the stream
+	bool m_stillPicture;                   ///< flag for still picture
 };
 
 #endif


### PR DESCRIPTION
This fixes StillPicture() for purely interlaced streams.

The filter thread is now always restarted when entering or leaving the trick speed state. This is necessary to deactivate the deinterlacer in trick speed, and activate it again when resuming to normal playback.

It is also started with the desired parameters, instead of checking frame markings.

The video path `decoder -> NV12 -> display output device` was removed as discussed here #101.

I changed the behavior of frames without PTS arriving in DisplayFrame(). These frames were dropped, now they are displayed, but the A/V sync is just skipped. I never saw this message, anyway?

Tested with:
- 720p H.264 (SW)
- 1080i H.264 (SW)
- 576i MPEG2 mixed progressive/interlaced frames (SW)
- 576i MPEG2 purely interlaced (SW)
- 1080p HEVC (HW)

Fixes #97