### PR TITLE
Fix uninitilized

### DIFF
--- a/videorender.h
+++ b/videorender.h
@@ -189,7 +189,7 @@ private:
 	                                    ///< That way, we don't change the current render pipeline (RenderFrame())
 	int m_numWrongProgressive;          ///< counter for progressive frames sent in an interlaced stream
 	                                    ///< (only used for logging)
-	bool m_deinterlacerDeactivated;		///< set, if the deinterlacer shall be deactivated temporarily (used for trick speed and still picture)
+	bool m_deinterlacerDeactivated = false; ///< set, if the deinterlacer shall be deactivated temporarily (used for trick speed and still picture)
 	bool m_checkFilterThreadNeeded;     ///< set, if we have to check, if filter thread is needed at start of playback
 
 	bool m_disableOglOsd;               ///< set, if ogl osd is disabled


### PR DESCRIPTION
==17919== Conditional jump or move depends on uninitialised value(s)
==17919==    at 0x5CEB370: cVideoRender::RenderFrame(AVCodecContext*, AVFrame*) (videorender.cpp:1083)
==17919==    by 0x5CEE147: cVideoStream::DecodeInput() (videostream.cpp:283)
==17919==    by 0x5CE611F: cDecodingThread::Action() (threads.cpp:62)
==17919==    by 0x2DE67B: cThread::StartThread(cThread*) (thread.c:294)
==17919==    by 0x4F4202F: start_thread (pthread_create.c:442)
==17919==    by 0x4FABF5B: thread_start (clone.S:79)