### PR TITLE
Wip/detach v10

### DIFF
--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -94,25 +94,32 @@ This is the model of the state machine implemented in softhddevice.cpp.
 
 ```mermaid
 stateDiagram-v2
-    [*] --> Stop: Initialize
+    [*] --> Detached: Initialize
+
+    Detached --> Stop: AttachEvent
 
     Stop --> Play: PlayEvent
+    Stop --> Detached: DetachEvent
 
     Play --> TrickSpeed: TrickSpeedEvent
     Play --> Stop: StopEvent
     Play --> Play: PauseEvent/StillPictureEvent
+    Play --> Detached: DetachEvent
 
     TrickSpeed --> Play: PlayEvent
     TrickSpeed --> Stop: StopEvent
     TrickSpeed --> TrickSpeed: PauseEvent/StillPictureEvent
+    TrickSpeed --> Detached: DetachEvent
 
     classDef stopState fill:#e57373,stroke:#d32f2f,stroke-width:2px,color:#000
     classDef playState fill:#81c784,stroke:#388e3c,stroke-width:2px,color:#000
     classDef trickspeedState fill:#64b5f6,stroke:#1976d2,stroke-width:2px,color:#000
+    classDef detachState fill:#fd00fd,stroke:#ca00ca,stroke-width:2px,color:#000
 
     class Stop stopState
     class Play playState
     class TrickSpeed trickspeedState
+    class Detached detachState
 ```
 
 ## Video Data Flow Call Graph

--- a/README.md
+++ b/README.md
@@ -7,16 +7,16 @@ A software and GPU emulated HD output device for VDR
 
 Why do we need another softhddevice version?
 --------------------------------------------
-This is basically a fork of https://github.com/zillevdr/vdr-plugin-softhddevice-drm.git
-and is aimed to merge all upstream commits back again - if possible.
+This was basically a fork of https://github.com/zillevdr/vdr-plugin-softhddevice-drm.git
+but has received major rewrites across most of the code.
 
 The target of this version are embedded devices, see supported hardware.
 
-The difference to the original fork is, that it adds some additional features like
-resized video, hardware accelerated OSD rendering, support for Rpi4/5 and Amlogic
-devices and a few more things. Read the commit history for detailed info.
-There are a bunch of changes in the code, especially the drm handling was re-written and has
-changed a bit to fully respect the atomic modesetting API now. Though everything should work
+The difference in function to the original fork is, that it adds some additional features
+like resized video, hardware accelerated OSD rendering, support for Rpi4/5 and Amlogic
+devices, detach/attach functionalizy  and a few more things. Read the commit history for detailed
+info. There are a bunch of changes in the code, especially the drm handling was re-written and has
+changed to fully respect the atomic modesetting API now. Though everything should work
 like it does with the original code, it's not guaranteed, that some bugs crept in.
 
 As a principle, this softhddevice version is only dealing with mainline versions and standards,
@@ -24,7 +24,7 @@ which means you can (and have to) use mainline (or to be mainlined) kernel, ffmp
 This code does not work with vendor provided software or even closed source binaries.
 
 www.LibreELEC.tv is good source to look for what is possible with mainlined media related software.
-In the LibreELEC project you can find at least patches all the software, even if some piece of code
+In the LibreELEC project you can find at least patches for all the software, even if some piece of code
 isn't able to be mainlined or simply not already there. Because LibreELEC is a distribution to run
 kodi on, you'll find everything you need.
 

--- a/README.md
+++ b/README.md
@@ -210,9 +210,6 @@ Setup:	environment
 Setup: /etc/vdr/setup.conf
 --------------------------
 
-	softhddevice-drm-gles.MakePrimary = 0
-		0 = no change, 1 make softhddevice primary at start
-
 	softhddevice-drm-gles.HideMainMenuEntry = 0
 		0 = show softhddevice main menu entry, 1 = hide entry
 

--- a/README.md
+++ b/README.md
@@ -64,7 +64,6 @@ In general, any device that provides a DRM/KMS output and is supported by FFmpeg
 
 Known Bugs/ TODO:
 -----------------
-- attach/detach isn't implemented
 - amlogic trickspeed is broken
 - rpi avcodec_flush_buffers is broken in ffmpeg, use a workaround for now
 - see https://github.com/rellla/vdr-plugin-softhddevice-drm-gles/issues
@@ -275,6 +274,11 @@ SVDRP:
 
 	Play a media file from web:
 		svdrpsend plug softhddevice-drm-gles PLAY http://www.media-server/path_to_file/media_file.mp4
+
+	DETA         Detach the plugin.
+		An "ATTA" is needed in order to exit a detached state and to continue playback.
+
+	ATTA         Attach the plugin again.
 
 
 Copyright:

--- a/audio.cpp
+++ b/audio.cpp
@@ -90,6 +90,7 @@ cSoftHdAudio::cSoftHdAudio(cSoftHdDevice *device)
 	m_passthrough = 0;
 	if (m_pConfig->ConfigAudioPassthroughState)
 		m_passthrough = m_pConfig->ConfigAudioPassthroughMask;
+	m_bufferTimeInMs = MIN_AUDIO_BUFFER + m_pConfig->ConfigAudioBufferTime;
 
 	m_paused = false;
 	m_muted = false;

--- a/audio.cpp
+++ b/audio.cpp
@@ -1306,6 +1306,7 @@ void cSoftHdAudio::Exit(void)
 		m_running = false;
 		m_paused = false;
 	}
+	m_initialized = false;
 }
 
 /******************************************************************************

--- a/audio.cpp
+++ b/audio.cpp
@@ -64,21 +64,33 @@ extern "C"
 cSoftHdAudio::cSoftHdAudio(cSoftHdDevice *device)
 {
 	m_pDevice = device;
+	m_pConfig = m_pDevice->Config();
 
-	m_pPassthroughDevice = nullptr;
-	m_pPCMDevice = nullptr;
+	m_pPassthroughDevice = m_pConfig->ConfigAudioPassthroughDevice;
+	m_pPCMDevice = m_pConfig->ConfigAudioPCMDevice;
 
 	m_pFilterGraph = nullptr;
 
 	m_pAlsaMixer = nullptr;
 	m_pMixerDevice = nullptr;
-	m_pMixerChannel = nullptr;
+	m_pMixerChannel = m_pConfig->ConfigAudioMixerChannel;
 	m_pAlsaMixerElem = nullptr;
 
 	m_compressionFactor = 0;
 	m_hwSampleRate = 0;
 	m_hwNumChannels = 0;
-	m_downmix = false;
+
+	m_downmix = m_pConfig->ConfigAudioDownmix;
+	m_softVolume = m_pConfig->ConfigAudioSoftvol;
+	SetNormalize(m_pConfig->ConfigAudioNormalize, m_pConfig->ConfigAudioMaxNormalize);
+	SetCompression(m_pConfig->ConfigAudioCompression, m_pConfig->ConfigAudioMaxCompression);
+	SetStereoDescent(m_pConfig->ConfigAudioStereoDescent);
+	m_appendAES = m_pConfig->ConfigAudioAutoAES;
+	SetEq(m_pConfig->ConfigAudioEqBand, m_pConfig->ConfigAudioEq);
+	m_passthrough = 0;
+	if (m_pConfig->ConfigAudioPassthroughState)
+		m_passthrough = m_pConfig->ConfigAudioPassthroughMask;
+
 	m_paused = false;
 	m_muted = false;
 	m_running = false;
@@ -1250,26 +1262,6 @@ void cSoftHdAudio::SetStereoDescent(int delta)
 }
 
 /**
- * Set pcm audio device.
- *
- * @param device    name of pcm device
- */
-void cSoftHdAudio::SetDevice(const char *device)
-{
-	m_pPCMDevice = device;
-}
-
-/**
- * Set pass-through audio device
- *
- * @param device    name of pass-through device
- */
-void cSoftHdAudio::SetPassthroughDevice(const char *device)
-{
-	m_pPassthroughDevice = device;
-}
-
-/**
  * Set audio passthrough mask
  *
  * @param mask    passthrough mask (as a bitmask)
@@ -1277,16 +1269,6 @@ void cSoftHdAudio::SetPassthroughDevice(const char *device)
 void cSoftHdAudio::SetPassthrough(int mask)
 {
 	m_passthrough = mask;
-}
-
-/**
- * Set pcm audio mixer channel
- *
- * @param channel    name of the mixer channel (e.g. PCM or Master)
- */
-void cSoftHdAudio::SetChannel(const char *channel)
-{
-	m_pMixerChannel = channel;
 }
 
 /**

--- a/audio.h
+++ b/audio.h
@@ -34,6 +34,7 @@ extern "C"
 #define NORMALIZE_MAX_INDEX 128		///< number of average values
 
 class cSoftHdDevice;
+class cSoftHdConfig;
 
 /**
  * cSoftHdAudio - Audio class
@@ -74,10 +75,7 @@ public:
 	void SetNormalize(bool, int);
 	void SetCompression(bool, int);
 	void SetStereoDescent(int);
-	void SetDevice(const char *);
-	void SetPassthroughDevice(const char *);
 	void SetPassthrough(int);
-	void SetChannel(const char *);
 	void SetAutoAES(bool appendAes) { m_appendAES = appendAes; }
 	void SetTimebase(AVRational *timebase) { m_pTimebase = timebase; };
 
@@ -89,6 +87,7 @@ public:
 
 private:
 	cSoftHdDevice *m_pDevice;               ///< pointer to device
+	cSoftHdConfig *m_pConfig;               ///< pointer to config
 
 	// thread
 	cAudioThread *m_pAudioThread;           ///< pointer to audio thread

--- a/codec_audio.cpp
+++ b/codec_audio.cpp
@@ -66,6 +66,8 @@ cAudioDecoder::cAudioDecoder(cSoftHdAudio *audio)
  */
 cAudioDecoder::~cAudioDecoder(void)
 {
+	Close();
+
 	av_frame_free(&m_pFrame);
 }
 

--- a/codec_video.cpp
+++ b/codec_video.cpp
@@ -37,6 +37,8 @@ extern "C" {
 #include "misc.h"
 }
 
+#include <vdr/thread.h>
+
 #include "buf2rgb.h"
 #include "codec_video.h"
 #include "videorender.h"
@@ -179,12 +181,12 @@ static const AVCodec *FindDecoder(enum AVCodecID codecId, int forceSoftwareDecod
 /**
  * cVideoDecoder constructor
  *
- * @param render     pointer to cVideoRender object
+ * @param hardwareQuirks     hardware specific quirks for decoder
  */
-cVideoDecoder::cVideoDecoder(cVideoRender *render)
+cVideoDecoder::cVideoDecoder(int hardwareQuirks)
 {
 	m_pVideoCtx = nullptr;
-	m_pRender = render;
+	m_hardwareQuirks = hardwareQuirks;
 
 	av_log_set_callback(CodecLogCallback);
 
@@ -225,9 +227,9 @@ int cVideoDecoder::Open(enum AVCodecID codecId, AVCodecParameters * par,
 
 	int swcodec = forceSoftwareDecoder;
 
-	if ((m_pRender->HardwareQuirks() & QUIRK_CODEC_DISABLE_MPEG_HW && codecId == AV_CODEC_ID_MPEG2VIDEO))
+	if ((m_hardwareQuirks & QUIRK_CODEC_DISABLE_MPEG_HW && codecId == AV_CODEC_ID_MPEG2VIDEO))
 		swcodec = 1;
-	if ((m_pRender->HardwareQuirks() & QUIRK_CODEC_DISABLE_H264_HW && codecId == AV_CODEC_ID_H264))
+	if ((m_hardwareQuirks & QUIRK_CODEC_DISABLE_H264_HW && codecId == AV_CODEC_ID_H264))
 		swcodec = 1;
 
 	LOGDEBUG2(L_CODEC, "videocodec: %s: Try to open decoder for CodecID %s%s", __FUNCTION__,
@@ -548,10 +550,10 @@ int cVideoDecoder::ReceiveFrame(AVFrame **frame)
 	// codec artifacts workaround for amlogic H264:
 	// skip QUIRK_CODEC_SKIP_NUM_FRAMES key frames
 	if (m_pVideoCtx->codec_id == AV_CODEC_ID_H264 &&
-	   (m_pRender->HardwareQuirks() & QUIRK_CODEC_SKIP_FIRST_FRAMES) && m_cntStartKeyFrames) {
-		if (m_pRender->IsKeyFrame(pFrame)) {
+	   (m_hardwareQuirks & QUIRK_CODEC_SKIP_FIRST_FRAMES) && m_cntStartKeyFrames) {
+		if (IsKeyFrame(pFrame)) {
 			LOGDEBUG2(L_CODEC, "videocodec: %s: artifact workaround - skip %s I-frame nr %d", __FUNCTION__,
-				m_pRender->IsInterlacedFrame(pFrame) ? "interlaced" : "progressive", m_cntStartKeyFrames);
+				IsInterlacedFrame(pFrame) ? "interlaced" : "progressive", m_cntStartKeyFrames);
 
 			if (m_cntStartKeyFrames++ > QUIRK_CODEC_SKIP_NUM_FRAMES - 1)
 				m_cntStartKeyFrames = 0;
@@ -567,7 +569,7 @@ int cVideoDecoder::ReceiveFrame(AVFrame **frame)
 	m_cntFramesReceived++;
 	LOGDEBUG2(L_PACKET, "videocodec: %s: %6d PTS %s --->> (%2d)%s", __FUNCTION__,
 		m_cntFramesReceived, Timestamp2String(pFrame->pts, 90), m_cntPacketsSent - m_cntFramesReceived,
-		m_pRender->IsInterlacedFrame(pFrame) ? " I" : "");
+		IsInterlacedFrame(pFrame) ? " I" : "");
 	m_mutex.Unlock();
 	return 0;
 }
@@ -638,4 +640,36 @@ void cVideoDecoder::GetVideoSize(int *width, int *height, double *aspect_ratio)
 	// TODO: use correct aspect ratio
 	if (m_pVideoCtx->coded_height > 0)
 		*aspect_ratio = (double)(m_pVideoCtx->coded_width) / (double)(m_pVideoCtx->coded_height);
+}
+
+/**
+ * Check, if this is an interlaced frame
+ *
+ * @param frame    AVFrame
+ *
+ * @return         true, if this frame is an interlaced frame
+ */
+bool cVideoDecoder::IsInterlacedFrame(AVFrame *frame)
+{
+#if LIBAVUTIL_VERSION_INT < AV_VERSION_INT(58,7,100)
+	return frame->interlaced_frame;
+#else
+	return frame->flags & AV_FRAME_FLAG_INTERLACED;
+#endif
+}
+
+/**
+ * Check, if this is a key frame
+ *
+ * @param frame    AVFrame
+ *
+ * @return         true, if this frame is a key frame
+ */
+bool cVideoDecoder::IsKeyFrame(AVFrame *frame)
+{
+#if LIBAVUTIL_VERSION_INT < AV_VERSION_INT(58,7,100)
+	return frame->key_frame;
+#else
+	return frame->flags & AV_FRAME_FLAG_KEY;
+#endif
 }

--- a/codec_video.h
+++ b/codec_video.h
@@ -22,21 +22,18 @@
 #define __CODEC_VIDEO_H
 
 #include <pthread.h>
+#include <vdr/thread.h>
 
 extern "C" {
 #include <libavcodec/avcodec.h>
 }
-
-#include "videorender.h"
-
-class cVideoRender;
 
 /**
  * cVideoDecoder - VideoDecoder class
  */
 class cVideoDecoder {
 public:
-	cVideoDecoder(cVideoRender *);
+	cVideoDecoder(int);
 	virtual ~cVideoDecoder(void);
 	int Open(enum AVCodecID, AVCodecParameters *, AVRational *, int, int, int);
 	void Close(void);
@@ -48,7 +45,6 @@ public:
 	AVCodecContext *GetContext(void) { return m_pVideoCtx; };
 
 private:
-	cVideoRender *m_pRender;                ///< video renderer
 	AVCodecContext *m_pVideoCtx = nullptr;  ///< video codec context
 	cMutex m_mutex;                         ///< mutex to lock codec context (TODO: is this needed?)
 	int m_cntPacketsSent;                   ///< number of packets sent to decoder
@@ -58,8 +54,11 @@ private:
 	                                        ///< in ReceiveFrame() before sending them to the renderer)
 	int m_lastCodedWidth;                   ///< save coded width while closing for a directly reopen
 	int m_lastCodedHeight;                  ///< save coded height while closing for a directly reopen
+	int m_hardwareQuirks;                   ///< hardware specific quirks needed for decoder
 
 	int GetExtraData(const AVPacket *);
+	bool IsKeyFrame(AVFrame *);
+	bool IsInterlacedFrame(AVFrame *);
 };
 
 #endif

--- a/config.cpp
+++ b/config.cpp
@@ -44,7 +44,7 @@ cSoftHdConfig::~cSoftHdConfig(void)
  *
  * @returns         true if the parameter is supported, false otherwise
  */
-bool cSoftHdConfig::SetupParse(const char *name, const char *value, cSoftHdDevice *device, cSoftHdAudio *audio)
+bool cSoftHdConfig::SetupParse(const char *name, const char *value)
 {
 	//LOGDEBUG("config: %s: '%s' = '%s'", __FUNCTION__, name, value);
 
@@ -55,53 +55,41 @@ bool cSoftHdConfig::SetupParse(const char *name, const char *value, cSoftHdDevic
 #endif
 #endif
 	} else if (!strcasecmp(name, "HideMainMenuEntry"))     { ConfigHideMainMenuEntry = atoi(value);
-	} else if (!strcasecmp(name, "LogLevel"))              { ConfigLog = abs(atoi(value));
-		                                                     LogState = atoi(value) > 0;
-		                                                     	SetLogState();
+	} else if (!strcasecmp(name, "LogLevel"))              { ConfigLogLevels = abs(atoi(value));
+	                                                         ConfigLogState = atoi(value) > 0;
+                                                                 PrintLogLevel(ConfigLogState ? ConfigLogLevels : 0);
+	                                                         cSoftHdLogger::GetLogger()->SetLogLevel(ConfigLogState ? ConfigLogLevels : 0);
 	} else if (!strcasecmp(name, "DisableDeint"))          { ConfigDisableDeint = atoi(value);
-		                                                     	device->SetDisableDeint();
 	} else if (!strcasecmp(name, "AudioDelay"))            { ConfigVideoAudioDelay = atoi(value);
-		                                                     	device->SetVideoAudioDelay(ConfigVideoAudioDelay);
-	} else if (!strcasecmp(name, "AudioPassthrough"))      { AudioPassthroughState = atoi(value) > 0;
-		                                                     ConfigAudioPassthrough = abs(atoi(value));
-		                                                     	SetPassthrough(device);
+	} else if (!strcasecmp(name, "AudioPassthrough"))      { ConfigAudioPassthroughMask = abs(atoi(value)); ConfigAudioPassthroughState = atoi(value) > 0;
 	} else if (!strcasecmp(name, "AudioDownmix"))          { ConfigAudioDownmix = atoi(value);
-		                                                     	audio->SetDownmix(ConfigAudioDownmix);
-	} else if (!strcasecmp(name, "AudioSoftvol"))          { ConfigAudioSoftvol = atoi(value),
-		                                                     	audio->SetSoftvol(ConfigAudioSoftvol);
+	} else if (!strcasecmp(name, "AudioSoftvol"))          { ConfigAudioSoftvol = atoi(value);
 	} else if (!strcasecmp(name, "AudioNormalize"))        { ConfigAudioNormalize = atoi(value);
-		                                                     	audio->SetNormalize(ConfigAudioNormalize, ConfigAudioMaxNormalize);
 	} else if (!strcasecmp(name, "AudioMaxNormalize"))     { ConfigAudioMaxNormalize = atoi(value);
-		                                                     	audio->SetNormalize(ConfigAudioNormalize, ConfigAudioMaxNormalize);
 	} else if (!strcasecmp(name, "AudioCompression"))      { ConfigAudioCompression = atoi(value);
-		                                                     	audio->SetCompression(ConfigAudioCompression, ConfigAudioMaxCompression);
 	} else if (!strcasecmp(name, "AudioMaxCompression"))   { ConfigAudioMaxCompression = atoi(value);
-		                                                     	audio->SetCompression(ConfigAudioCompression, ConfigAudioMaxCompression);
 	} else if (!strcasecmp(name, "AudioStereoDescent"))    { ConfigAudioStereoDescent = atoi(value);
-		                                                     	audio->SetStereoDescent(ConfigAudioStereoDescent);
 	} else if (!strcasecmp(name, "AudioBufferTime"))       { ConfigAudioBufferTime = atoi(value);
 	} else if (!strcasecmp(name, "AudioAutoAES"))          { ConfigAudioAutoAES = atoi(value);
-		                                                     	audio->SetAutoAES(ConfigAudioAutoAES);
 	} else if (!strcasecmp(name, "AudioEq"))               { ConfigAudioEq = atoi(value);
-	} else if (!strcasecmp(name, "AudioEqBand01b"))        { SetupAudioEqBand[0] = atoi(value);
-	} else if (!strcasecmp(name, "AudioEqBand02b"))        { SetupAudioEqBand[1] = atoi(value);
-	} else if (!strcasecmp(name, "AudioEqBand03b"))        { SetupAudioEqBand[2] = atoi(value);
-	} else if (!strcasecmp(name, "AudioEqBand04b"))        { SetupAudioEqBand[3] = atoi(value);
-	} else if (!strcasecmp(name, "AudioEqBand05b"))        { SetupAudioEqBand[4] = atoi(value);
-	} else if (!strcasecmp(name, "AudioEqBand06b"))        { SetupAudioEqBand[5] = atoi(value);
-	} else if (!strcasecmp(name, "AudioEqBand07b"))        { SetupAudioEqBand[6] = atoi(value);
-	} else if (!strcasecmp(name, "AudioEqBand08b"))        { SetupAudioEqBand[7] = atoi(value);
-	} else if (!strcasecmp(name, "AudioEqBand09b"))        { SetupAudioEqBand[8] = atoi(value);
-	} else if (!strcasecmp(name, "AudioEqBand10b"))        { SetupAudioEqBand[9] = atoi(value);
-	} else if (!strcasecmp(name, "AudioEqBand11b"))        { SetupAudioEqBand[10] = atoi(value);
-	} else if (!strcasecmp(name, "AudioEqBand12b"))        { SetupAudioEqBand[11] = atoi(value);
-	} else if (!strcasecmp(name, "AudioEqBand13b"))        { SetupAudioEqBand[12] = atoi(value);
-	} else if (!strcasecmp(name, "AudioEqBand14b"))        { SetupAudioEqBand[13] = atoi(value);
-	} else if (!strcasecmp(name, "AudioEqBand15b"))        { SetupAudioEqBand[14] = atoi(value);
-	} else if (!strcasecmp(name, "AudioEqBand16b"))        { SetupAudioEqBand[15] = atoi(value);
-	} else if (!strcasecmp(name, "AudioEqBand17b"))        { SetupAudioEqBand[16] = atoi(value);
-	} else if (!strcasecmp(name, "AudioEqBand18b"))        { SetupAudioEqBand[17] = atoi(value);
-		                                                     	audio->SetEq(SetupAudioEqBand, ConfigAudioEq);
+	} else if (!strcasecmp(name, "AudioEqBand01b"))        { ConfigAudioEqBand[0] = atoi(value);
+	} else if (!strcasecmp(name, "AudioEqBand02b"))        { ConfigAudioEqBand[1] = atoi(value);
+	} else if (!strcasecmp(name, "AudioEqBand03b"))        { ConfigAudioEqBand[2] = atoi(value);
+	} else if (!strcasecmp(name, "AudioEqBand04b"))        { ConfigAudioEqBand[3] = atoi(value);
+	} else if (!strcasecmp(name, "AudioEqBand05b"))        { ConfigAudioEqBand[4] = atoi(value);
+	} else if (!strcasecmp(name, "AudioEqBand06b"))        { ConfigAudioEqBand[5] = atoi(value);
+	} else if (!strcasecmp(name, "AudioEqBand07b"))        { ConfigAudioEqBand[6] = atoi(value);
+	} else if (!strcasecmp(name, "AudioEqBand08b"))        { ConfigAudioEqBand[7] = atoi(value);
+	} else if (!strcasecmp(name, "AudioEqBand09b"))        { ConfigAudioEqBand[8] = atoi(value);
+	} else if (!strcasecmp(name, "AudioEqBand10b"))        { ConfigAudioEqBand[9] = atoi(value);
+	} else if (!strcasecmp(name, "AudioEqBand11b"))        { ConfigAudioEqBand[10] = atoi(value);
+	} else if (!strcasecmp(name, "AudioEqBand12b"))        { ConfigAudioEqBand[11] = atoi(value);
+	} else if (!strcasecmp(name, "AudioEqBand13b"))        { ConfigAudioEqBand[12] = atoi(value);
+	} else if (!strcasecmp(name, "AudioEqBand14b"))        { ConfigAudioEqBand[13] = atoi(value);
+	} else if (!strcasecmp(name, "AudioEqBand15b"))        { ConfigAudioEqBand[14] = atoi(value);
+	} else if (!strcasecmp(name, "AudioEqBand16b"))        { ConfigAudioEqBand[15] = atoi(value);
+	} else if (!strcasecmp(name, "AudioEqBand17b"))        { ConfigAudioEqBand[16] = atoi(value);
+	} else if (!strcasecmp(name, "AudioEqBand18b"))        { ConfigAudioEqBand[17] = atoi(value);
 #ifdef USE_GLES
 	} else if (!strcasecmp(name, "MaxSizeGPUImageCache"))  { ConfigMaxSizeGPUImageCache = atoi(value);
 #endif
@@ -145,24 +133,4 @@ void cSoftHdConfig::PrintLogLevel(int loglevel)
 		strcat(prefix, " grabbing");
 
 	LOGINFO("%s", prefix);
-}
-
-void cSoftHdConfig::SetLogState(void)
-{
-	if (LogState) {
-		PrintLogLevel(ConfigLog);
-		cSoftHdLogger::GetLogger()->SetLogLevel(ConfigLog);
-	} else {
-		PrintLogLevel(0);
-		cSoftHdLogger::GetLogger()->SetLogLevel(0);
-	}
-}
-
-void cSoftHdConfig::SetPassthrough(cSoftHdDevice *device)
-{
-	if (AudioPassthroughState) {
-		device->SetPassthrough(ConfigAudioPassthrough);
-	} else {
-		device->SetPassthrough(0);
-	}
 }

--- a/config.cpp
+++ b/config.cpp
@@ -48,13 +48,12 @@ bool cSoftHdConfig::SetupParse(const char *name, const char *value)
 {
 	//LOGDEBUG("config: %s: '%s' = '%s'", __FUNCTION__, name, value);
 
-	if        (!strcasecmp(name, "MakePrimary"))           { ConfigMakePrimary = atoi(value);
+	if        (!strcasecmp(name, "HideMainMenuEntry"))     { ConfigHideMainMenuEntry = atoi(value);
 #ifdef USE_GLES
 #ifdef WRITE_PNG
 	} else if (!strcasecmp(name, "WritePngs"))             { ConfigWritePngs = atoi(value);
 #endif
 #endif
-	} else if (!strcasecmp(name, "HideMainMenuEntry"))     { ConfigHideMainMenuEntry = atoi(value);
 	} else if (!strcasecmp(name, "LogLevel"))              { ConfigLogLevels = abs(atoi(value));
 	                                                         ConfigLogState = atoi(value) > 0;
                                                                  PrintLogLevel(ConfigLogState ? ConfigLogLevels : 0);

--- a/config.h
+++ b/config.h
@@ -32,7 +32,9 @@ public:
 	cSoftHdConfig(void) = default;
 	virtual ~cSoftHdConfig(void);
 
-	bool SetupParse(const char *, const char *, cSoftHdDevice *, cSoftHdAudio *);
+	bool SetupParse(const char *, const char *);
+
+	// setup conf parameters
 #ifdef USE_GLES
 #ifdef WRITE_PNG
 	bool ConfigWritePngs = false;               ///< config write pngs from OSD
@@ -41,8 +43,8 @@ public:
 	int ConfigDisableOglOsd = 0;                ///< config disable ogl osd
 #endif
 	int ConfigVideoAudioDelay = 0;              ///< config audio delay
-	int ConfigAudioPassthrough = 0;             ///< config audio pass-through mask
-	bool AudioPassthroughState = false;         ///< flag audio-passthrough on/off
+	int ConfigAudioPassthroughMask = 0;         ///< config audio pass-through mask
+	bool ConfigAudioPassthroughState = false;   ///< flag audio-passthrough on/off
 	bool ConfigAudioDownmix = false;            ///< config ffmpeg audio downmix
 	bool ConfigAudioSoftvol = false;            ///< config use software volume
 	bool ConfigAudioNormalize = false;          ///< config use normalize volume
@@ -53,20 +55,22 @@ public:
 	int ConfigAudioBufferTime = 0;              ///< config size ms of audio buffer
 	int ConfigAudioAutoAES = 0;                 ///< config automatic AES handling
 	int ConfigAudioEq = 0;                      ///< config equalizer filter
-	int SetupAudioEqBand[18] =
+	int ConfigAudioEqBand[18] =
 		{ 0, 0, 0, 0, 0, 0, 0, 0, 0,
 		  0, 0, 0, 0, 0, 0, 0, 0, 0 };      ///< config equalizer filter bands
-
 	bool ConfigMakePrimary = false;             ///< config primary wanted
 	bool ConfigHideMainMenuEntry = false;       ///< config hide main menu entry
-	bool LogState = true;                       ///< flag logging on/off
-	int ConfigLog = 0;                          ///< loglevel config
-
+	bool ConfigLogState = true;                 ///< flag logging on/off
+	int ConfigLogLevels = 0;                    ///< loglevel config
 	bool ConfigDisableDeint = false;            ///< disable deinterlacer
+
+	// command line parameters
+	const char *ConfigAudioPCMDevice = nullptr;         ///< audio PCM device
+	const char *ConfigAudioPassthroughDevice = nullptr; ///< audio passthrough device
+	const char *ConfigAudioMixerChannel = nullptr;      ///< audio mixer channel name
+	const char *ConfigDisplayResolution = nullptr;      ///< display resolution (syntax: "1920x1080@50")
+
 	void PrintLogLevel(int);
-private:
-	void SetLogState(void);
-	void SetPassthrough(cSoftHdDevice *);
 };
 
 #endif

--- a/config.h
+++ b/config.h
@@ -58,7 +58,6 @@ public:
 	int ConfigAudioEqBand[18] =
 		{ 0, 0, 0, 0, 0, 0, 0, 0, 0,
 		  0, 0, 0, 0, 0, 0, 0, 0, 0 };      ///< config equalizer filter bands
-	bool ConfigMakePrimary = false;             ///< config primary wanted
 	bool ConfigHideMainMenuEntry = false;       ///< config hide main menu entry
 	bool ConfigLogState = true;                 ///< flag logging on/off
 	int ConfigLogLevels = 0;                    ///< loglevel config

--- a/drmdevice.cpp
+++ b/drmdevice.cpp
@@ -74,11 +74,14 @@ extern "C" {
  *
  * @param render         pointer to cVideoRender object
  */
-cDrmDevice::cDrmDevice(cVideoRender *render)
+cDrmDevice::cDrmDevice(cVideoRender *render, const char* resolution)
 {
 	m_pRender = render;
 	m_useZpos = false;
 	m_userReqDisplayWidth = 0;
+
+	if (resolution)
+		sscanf(resolution, "%dx%d@%d", &m_userReqDisplayWidth, &m_userReqDisplayHeight, &m_userReqDisplayRefreshRate);
 }
 
 /**
@@ -974,18 +977,4 @@ void cDrmDevice::InitEvent(void)
 {
 	memset(&m_drmEventCtx, 0, sizeof(m_drmEventCtx));
 	m_drmEventCtx.version = 2;
-}
-
-/**
- * Set the user requested display parameters
- *
- * @param width           width
- * @param height          height
- * @param refreshRate     refresh rate
- */
-void cDrmDevice::SetUserReqDisplayParams(int width, int height, int refreshRate)
-{
-	m_userReqDisplayWidth = width;
-	m_userReqDisplayHeight = height;
-	m_userReqDisplayRefreshRate = refreshRate;
 }

--- a/drmdevice.cpp
+++ b/drmdevice.cpp
@@ -79,6 +79,7 @@ cDrmDevice::cDrmDevice(cVideoRender *render, const char* resolution)
 	m_pRender = render;
 	m_useZpos = false;
 	m_userReqDisplayWidth = 0;
+	m_fdDrm = -1;
 
 	if (resolution)
 		sscanf(resolution, "%dx%d@%d", &m_userReqDisplayWidth, &m_userReqDisplayHeight, &m_userReqDisplayRefreshRate);
@@ -89,6 +90,7 @@ cDrmDevice::cDrmDevice(cVideoRender *render, const char* resolution)
  */
 cDrmDevice::~cDrmDevice(void)
 {
+	LOGDEBUG2(L_DRM, "drmdevice: %s", __FUNCTION__);
 }
 
 static int get_resources(int fd, drmModeRes **resources)
@@ -142,7 +144,7 @@ static int FindDrmDevice(drmModeRes **resources)
 	drmDevicePtr devices[MAX_DRM_DEVICES] = { NULL };
 	int num_devices, fd = -1;
 
-	num_devices = drmGetDevices2(0, devices,MAX_DRM_DEVICES);
+	num_devices = drmGetDevices2(0, devices, MAX_DRM_DEVICES);
 	if (num_devices < 0) {
 		LOGERROR("drmdevice: %s: drmGetDevices2 failed: %s", __FUNCTION__, strerror(-num_devices));
 		return fd;
@@ -271,8 +273,8 @@ int cDrmDevice::Init(void)
 		return -1;
 	}
 
-	LOGDEBUG2(L_DRM, "drmdevice: %s: DRM have %i connectors, %i crtcs, %i encoders", __FUNCTION__,
-		resources->count_connectors, resources->count_crtcs,
+	LOGDEBUG2(L_DRM, "drmdevice: %s: fd: %d DRM have %i connectors, %i crtcs, %i encoders", __FUNCTION__,
+		m_fdDrm, resources->count_connectors, resources->count_crtcs,
 		resources->count_encoders);
 
 	// find a connector
@@ -533,6 +535,18 @@ int cDrmDevice::Init(void)
 		}
 		LOGDEBUG2(L_DRM, "%s", str_zpos);
 	}
+
+	if (drmSetMaster(m_fdDrm) < 0) {
+		LOGDEBUG2(L_DRM, "drmdevice: Failed to set drm master, try authorize instead: {}", strerror(errno));
+
+		drm_magic_t magic;
+		if (drmGetMagic(m_fdDrm, &magic) < 0)
+			LOGFATAL("drmdevice: Failed to get drm magic: {}", strerror(errno));
+
+		if (drmAuthMagic(m_fdDrm, magic) < 0)
+			LOGFATAL("drmdevice: Failed to authorize drm magic: {}", strerror(errno));
+	}
+
 	drmModeFreePlaneResources(planeRes);
 	drmModeFreeEncoder(encoder);
 	drmModeFreeResources(resources);
@@ -897,7 +911,11 @@ int32_t cDrmDevice::FindCrtcForConnector(const drmModeRes *resources, const drmM
  */
 void cDrmDevice::Close(void)
 {
+	LOGDEBUG2(L_DRM, "drmdevice: %s: closing fd %d", __FUNCTION__, m_fdDrm);
+	drmDropMaster(m_fdDrm);
+
 	close(m_fdDrm);
+	m_fdDrm = -1;
 }
 
 /**

--- a/drmdevice.h
+++ b/drmdevice.h
@@ -75,7 +75,7 @@ extern "C" {
 class cDrmDevice
 {
 public:
-	cDrmDevice(cVideoRender *);
+	cDrmDevice(cVideoRender *, const char *);
 	virtual ~cDrmDevice(void);
 
 	int Init(void);
@@ -84,7 +84,6 @@ public:
 	void Close(void);
 
 	// setters and getters
-	void SetUserReqDisplayParams(int, int, int);
 	uint32_t ConnectorId(void) { return m_connectorId; };
 
 	uint64_t DisplayWidth(void) { return m_drmModeInfo.hdisplay; };

--- a/dummyosd.h
+++ b/dummyosd.h
@@ -1,0 +1,99 @@
+/**
+ * @file dummyosd.h
+ * Dummy osd class
+ *
+ * @copyright (c) 2025 by Andreas Baierl. All Rights Reserved.
+ *
+ * @license{AGPLv3
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.}
+ *
+ * The code is borrowed from the dummydevice plugin:
+ *    http://phivdr.dyndns.org/vdr/
+ * which was written by:
+ *    Petri Hintukainen <phintuka@users.sourceforge.net>
+ * and released under the GNU GPLv2
+ */
+#ifndef __DUMMYOSD_H
+#define __DUMMYOSD_H
+
+#include <vdr/config.h>
+#include <vdr/device.h>
+
+#include <vdr/osd.h>
+
+/**
+ * cDummyPixmap - dummy pixmap class for skins
+ *
+ * This pixmap just inits but does nothing else
+ */
+class cDummyPixmap : public cPixmap {
+public:
+	cDummyPixmap(int Layer, const cRect &ViewPort, const cRect &DrawPort = cRect::Null)
+		: cPixmap(Layer, ViewPort, DrawPort) {}
+	virtual ~cDummyPixmap(void) {}
+	virtual void Clear(void) {}
+	virtual void Fill([[maybe_unused]] tColor Color) {}
+	virtual void DrawImage([[maybe_unused]] const cPoint &Point, [[maybe_unused]] const cImage &Image) {}
+	virtual void DrawImage([[maybe_unused]] const cPoint &Point, [[maybe_unused]] int ImageHandle) {}
+	virtual void DrawScaledImage([[maybe_unused]] const cPoint &Point, [[maybe_unused]] const cImage &Image, [[maybe_unused]] double FactorX, [[maybe_unused]] double FactorY, [[maybe_unused]] bool AntiAlias) {}
+	virtual void DrawScaledImage([[maybe_unused]] const cPoint &Point, [[maybe_unused]] int ImageHandle, [[maybe_unused]] double FactorX, [[maybe_unused]] double FactorY, [[maybe_unused]] bool AntiAlias) {}
+	virtual void DrawPixel([[maybe_unused]] const cPoint &Point, [[maybe_unused]] tColor Color) {}
+	virtual void DrawBitmap([[maybe_unused]] const cPoint &Point, [[maybe_unused]] const cBitmap &Bitmap, [[maybe_unused]] tColor ColorFg = 0, [[maybe_unused]] tColor ColorBg = 0,
+		[[maybe_unused]] bool Overlay = false) {}
+	virtual void DrawText([[maybe_unused]] const cPoint &Point, [[maybe_unused]] const char *s, [[maybe_unused]] tColor ColorFg, [[maybe_unused]] tColor ColorBg, [[maybe_unused]] const cFont *Font,
+		[[maybe_unused]] int Width = 0, [[maybe_unused]] int Height = 0, [[maybe_unused]] int Alignment = taDefault) {}
+	virtual void DrawRectangle([[maybe_unused]] const cRect &Rect, [[maybe_unused]] tColor Color) {}
+	virtual void DrawEllipse([[maybe_unused]] const cRect &Rect, [[maybe_unused]] tColor Color, [[maybe_unused]] int Quadrants = 0) {}
+	virtual void DrawSlope([[maybe_unused]] const cRect &Rect, [[maybe_unused]] tColor Color, [[maybe_unused]] int Type) {}
+	virtual void Render([[maybe_unused]] const cPixmap *Pixmap, [[maybe_unused]] const cRect &Source, [[maybe_unused]] const cPoint &Dest) {}
+	virtual void Copy([[maybe_unused]] const cPixmap *Pixmap, [[maybe_unused]] const cRect &Source, [[maybe_unused]] const cPoint &Dest) {}
+	virtual void Scroll([[maybe_unused]] const cPoint &Dest, [[maybe_unused]] const cRect &Source = cRect::Null) {}
+	virtual void Pan([[maybe_unused]] const cPoint &Dest, [[maybe_unused]] const cRect &Source = cRect::Null) {}
+};
+
+/**
+ * cDummyOsd - dummy osd class
+ *
+ * This osd just inits and can create a dummy pixmap but really nothing else
+ */
+class cDummyOsd : public cOsd {
+private:
+	 cDummyPixmap *m_pixmap;
+public:
+	cDummyOsd(int Left, int Top, uint Level) : cOsd(Left, Top, Level) {}
+	virtual ~cDummyOsd() {}
+
+	virtual cPixmap *CreatePixmap(int Layer, const cRect &ViewPort, const cRect &DrawPort = cRect::Null) {
+		m_pixmap = new cDummyPixmap(Layer, ViewPort, DrawPort);
+		return m_pixmap;
+	}
+
+	virtual void DestroyPixmap([[maybe_unused]] cPixmap *Pixmap) {}
+	virtual void DrawImage([[maybe_unused]] const cPoint &Point, [[maybe_unused]] const cImage &Image) {}
+	virtual void DrawImage([[maybe_unused]] const cPoint &Point, [[maybe_unused]] int ImageHandle) {}
+	virtual eOsdError CanHandleAreas([[maybe_unused]] const tArea *Areas, [[maybe_unused]] int NumAreas) {return oeOk;}
+	virtual eOsdError SetAreas([[maybe_unused]] const tArea *Areas, [[maybe_unused]] int NumAreas) {return oeOk;}
+	virtual void SaveRegion([[maybe_unused]] int x1, [[maybe_unused]] int y1, [[maybe_unused]] int x2, [[maybe_unused]] int y2) {}
+	virtual void RestoreRegion(void) {}
+	virtual eOsdError SetPalette([[maybe_unused]] const cPalette &Palette, [[maybe_unused]] int Area) {return oeOk;}
+	virtual void DrawPixel([[maybe_unused]] int x, [[maybe_unused]] int y, [[maybe_unused]] tColor Color) {}
+	virtual void DrawBitmap([[maybe_unused]] int x, [[maybe_unused]] int y, [[maybe_unused]] const cBitmap &Bitmap, [[maybe_unused]] tColor ColorFg = 0,
+		[[maybe_unused]] tColor ColorBg = 0, [[maybe_unused]] bool ReplacePalette = false, [[maybe_unused]] bool Overlay = false) {}
+	virtual void DrawText([[maybe_unused]] int x, [[maybe_unused]] int y, [[maybe_unused]] const char *s, [[maybe_unused]] tColor ColorFg, [[maybe_unused]] tColor ColorBg,
+		[[maybe_unused]] const cFont *Font, [[maybe_unused]] int Width = 0, [[maybe_unused]] int Height = 0, [[maybe_unused]] int Alignment = taDefault) {}
+	virtual void DrawRectangle([[maybe_unused]] int x1, [[maybe_unused]] int y1, [[maybe_unused]] int x2, [[maybe_unused]] int y2, [[maybe_unused]] tColor Color) {}
+	virtual void DrawEllipse([[maybe_unused]] int x1, [[maybe_unused]] int y1, [[maybe_unused]] int x2, [[maybe_unused]] int y2, [[maybe_unused]] tColor Color, [[maybe_unused]] int Quadrants = 0) {}
+	virtual void DrawSlope([[maybe_unused]] int x1, [[maybe_unused]] int y1, [[maybe_unused]] int x2, [[maybe_unused]] int y2, [[maybe_unused]] tColor Color, [[maybe_unused]] int Type) {}
+	virtual void Flush(void) {}
+};
+
+#endif

--- a/softhddevice-drm-gles.cpp
+++ b/softhddevice-drm-gles.cpp
@@ -251,6 +251,8 @@ bool cPluginSoftHdDevice::Service(const char *id, void *data)
  */
 static const char *SVDRPHelpText[] = {
 	"PLAY Url\n" "    Play the media from the given url.\n",
+	"DETA\n" "        Detach the plugin.\n",
+	"ATTA\n" "        Attach the plugin.\n",
 	NULL
 };
 
@@ -280,6 +282,22 @@ cString cPluginSoftHdDevice::SVDRPCommand(const char *command,
 		LOGDEBUG2(L_MEDIA, "plugin: %s: SVDRPCommand: %s %s", __FUNCTION__, command, option);
 		cControl::Launch(new cSoftHdControl(option, m_pDevice));
 		return "PLAY url";
+	}
+	if (!strcasecmp(command, "DETA")) {
+		LOGDEBUG("plugin: %s: SVDRPCommand: %s %s", __FUNCTION__, command, option);
+		if (m_pDevice->IsDetached())
+			return "SoftHdDevice is already detached";
+
+		m_pDevice->Detach();
+		return "Detached SoftHdDevice";
+	}
+	if (!strcasecmp(command, "ATTA")) {
+		LOGDEBUG("plugin: %s: SVDRPCommand: %s %s", __FUNCTION__, command, option);
+		if (!m_pDevice->IsDetached())
+			return "SoftHdDevice is not detached";
+
+		m_pDevice->Attach();
+		return "Attached SoftHdDevice";
 	}
 
 	return NULL;

--- a/softhddevice-drm-gles.cpp
+++ b/softhddevice-drm-gles.cpp
@@ -288,6 +288,11 @@ cString cPluginSoftHdDevice::SVDRPCommand(const char *command,
 		if (m_pDevice->IsDetached())
 			return "SoftHdDevice is already detached";
 
+		if (m_pDevice->Replaying()) {
+			LOGDEBUG("plugin: %s: Device is replaying, stop replay first", __FUNCTION__);
+			m_pDevice->StopReplay();
+		}
+
 		m_pDevice->Detach();
 		return "Detached SoftHdDevice";
 	}

--- a/softhddevice-drm-gles.cpp
+++ b/softhddevice-drm-gles.cpp
@@ -57,7 +57,7 @@ extern "C"
 /*****************************************************************************
  * Static variables
  ****************************************************************************/
-static const char *const VERSION = "1.1.2";    ///< vdr-plugin version number
+static const char *const VERSION = "1.2.0";    ///< vdr-plugin version number
                                                ///< Makefile extracts the version number for generating the file name
                                                ///< for the distribution archive.
 

--- a/softhddevice-drm-gles.cpp
+++ b/softhddevice-drm-gles.cpp
@@ -83,7 +83,6 @@ cPluginSoftHdDevice::cPluginSoftHdDevice(void)
 {
 	m_pConfig = new cSoftHdConfig();
 	m_pDevice = new cSoftHdDevice(m_pConfig); // no need to delete m_pDevice, because VDR does it for us
-	m_pAudio = m_pDevice->Audio();
 }
 
 /**
@@ -230,7 +229,7 @@ cMenuSetupPage *cPluginSoftHdDevice::SetupMenu(void)
  */
 bool cPluginSoftHdDevice::SetupParse(const char *name, const char *value)
 {
-	return m_pConfig->SetupParse(name, value, m_pDevice, m_pAudio);
+	return m_pConfig->SetupParse(name, value);
 }
 
 /**

--- a/softhddevice-drm-gles.cpp
+++ b/softhddevice-drm-gles.cpp
@@ -158,16 +158,6 @@ bool cPluginSoftHdDevice::Start(void)
 {
 //	LOGDEBUG("plugin: %s:", __FUNCTION__);
 
-	if (!m_pDevice->IsPrimaryDevice()) {
-		LOGINFO("softhddevice %d is not the primary device!",
-			m_pDevice->DeviceNumber());
-		if (m_pConfig->ConfigMakePrimary) {
-			// Must be done in the main thread
-			LOGDEBUG("plugin: %s: making softhddevice %d the primary device!",
-				__FUNCTION__, m_pDevice->DeviceNumber());
-			m_doMakePrimary = m_pDevice->DeviceNumber() + 1;
-		}
-	}
 	m_pDevice->Start();
 
 	return true;

--- a/softhddevice-drm-gles.cpp
+++ b/softhddevice-drm-gles.cpp
@@ -78,6 +78,10 @@ static const char *const MAINMENUENTRY = trNOOP("SHD Media Player");
  *
  * @note DON'T DO ANYTHING ELSE THAT MAY HAVE SIDE EFFECTS, REQUIRE GLOBAL
  * VDR OBJECTS TO EXIST OR PRODUCE ANY OUTPUT!
+ *
+ * We only create the config and the device itself, because Plugin->SetupParse
+ * is done next and that one needs config to be available.
+ * SetupParse must not access any other objects!
  */
 cPluginSoftHdDevice::cPluginSoftHdDevice(void)
 {

--- a/softhddevice-drm-gles.h
+++ b/softhddevice-drm-gles.h
@@ -61,7 +61,6 @@ public:
 private:
 	cSoftHdDevice *m_pDevice;          ///< pointer to cSoftHdDevice object
 	cSoftHdConfig *m_pConfig;          ///< pointer to cSoftHdConfig object
-	int m_doMakePrimary;               ///< switch primary device to this
 };
 
 #endif

--- a/softhddevice-drm-gles.h
+++ b/softhddevice-drm-gles.h
@@ -60,7 +60,6 @@ public:
 	virtual cString SVDRPCommand(const char *, const char *, int &);
 private:
 	cSoftHdDevice *m_pDevice;          ///< pointer to cSoftHdDevice object
-	cSoftHdAudio *m_pAudio;            ///< pointer to cSoftHdAudio object
 	cSoftHdConfig *m_pConfig;          ///< pointer to cSoftHdConfig object
 	int m_doMakePrimary;               ///< switch primary device to this
 };

--- a/softhddevice.cpp
+++ b/softhddevice.cpp
@@ -147,8 +147,6 @@ cSoftHdDevice::cSoftHdDevice(cSoftHdConfig *config)
 	m_pAudioDecoder = nullptr;
 	m_videoAudioDelay = m_pConfig->ConfigVideoAudioDelay;
 	m_audioChannelID = -1;
-
-	m_started = false;
 }
 
 /**
@@ -194,18 +192,7 @@ void cSoftHdDevice::Start(void)
 {
 	LOGDEBUG("device: %s:", __FUNCTION__);
 
-	if (m_started)
-		return;
-
-	m_pAudio = new cSoftHdAudio(this);
-	m_pRender = new cVideoRender(this);
-	m_pVideoStream = new cVideoStream(this);
-	m_pAudioDecoder = new cAudioDecoder(m_pAudio);
-	m_pRender->Init(); // starts display thread
-	m_pVideoStream->StartDecoder(new cVideoDecoder(m_pRender->HardwareQuirks())); // starts decoding thread
-	// Audio is init lazily (includes starting thread)
-
-	m_started = true;
+	OnEventReceived(AttachEvent{});
 }
 
 /**
@@ -217,19 +204,8 @@ void cSoftHdDevice::Start(void)
 void cSoftHdDevice::Stop(void)
 {
 	LOGDEBUG("device: %s:", __FUNCTION__);
-	if (!m_started)
-		return;
 
-	m_pAudio->Exit();
-	m_pRender->Exit(); // render must be stopped before videostream!
-	m_pVideoStream->Exit();
-
-	delete m_pAudioDecoder; // includes a Close()
-	delete m_pVideoStream;
-	delete m_pRender;
-	delete m_pAudio;
-
-	m_started = false;
+	OnEventReceived(DetachEvent{});
 }
 
 /**
@@ -314,23 +290,36 @@ void cSoftHdDevice::HandlePause(void)
  *
  * @param event     The event to process (variant type containing specific event data)
  */
-void cSoftHdDevice::OnEventReceived(const Event& event) {
-
-	// don't do state changes if the plugin isn't started
-	// VDR sends SetPlayMode(0) after stopping the plugin
-	if (!m_started)
-		return;
-
+void cSoftHdDevice::OnEventReceived(const Event& event)
+{
 	LOGDEBUG("device: received %s", EventToString(event));
 
-	m_pRender->DisplayThreadHalt(); // the display thread needs to be halted first, otherwise a deadlock can occur in WaitForAudioClock()
-	m_pVideoStream->DecodingThreadHalt();
+	if (m_state != DETACHED) {
+		m_pRender->DisplayThreadHalt(); // the display thread needs to be halted first, otherwise a deadlock can occur in WaitForAudioClock()
+		m_pVideoStream->DecodingThreadHalt();
+	}
+
+	bool needsResume = true;
 
 	auto invalid = [this, &event]() {
 		LOGWARNING("device: Invalid event '%s' in state '%s' received", EventToString(event), StateToString(m_state));
 	};
 
 	switch (m_state) {
+		case State::DETACHED:
+			std::visit(overload{
+				[&invalid](const PlayEvent&) { invalid(); },
+				[&invalid](const PauseEvent&) { invalid(); },
+				[&invalid](const StopEvent&) { invalid(); },
+				[&invalid](const TrickSpeedEvent&) { invalid(); },
+				[&invalid](const StillPictureEvent&) { invalid(); },
+				[&invalid](const DetachEvent&) { invalid(); },
+				[this](const AttachEvent&) {
+					SetState(STOP);
+				},
+			}, event);
+			needsResume = false;
+			break;
 		case State::STOP:
 			std::visit(overload{
 				[this](const PlayEvent&) {
@@ -342,6 +331,11 @@ void cSoftHdDevice::OnEventReceived(const Event& event) {
 				[&invalid](const StopEvent&) { invalid(); },
 				[&invalid](const TrickSpeedEvent&) { invalid(); },
 				[&invalid](const StillPictureEvent&) { invalid(); },
+				[this, &needsResume](const DetachEvent&) {
+					SetState(DETACHED);
+					needsResume = false;
+				},
+				[&invalid](const AttachEvent&) { invalid(); },
 			}, event);
 			break;
 		case State::PLAY:
@@ -364,6 +358,11 @@ void cSoftHdDevice::OnEventReceived(const Event& event) {
 				[this](const StillPictureEvent& s) {
 					HandleStillPicture(s.data, s.size);
 				 },
+				[this, &needsResume](const DetachEvent&) {
+					SetState(DETACHED);
+					needsResume = false;
+				},
+				[&invalid](const AttachEvent&) { invalid(); },
 			}, event);
 			break;
 		case State::TRICK_SPEED:
@@ -385,6 +384,11 @@ void cSoftHdDevice::OnEventReceived(const Event& event) {
 				[this](const StillPictureEvent& s) {
 					HandleStillPicture(s.data, s.size);
 				 },
+				[this, &needsResume](const DetachEvent&) {
+					SetState(DETACHED);
+					needsResume = false;
+				},
+				[&invalid](const AttachEvent&) { invalid(); },
 			}, event);
 			break;
 		case State::STILL_PICTURE:
@@ -403,12 +407,19 @@ void cSoftHdDevice::OnEventReceived(const Event& event) {
 				[this](const StillPictureEvent& s) {
 					HandleStillPicture(s.data, s.size);
 				 },
+				[this, &needsResume](const DetachEvent&) {
+					SetState(DETACHED);
+					needsResume = false;
+				},
+				[&invalid](const AttachEvent&) { invalid(); },
 			}, event);
 			break;
 	}
 
-	m_pVideoStream->DecodingThreadResume();
-	m_pRender->DisplayThreadResume();
+	if (needsResume) {
+		m_pVideoStream->DecodingThreadResume();
+		m_pRender->DisplayThreadResume();
+	}
 }
 
 /**
@@ -450,6 +461,35 @@ void cSoftHdDevice::OnEnteringState(enum State state) {
 		case STILL_PICTURE:
 			m_pRender->SetDeinterlacerDeactivated(true);
 			break;
+		case DETACHED:
+			// do the same cleanup as in STOP first except audio resume and flushing
+			m_pRender->CancelFilterThread();
+
+			m_pRender->Reset();
+			m_pRender->DestroyFrameBuffers();
+			m_pRender->ScheduleDisplayBlackFrame();
+
+			m_videoReassemblyBuffer.Reset();
+			m_pVideoStream->ClearVdrCoreToDecoderQueue();
+			m_pRender->ClearDecoderToDisplayQueue();
+			m_pVideoStream->CloseDecoder();
+
+			m_audioReassemblyBuffer.Reset();
+
+			// resume the previously stopped threads
+			m_pVideoStream->DecodingThreadResume();
+			m_pRender->DisplayThreadResume();
+
+			// now do the detach
+			m_pAudio->Exit();
+			m_pRender->Exit(); // render must be stopped before videostream!
+			m_pVideoStream->Exit();
+
+			delete m_pAudioDecoder; // includes a Close()
+			delete m_pVideoStream;
+			delete m_pRender;
+			delete m_pAudio;
+			break;
 	}
 }
 
@@ -484,6 +524,20 @@ void cSoftHdDevice::OnLeavingState(enum State state) {
 			break;
 		case STILL_PICTURE:
 			m_pRender->SetDeinterlacerDeactivated(false);
+			break;
+		case DETACHED:
+#ifdef USE_GLES
+			SetEnableOglOsd();
+#endif
+			m_pAudio = new cSoftHdAudio(this);
+			m_pAudio->LazyInit();
+			m_pRender = new cVideoRender(this);
+			m_pVideoStream = new cVideoStream(this);
+			m_pAudioDecoder = new cAudioDecoder(m_pAudio);
+			m_pRender->Init(); // starts display thread
+			m_pVideoStream->StartDecoder(new cVideoDecoder(m_pRender->HardwareQuirks())); // starts decoding thread
+			// Audio is init lazily (includes starting thread)
+			m_skipstream = false;
 			break;
 	}
 }

--- a/softhddevice.cpp
+++ b/softhddevice.cpp
@@ -329,7 +329,7 @@ void cSoftHdDevice::OnEventReceived(const Event& event) {
 	LOGDEBUG("device: received %s", EventToString(event));
 
 	m_pRender->DisplayThreadHalt(); // the display thread needs to be halted first, otherwise a deadlock can occur in WaitForAudioClock()
-	m_pRender->DecodingThreadHalt();
+	m_pVideoStream->DecodingThreadHalt();
 
 	auto invalid = [this, &event]() {
 		LOGWARNING("device: Invalid event '%s' in state '%s' received", EventToString(event), StateToString(m_state));
@@ -412,7 +412,7 @@ void cSoftHdDevice::OnEventReceived(const Event& event) {
 			break;
 	}
 
-	m_pRender->DecodingThreadResume();
+	m_pVideoStream->DecodingThreadResume();
 	m_pRender->DisplayThreadResume();
 }
 
@@ -586,7 +586,7 @@ void cSoftHdDevice::Clear(void)
 	cDevice::Clear();
 
 	m_pRender->DisplayThreadHalt(); // the display thread needs to be halted first, otherwise a deadlock can occur in WaitForAudioClock()
-	m_pRender->DecodingThreadHalt();
+	m_pVideoStream->DecodingThreadHalt();
 
 	m_pRender->CancelFilterThread();
 
@@ -603,7 +603,7 @@ void cSoftHdDevice::Clear(void)
 	ClearAudio();
 
 	m_pRender->DisplayThreadResume();
-	m_pRender->DecodingThreadResume();
+	m_pVideoStream->DecodingThreadResume();
 }
 
 /**

--- a/softhddevice.cpp
+++ b/softhddevice.cpp
@@ -27,6 +27,7 @@
 #define __USE_GNU
 #endif
 
+#include <mutex>
 #include <variant>
 
 #include <assert.h>
@@ -147,6 +148,8 @@ cSoftHdDevice::cSoftHdDevice(cSoftHdConfig *config)
 	m_pAudioDecoder = nullptr;
 	m_videoAudioDelay = m_pConfig->ConfigVideoAudioDelay;
 	m_audioChannelID = -1;
+	m_pOsdProvider = nullptr;
+	m_skipstream = false;
 }
 
 /**
@@ -234,7 +237,7 @@ void cSoftHdDevice::MakePrimaryDevice(bool on)
 
 	cDevice::MakePrimaryDevice(on);
 	if (on)
-		new cSoftOsdProvider(this);
+		m_pOsdProvider = new cSoftOsdProvider(this); // no need to delete it, VDR does it
 }
 
 /**
@@ -292,6 +295,8 @@ void cSoftHdDevice::HandlePause(void)
  */
 void cSoftHdDevice::OnEventReceived(const Event& event)
 {
+	m_mutex.lock();
+
 	LOGDEBUG("device: received %s", EventToString(event));
 
 	if (m_state != DETACHED) {
@@ -420,6 +425,8 @@ void cSoftHdDevice::OnEventReceived(const Event& event)
 		m_pVideoStream->DecodingThreadResume();
 		m_pRender->DisplayThreadResume();
 	}
+
+	m_mutex.unlock();
 }
 
 /**
@@ -462,6 +469,7 @@ void cSoftHdDevice::OnEnteringState(enum State state) {
 			m_pRender->SetDeinterlacerDeactivated(true);
 			break;
 		case DETACHED:
+			m_skipstream = true;
 			// do the same cleanup as in STOP first except audio resume and flushing
 			m_pRender->CancelFilterThread();
 
@@ -484,7 +492,10 @@ void cSoftHdDevice::OnEnteringState(enum State state) {
 			m_pAudio->Exit();
 			m_pRender->Exit(); // render must be stopped before videostream!
 			m_pVideoStream->Exit();
-
+#ifdef USE_GLES
+			m_pOsdProvider->StopOpenGlThread();
+			SetDisableOglOsd();
+#endif
 			delete m_pAudioDecoder; // includes a Close()
 			delete m_pVideoStream;
 			delete m_pRender;
@@ -895,6 +906,9 @@ int cSoftHdDevice::PlayAudio(const uchar *data, int size, uchar id)
 {
 //	LOGDEBUG("device: %s: %p %p %d %d", __FUNCTION__, this, data, size, id);
 
+	if (m_skipstream)
+		return size;
+
 	// hard limit buffer full: don't overrun audio buffers on replay
 	if (m_pAudio->GetFreeBytes() < AUDIO_MIN_BUFFER_FREE) {
 //		LOGDEBUG("device: %s: Buffer is Full (%d|%d)!", __FUNCTION__, m_pAudio->GetFreeBytes(), AUDIO_MIN_BUFFER_FREE);
@@ -980,6 +994,9 @@ void cSoftHdDevice::SetVolumeDevice(int volume)
 int cSoftHdDevice::PlayVideo(const uchar *data, int size)
 {
 	// LOGDEBUG("device: %s: %p %d", __FUNCTION__, data, size);
+
+	if (m_skipstream)
+		return size;
 
 	if (m_pVideoStream->GetAvPacketsFilled() >= VIDEO_PACKET_MAX - 10)
 		return 0;
@@ -1325,6 +1342,17 @@ void cSoftHdDevice::SetDisableOglOsd(void)
 	if (m_pRender)
 		m_pRender->DisableOglOsd();
 }
+
+/**
+ * Enables OpenGL/ES Osd
+ */
+void cSoftHdDevice::SetEnableOglOsd(void)
+{
+	m_pConfig->ConfigDisableOglOsd = 0;
+	if (m_pRender)
+		m_pRender->EnableOglOsd();
+}
+
 #endif
 
 /**
@@ -1439,4 +1467,39 @@ int cSoftHdDevice::PlayVideoPkts(AVPacket * pkt)
 	m_pVideoStream->PushAvPacket(pkt);
 
 	return 1;
+}
+
+/**
+ * Detach the device
+ *
+ * Clears audio and video, stops all threads and releases drm/alsa.
+ * A detached state can only be exited (restarted) with an AttachEvent.
+ */
+void cSoftHdDevice::Detach(void)
+{
+	OnEventReceived(DetachEvent{});
+}
+
+/**
+ * Attach the device again
+ *
+ * Kind of a plugin restart. Inits and starts all necessary resources.
+ * Only valid after a detach.
+ */
+void cSoftHdDevice::Attach(void)
+{
+	OnEventReceived(AttachEvent{});
+}
+
+/**
+ * Returns true, id the device detached or suspended
+ *
+ * Use m_skipstream here instead of State::DETACHED or State::SUSPENDED,
+ * because that one is set right before entering and after leaving DETACHED/SUSPENDED.
+ * The state change is done somewhere in between and we can't rely on that.
+ */
+bool cSoftHdDevice::IsDetached(void)
+{
+	std::lock_guard<std::mutex> lock(m_mutex);
+	return m_skipstream;
 }

--- a/softhddevice.cpp
+++ b/softhddevice.cpp
@@ -497,7 +497,6 @@ void cSoftHdDevice::OnEnteringState(enum State state) {
 			m_pVideoStream->Exit();
 #ifdef USE_GLES
 			m_pOsdProvider->StopOpenGlThread();
-			SetDisableOglOsd();
 #endif
 			delete m_pAudioDecoder; // includes a Close()
 			delete m_pVideoStream;
@@ -540,9 +539,6 @@ void cSoftHdDevice::OnLeavingState(enum State state) {
 			m_pRender->SetDeinterlacerDeactivated(false);
 			break;
 		case DETACHED:
-#ifdef USE_GLES
-			SetEnableOglOsd();
-#endif
 			m_pAudio = new cSoftHdAudio(this);
 			m_pAudio->LazyInit();
 			m_pRender = new cVideoRender(this);

--- a/softhddevice.cpp
+++ b/softhddevice.cpp
@@ -149,7 +149,6 @@ cSoftHdDevice::cSoftHdDevice(cSoftHdConfig *config)
 	m_videoAudioDelay = m_pConfig->ConfigVideoAudioDelay;
 	m_audioChannelID = -1;
 	m_pOsdProvider = nullptr;
-	m_skipstream = false;
 }
 
 /**
@@ -260,7 +259,11 @@ cSpuDecoder *cSoftHdDevice::GetSpuDecoder(void)
  */
 bool cSoftHdDevice::HasDecoder(void) const
 {
-	return true;
+	bool hasDecoder = !IsDetached();
+
+//	LOGDEBUG("device: %s: %d", __FUNCTION__, hasDecoder);
+
+	return hasDecoder;
 }
 
 /**
@@ -268,8 +271,11 @@ bool cSoftHdDevice::HasDecoder(void) const
  */
 bool cSoftHdDevice::CanReplay(void) const
 {
-	LOGDEBUG("device: %s:", __FUNCTION__);
-	return true;
+	bool canReplay = !IsDetached();
+
+	LOGDEBUG("device: %s: %d", __FUNCTION__, canReplay);
+
+	return canReplay;
 }
 
 /**
@@ -295,7 +301,7 @@ void cSoftHdDevice::HandlePause(void)
  */
 void cSoftHdDevice::OnEventReceived(const Event& event)
 {
-	m_mutex.lock();
+	std::lock_guard<std::mutex> lock(m_mutex);
 
 	LOGDEBUG("device: received %s", EventToString(event));
 
@@ -425,8 +431,6 @@ void cSoftHdDevice::OnEventReceived(const Event& event)
 		m_pVideoStream->DecodingThreadResume();
 		m_pRender->DisplayThreadResume();
 	}
-
-	m_mutex.unlock();
 }
 
 /**
@@ -469,7 +473,6 @@ void cSoftHdDevice::OnEnteringState(enum State state) {
 			m_pRender->SetDeinterlacerDeactivated(true);
 			break;
 		case DETACHED:
-			m_skipstream = true;
 			// do the same cleanup as in STOP first except audio resume and flushing
 			m_pRender->CancelFilterThread();
 
@@ -548,7 +551,6 @@ void cSoftHdDevice::OnLeavingState(enum State state) {
 			m_pRender->Init(); // starts display thread
 			m_pVideoStream->StartDecoder(new cVideoDecoder(m_pRender->HardwareQuirks())); // starts decoding thread
 			// Audio is init lazily (includes starting thread)
-			m_skipstream = false;
 			break;
 	}
 }
@@ -608,6 +610,9 @@ bool cSoftHdDevice::SetPlayMode(ePlayMode play_mode)
 int64_t cSoftHdDevice::GetSTC(void)
 {
 //    LOGDEBUG("%s:", __FUNCTION__);
+	if (IsDetached())
+		return AV_NOPTS_VALUE;
+
 	if (m_pRender)
 		return m_pRender->GetVideoClock();
 
@@ -644,6 +649,9 @@ void cSoftHdDevice::Clear(void)
 {
 	LOGDEBUG("device: %s:", __FUNCTION__);
 	cDevice::Clear();
+
+	if (IsDetached())
+		return;
 
 	m_pRender->DisplayThreadHalt(); // the display thread needs to be halted first, otherwise a deadlock can occur in WaitForAudioClock()
 	m_pVideoStream->DecodingThreadHalt();
@@ -755,6 +763,9 @@ bool cSoftHdDevice::Poll(__attribute__ ((unused)) cPoller & poller, int timeout)
 {
 //	LOGDEBUG("device: %s: timeout %d", __FUNCTION__, timeout_ms);
 
+	if (IsDetached())
+		return true;
+
 	for (;;) {
 		int full;
 		int t;
@@ -782,6 +793,8 @@ bool cSoftHdDevice::Poll(__attribute__ ((unused)) cPoller & poller, int timeout)
 		usleep(t * 1000);		// let display thread work
 		timeout -= t;
 	}
+
+	return true;
 }
 
 /**
@@ -791,6 +804,9 @@ bool cSoftHdDevice::Poll(__attribute__ ((unused)) cPoller & poller, int timeout)
  */
 bool cSoftHdDevice::Flush(int timeout)
 {
+	if (IsDetached())
+		return true;
+
 	LOGDEBUG("device: %s: timeout %d ms", __FUNCTION__, timeout);
 	if (m_pVideoStream->GetAvPacketsFilled()) {
 		if (timeout) {			// let display thread work
@@ -799,7 +815,7 @@ bool cSoftHdDevice::Flush(int timeout)
 		return !m_pVideoStream->GetAvPacketsFilled();
 	}
 
-	return 1;
+	return true;
 }
 
 /**
@@ -844,6 +860,8 @@ void cSoftHdDevice::SetVideoFormat(bool videoFormat16_9)
 void cSoftHdDevice::GetVideoSize(int &width, int &height, double &aspectRatio)
 {
 //	LOGDEBUG("device: %s: %d x %d @ %f", __FUNCTION__, *width, *height, *aspectRatio);
+	if (IsDetached())
+		return;
 
 	m_pVideoStream->Decoder()->GetVideoSize(&width, &height, &aspectRatio);
 }
@@ -855,6 +873,9 @@ void cSoftHdDevice::GetVideoSize(int &width, int &height, double &aspectRatio)
  */
 void cSoftHdDevice::GetOsdSize(int &width, int &height, double &aspectRatio)
 {
+	if (IsDetached())
+		return;
+
 	m_pRender->GetScreenSize(&width, &height, &aspectRatio);
 }
 
@@ -905,8 +926,7 @@ static void PrintStreamData(const uchar *payload)
 int cSoftHdDevice::PlayAudio(const uchar *data, int size, uchar id)
 {
 //	LOGDEBUG("device: %s: %p %p %d %d", __FUNCTION__, this, data, size, id);
-
-	if (m_skipstream)
+	if (IsDetached())
 		return size;
 
 	// hard limit buffer full: don't overrun audio buffers on replay
@@ -981,6 +1001,9 @@ int cSoftHdDevice::GetAudioChannelDevice(void)
  */
 void cSoftHdDevice::SetVolumeDevice(int volume)
 {
+	if (IsDetached())
+		return;
+
 	LOGDEBUG("device: %s: %d", __FUNCTION__, volume);
 	m_pAudio->SetVolume((volume * 1000) / 255);
 }
@@ -994,8 +1017,7 @@ void cSoftHdDevice::SetVolumeDevice(int volume)
 int cSoftHdDevice::PlayVideo(const uchar *data, int size)
 {
 	// LOGDEBUG("device: %s: %p %d", __FUNCTION__, data, size);
-
-	if (m_skipstream)
+	if (IsDetached())
 		return size;
 
 	if (m_pVideoStream->GetAvPacketsFilled() >= VIDEO_PACKET_MAX - 10)
@@ -1058,6 +1080,9 @@ int cSoftHdDevice::PlayVideo(const uchar *data, int size)
  */
 uchar *cSoftHdDevice::GrabImage(int &size, bool jpeg, int quality, int width, int height)
 {
+	if (IsDetached())
+		return NULL;
+
 	if (m_grabActive) {
 		LOGWARNING("device: %s: wait for the last grab to be finished - skip!", __FUNCTION__);
 		return NULL;
@@ -1195,6 +1220,9 @@ cRect cSoftHdDevice::CanScaleVideo(const cRect & rect, __attribute__ ((unused)) 
  */
 void cSoftHdDevice::ScaleVideo(const cRect & rect)
 {
+	if (IsDetached())
+		return;
+
 	LOGDEBUG2(L_OSD, "device: %s: %dx%d%+d%+d",
 		__FUNCTION__, rect.Width(), rect.Height(), rect.X(), rect.Y());
 
@@ -1286,6 +1314,9 @@ int cSoftHdDevice::ProcessArgs(int argc, char *argv[])
  */
 void cSoftHdDevice::OsdClose(void)
 {
+	if (IsDetached())
+		return;
+
 	m_pRender->OsdClear();
 }
 
@@ -1304,6 +1335,9 @@ void cSoftHdDevice::OsdClose(void)
 void cSoftHdDevice::OsdDrawARGB(int xi, int yi, int height, int width, int pitch,
 	const uint8_t * argb, int x, int y)
 {
+	if (IsDetached())
+		return;
+
 	m_pRender->OsdDrawARGB(xi, yi, height, width, pitch, argb, x, y);
 }
 
@@ -1492,14 +1526,10 @@ void cSoftHdDevice::Attach(void)
 }
 
 /**
- * Returns true, id the device detached or suspended
- *
- * Use m_skipstream here instead of State::DETACHED or State::SUSPENDED,
- * because that one is set right before entering and after leaving DETACHED/SUSPENDED.
- * The state change is done somewhere in between and we can't rely on that.
+ * Returns true, if the device is detached
  */
-bool cSoftHdDevice::IsDetached(void)
+bool cSoftHdDevice::IsDetached(void) const
 {
 	std::lock_guard<std::mutex> lock(m_mutex);
-	return m_skipstream;
+	return m_state == State::DETACHED;
 }

--- a/softhddevice.cpp
+++ b/softhddevice.cpp
@@ -202,7 +202,7 @@ void cSoftHdDevice::Start(void)
 	m_pVideoStream = new cVideoStream(this);
 	m_pAudioDecoder = new cAudioDecoder(m_pAudio);
 	m_pRender->Init(); // starts display thread
-	m_pVideoStream->StartDecoder(new cVideoDecoder(m_pRender)); // start decoding thread
+	m_pVideoStream->StartDecoder(new cVideoDecoder(m_pRender->HardwareQuirks())); // starts decoding thread
 	// Audio is init lazily (includes starting thread)
 
 	m_started = true;

--- a/softhddevice.cpp
+++ b/softhddevice.cpp
@@ -152,6 +152,8 @@ cSoftHdDevice::cSoftHdDevice(cSoftHdConfig *config)
 	m_pVideoStream = new cVideoStream(this);
 
 	m_pAudioDecoder = nullptr;
+
+	m_videoAudioDelay = m_pConfig->ConfigVideoAudioDelay;
 }
 
 /**
@@ -1169,16 +1171,16 @@ int cSoftHdDevice::ProcessArgs(int argc, char *argv[])
 		switch (getopt(argc, argv, "-a:c:p:d:")) {
 #endif
 		case 'a':           // audio device for pcm
-			m_pAudio->SetDevice(optarg);
+			m_pConfig->ConfigAudioPCMDevice = optarg;
 			continue;
 		case 'c':           // channel of audio mixer
-			m_pAudio->SetChannel(optarg);
+			m_pConfig->ConfigAudioMixerChannel = optarg;
 			continue;
 		case 'p':           // pass-through audio device
-			m_pAudio->SetPassthroughDevice(optarg);
+			m_pConfig->ConfigAudioPassthroughDevice = optarg;
 			continue;
 		case 'd':           // set display output
-			m_pRender->SetDisplayResolution(optarg);
+			m_pConfig->ConfigDisplayResolution = optarg;
 			continue;
 #ifdef USE_GLES
 		case 'w':           // workarounds

--- a/softhddevice.cpp
+++ b/softhddevice.cpp
@@ -134,113 +134,102 @@ uint8_t *CreateJpeg(uint8_t * image, int raw_size, int *size, int quality,
 /**
  * cSoftHdDevice constructor
  *
- * creates
- *     audio device
- *     render device
- *     video stream device
+ * Initializes some member variables
  *
  * @param config       pointer to cSoftHdConfig class
  */
 cSoftHdDevice::cSoftHdDevice(cSoftHdConfig *config)
 {
-	LOGDEBUG("device: %s:", __FUNCTION__);
-	m_pSpuDecoder = NULL;
+//	LOGDEBUG("device: %s:", __FUNCTION__);
 
+	m_pSpuDecoder = new cDvbSpuDecoder();
 	m_pConfig = config;
-	m_pAudio = new cSoftHdAudio(this);
-	m_pRender = new cVideoRender(this);
-	m_pVideoStream = new cVideoStream(this);
-
 	m_pAudioDecoder = nullptr;
-
 	m_videoAudioDelay = m_pConfig->ConfigVideoAudioDelay;
+	m_audioChannelID = -1;
+
+	m_started = false;
 }
 
 /**
  * cSoftHdDevice destructor
  *
- * deletes
- *    audio device
- *    render device
- *    video stream device
+ * only deletes spu decoder, which was created in constructor
  */
 cSoftHdDevice::~cSoftHdDevice(void)
 {
 	LOGDEBUG("device: %s:", __FUNCTION__);
-	Exit();
-
-	delete m_pVideoStream;
-	delete m_pAudio;
-	delete m_pRender;
-
 	delete m_pSpuDecoder;
-	LOGDEBUG("device: %s: deleted", __FUNCTION__);
 }
 
 /**
  * Device init
  *
- * prepares the renderer
+ * .. currently does nothing
  */
-void cSoftHdDevice::Init()
+void cSoftHdDevice::Init(void)
 {
-	LOGDEBUG("device: %s:", __FUNCTION__);
-	m_pRender->Prepare();
+	LOGDEBUG("device: %s: (do nothing)", __FUNCTION__);
 }
 
 /**
- * Device exit
- */
-void cSoftHdDevice::Exit(void)
-{
-	LOGDEBUG("device: %s:", __FUNCTION__);
-	m_pAudio->Exit();
-	if (m_pAudioDecoder) {
-		m_pAudioDecoder->Close();
-		delete m_pAudioDecoder;
-	}
-	m_pRender->Exit();
-	m_pVideoStream->Exit();
-
-	LOGDEBUG("device: %s: exited", __FUNCTION__);
-}
-
-/**
- * Device prepare
+ * Start plugin
  *
- * If we don't have the audio decoder created,
- * init the audio, audio decoder and renderer
+ * creates
+ *     audio device
+ *     render device
+ *     video stream device
+ *     audio decoder
+ *
+ * inits
+ *     renderer
+ *
+ * starts
+ *     display thread (filter thread starts on demand)
+ *     decoding thread
+ *
+ * No need to init audio and start audio thread, because this is done lazily.
  */
 void cSoftHdDevice::Start(void)
 {
 	LOGDEBUG("device: %s:", __FUNCTION__);
-	if (!m_pAudioDecoder) {
 
-		// audio
-		m_pAudio->SetBufferTimeInMs(m_pConfig->ConfigAudioBufferTime);
+	if (m_started)
+		return;
 
-		m_pAudioDecoder = new cAudioDecoder(m_pAudio);
-		m_audioChannelID = -1;
+	m_pAudio = new cSoftHdAudio(this);
+	m_pRender = new cVideoRender(this);
+	m_pVideoStream = new cVideoStream(this);
+	m_pAudioDecoder = new cAudioDecoder(m_pAudio);
+	m_pRender->Init(); // starts display thread
+	m_pVideoStream->StartDecoder(new cVideoDecoder(m_pRender)); // start decoding thread
+	// Audio is init lazily (includes starting thread)
 
-#ifdef USE_GLES
-		if (m_pConfig->ConfigDisableOglOsd)
-			m_pRender->DisableOglOsd();
-#endif
-		m_pRender->DisableDeint(m_pConfig->ConfigDisableDeint);
-		m_pRender->Init();
-
-		m_pVideoStream->StartDecoder(new cVideoDecoder(m_pRender));
-	}
+	m_started = true;
 }
 
 /**
- * Stop plugin.
+ * Stop plugin
  *
- * @note stop everything, but don't cleanup, module is still called.
+ * Stop and delete everything except the config and device itself
+ *
  */
 void cSoftHdDevice::Stop(void)
 {
-	LOGDEBUG("device: %s: nothing to do", __FUNCTION__);
+	LOGDEBUG("device: %s:", __FUNCTION__);
+	if (!m_started)
+		return;
+
+	m_pAudio->Exit();
+	m_pRender->Exit(); // render must be stopped before videostream!
+	m_pVideoStream->Exit();
+
+	delete m_pAudioDecoder; // includes a Close()
+	delete m_pVideoStream;
+	delete m_pRender;
+	delete m_pAudio;
+
+	m_started = false;
 }
 
 /**
@@ -263,7 +252,7 @@ void cSoftHdDevice::MakePrimaryDevice(bool on)
 {
 	LOGDEBUG("device: %s: %d", __FUNCTION__, on);
 	if (!on)
-		Exit();
+		Stop();
 	else
 		Start();
 
@@ -281,8 +270,8 @@ void cSoftHdDevice::MakePrimaryDevice(bool on)
 cSpuDecoder *cSoftHdDevice::GetSpuDecoder(void)
 {
 	LOGDEBUG("device: %s:", __FUNCTION__);
-	if (!m_pSpuDecoder && IsPrimaryDevice())
-		m_pSpuDecoder = new cDvbSpuDecoder();
+	if (!IsPrimaryDevice())
+		return NULL;
 
 	return m_pSpuDecoder;
 }
@@ -326,6 +315,12 @@ void cSoftHdDevice::HandlePause(void)
  * @param event     The event to process (variant type containing specific event data)
  */
 void cSoftHdDevice::OnEventReceived(const Event& event) {
+
+	// don't do state changes if the plugin isn't started
+	// VDR sends SetPlayMode(0) after stopping the plugin
+	if (!m_started)
+		return;
+
 	LOGDEBUG("device: received %s", EventToString(event));
 
 	m_pRender->DisplayThreadHalt(); // the display thread needs to be halted first, otherwise a deadlock can occur in WaitForAudioClock()

--- a/softhddevice.h
+++ b/softhddevice.h
@@ -156,6 +156,7 @@ public:
 	//
 	// wrapped by cPluginSoftHdDevice
 	//
+	void Init(void);                    // wrapped by cPluginSoftHdDevice::Initialize()
 	void Start(void);                   // wrapped by cPluginSoftHdDevice::Start()
 	void Stop(void);                    // wrapped by cPluginSoftHdDevice::Stop()
 	const char *CommandLineHelp(void);  // wrapped by cPluginSoftHdDevice::CommandLineHelp()
@@ -164,7 +165,6 @@ public:
 	//
 	// cSoftHdDevice public methods
 	//
-	void Init(void);
 	cSoftHdConfig *Config(void) { return m_pConfig; };
 	cVideoStream *VideoStream(void) { return m_pVideoStream; };
 	cVideoRender *Render(void) { return m_pRender; };
@@ -204,6 +204,8 @@ public:
 	void OnLeavingState(enum State);
 
 private:
+	bool m_started;                  ///< plugin was started and initialized (should this be done with the state machine?)
+
 	enum State m_state = STOP;       ///< current plugin state
 	cDvbSpuDecoder *m_pSpuDecoder;   ///< pointer to spu decoder
 	cSoftHdConfig *m_pConfig;        ///< pointer to cSoftHdConfig object

--- a/softhddevice.h
+++ b/softhddevice.h
@@ -215,7 +215,7 @@ public:
 	// detach/ attach
 	void Detach(void);
 	void Attach(void);
-	bool IsDetached(void);
+	bool IsDetached(void) const;
 
 private:
 	enum State m_state = DETACHED;   ///< current plugin state, normal plugin start sets detached state
@@ -233,8 +233,7 @@ private:
 	int m_videoAudioDelay;           ///< audio/video delay set via setup menu
 	bool m_grabActive;               ///< simple lock variable
 	                                 ///< skips a new grab request if the last one is still active
-	bool m_skipstream;               ///< skips audio and video data (in detached state)
-	std::mutex m_mutex;              ///< mutex to lock the state machine
+	mutable std::mutex m_mutex;      ///< mutex to lock the state machine
 
 	void ClearAudio(void);
 	void Exit(void);

--- a/softhddevice.h
+++ b/softhddevice.h
@@ -47,7 +47,8 @@ enum State {
 	STOP,
 	PLAY,
 	TRICK_SPEED,
-	STILL_PICTURE
+	STILL_PICTURE,
+	DETACHED
 };
 
 struct PlayEvent {};
@@ -61,8 +62,10 @@ struct StillPictureEvent {
 	const uchar *data;
 	int size;
 };
+struct DetachEvent {};
+struct AttachEvent {};
 
-using Event = std::variant<PlayEvent, PauseEvent, StopEvent, TrickSpeedEvent, StillPictureEvent>;
+using Event = std::variant<PlayEvent, PauseEvent, StopEvent, TrickSpeedEvent, StillPictureEvent, DetachEvent, AttachEvent>;
 
 template<class... Ts>
 struct overload : Ts... { using Ts::operator()...; };
@@ -75,6 +78,8 @@ inline const char* EventToString(const Event& e) {
         [](const StopEvent&) -> const char* { return "StopEvent"; },
         [](const TrickSpeedEvent&) -> const char* { return "TrickSpeedEvent"; },
         [](const StillPictureEvent&) -> const char* { return "StillPictureEvent"; },
+        [](const DetachEvent&) -> const char* { return "DetachEvent"; },
+        [](const AttachEvent&) -> const char* { return "AttachEvent"; },
     }, e);
 }
 
@@ -83,7 +88,8 @@ inline const char* StateToString(State s) {
         case State::STOP: return "STOP";
         case State::PLAY: return "PLAY";
         case State::TRICK_SPEED: return "TRICK_SPEED";
-		case State::STILL_PICTURE: return "STILL_PICTURE";
+        case State::STILL_PICTURE: return "STILL_PICTURE";
+        case State::DETACHED: return "DETACHED";
     }
     return "Unknown";
 }
@@ -204,9 +210,7 @@ public:
 	void OnLeavingState(enum State);
 
 private:
-	bool m_started;                  ///< plugin was started and initialized (should this be done with the state machine?)
-
-	enum State m_state = STOP;       ///< current plugin state
+	enum State m_state = DETACHED;   ///< current plugin state, normal plugin start sets detached state
 	cDvbSpuDecoder *m_pSpuDecoder;   ///< pointer to spu decoder
 	cSoftHdConfig *m_pConfig;        ///< pointer to cSoftHdConfig object
 	cVideoRender *m_pRender;         ///< pointer to cVideoRender object

--- a/softhddevice.h
+++ b/softhddevice.h
@@ -21,6 +21,7 @@
 #ifndef __SOFTHDDEVICE_H
 #define __SOFTHDDEVICE_H
 
+#include <mutex>
 #include <variant>
 
 #include <vdr/dvbspu.h>
@@ -35,6 +36,7 @@ extern "C"
 #include "videostream.h"
 #include "audio.h"
 #include "videorender.h"
+#include "softhdosd.h"
 
 #if __cplusplus < 201703L
 #error "C++17 or higher is required"
@@ -184,6 +186,7 @@ public:
 	int MaxSizeGPUImageCache(void);
 	int OglOsdIsDisabled(void);
 	void SetDisableOglOsd(void);
+	void SetEnableOglOsd(void);
 #endif
 	void SetDisableDeint(void);
 	void OsdClose(void);
@@ -209,6 +212,11 @@ public:
 	void OnEnteringState(enum State);
 	void OnLeavingState(enum State);
 
+	// detach/ attach
+	void Detach(void);
+	void Attach(void);
+	bool IsDetached(void);
+
 private:
 	enum State m_state = DETACHED;   ///< current plugin state, normal plugin start sets detached state
 	cDvbSpuDecoder *m_pSpuDecoder;   ///< pointer to spu decoder
@@ -217,6 +225,7 @@ private:
 	cVideoStream *m_pVideoStream;    ///< pointer to cVideoStream object
 	cSoftHdAudio *m_pAudio;          ///< pointer to cSoftHdAudio object
 	cAudioDecoder *m_pAudioDecoder;  ///< pointer to cAudioDecoder object
+	cSoftOsdProvider *m_pOsdProvider; ///< pointer to cSoftOsdProvider object
 	cReassemblyBufferVideo m_videoReassemblyBuffer; ///< video pes reassembly buffer
 	cReassemblyBufferAudio m_audioReassemblyBuffer; ///< audio pes reassembly buffer
 
@@ -224,6 +233,8 @@ private:
 	int m_videoAudioDelay;           ///< audio/video delay set via setup menu
 	bool m_grabActive;               ///< simple lock variable
 	                                 ///< skips a new grab request if the last one is still active
+	bool m_skipstream;               ///< skips audio and video data (in detached state)
+	std::mutex m_mutex;              ///< mutex to lock the state machine
 
 	void ClearAudio(void);
 	void Exit(void);

--- a/softhdmenu.cpp
+++ b/softhdmenu.cpp
@@ -311,21 +311,21 @@ cMenuSetupSoft::cMenuSetupSoft(cSoftHdDevice *device)
 	// Logging
 	//
 	m_cLogging = 0;
-	m_cLogDefault   = m_pConfig->LogState;
-	m_cLogDebug_    = m_pConfig->ConfigLog & L_DEBUG;
-	m_cLogAVSync    = m_pConfig->ConfigLog & L_AV_SYNC;
-	m_cLogSound     = m_pConfig->ConfigLog & L_SOUND;
-	m_cLogOSD       = m_pConfig->ConfigLog & L_OSD;
-	m_cLogDRM       = m_pConfig->ConfigLog & L_DRM;
-	m_cLogCodec     = m_pConfig->ConfigLog & L_CODEC;
-	m_cLogStill     = m_pConfig->ConfigLog & L_STILL;
-	m_cLogTrick     = m_pConfig->ConfigLog & L_TRICK;
-	m_cLogMedia     = m_pConfig->ConfigLog & L_MEDIA;
-	m_cLogGL        = m_pConfig->ConfigLog & L_OPENGL;
-	m_cLogGLTime    = m_pConfig->ConfigLog & L_OPENGL_TIME;
-	m_cLogGLTimeAll = m_pConfig->ConfigLog & L_OPENGL_TIME_ALL;
-	m_cLogPacket    = m_pConfig->ConfigLog & L_PACKET;
-	m_cLogGrab      = m_pConfig->ConfigLog & L_GRAB;
+	m_cLogDefault   = m_pConfig->ConfigLogState;
+	m_cLogDebug_    = m_pConfig->ConfigLogLevels & L_DEBUG;
+	m_cLogAVSync    = m_pConfig->ConfigLogLevels & L_AV_SYNC;
+	m_cLogSound     = m_pConfig->ConfigLogLevels & L_SOUND;
+	m_cLogOSD       = m_pConfig->ConfigLogLevels & L_OSD;
+	m_cLogDRM       = m_pConfig->ConfigLogLevels & L_DRM;
+	m_cLogCodec     = m_pConfig->ConfigLogLevels & L_CODEC;
+	m_cLogStill     = m_pConfig->ConfigLogLevels & L_STILL;
+	m_cLogTrick     = m_pConfig->ConfigLogLevels & L_TRICK;
+	m_cLogMedia     = m_pConfig->ConfigLogLevels & L_MEDIA;
+	m_cLogGL        = m_pConfig->ConfigLogLevels & L_OPENGL;
+	m_cLogGLTime    = m_pConfig->ConfigLogLevels & L_OPENGL_TIME;
+	m_cLogGLTimeAll = m_pConfig->ConfigLogLevels & L_OPENGL_TIME_ALL;
+	m_cLogPacket    = m_pConfig->ConfigLogLevels & L_PACKET;
+	m_cLogGrab      = m_pConfig->ConfigLogLevels & L_GRAB;
 
 	//
 	// Video
@@ -346,11 +346,11 @@ cMenuSetupSoft::cMenuSetupSoft(cSoftHdDevice *device)
 	m_cAudioMaxCompression     = m_pConfig->ConfigAudioMaxCompression;
 	m_cAudioStereoDescent      = m_pConfig->ConfigAudioStereoDescent;
 	m_cAudioDownmix            = m_pConfig->ConfigAudioDownmix;
-	m_cAudioPassthroughDefault = m_pConfig->AudioPassthroughState;
-	m_cAudioPassthroughPCM     = m_pConfig->ConfigAudioPassthrough & CODEC_PCM;
-	m_cAudioPassthroughAC3     = m_pConfig->ConfigAudioPassthrough & CODEC_AC3;
-	m_cAudioPassthroughEAC3    = m_pConfig->ConfigAudioPassthrough & CODEC_EAC3;
-	m_cAudioPassthroughDTS     = m_pConfig->ConfigAudioPassthrough & CODEC_DTS;
+	m_cAudioPassthroughDefault = m_pConfig->ConfigAudioPassthroughState;
+	m_cAudioPassthroughPCM     = m_pConfig->ConfigAudioPassthroughMask & CODEC_PCM;
+	m_cAudioPassthroughAC3     = m_pConfig->ConfigAudioPassthroughMask & CODEC_AC3;
+	m_cAudioPassthroughEAC3    = m_pConfig->ConfigAudioPassthroughMask & CODEC_EAC3;
+	m_cAudioPassthroughDTS     = m_pConfig->ConfigAudioPassthroughMask & CODEC_DTS;
 	m_cAudioAutoAES            = m_pConfig->ConfigAudioAutoAES;
 
 	//
@@ -359,7 +359,7 @@ cMenuSetupSoft::cMenuSetupSoft(cSoftHdDevice *device)
 	m_cAudioEq = m_pConfig->ConfigAudioEq;
 	m_cAudioFilter = 0;
 	for (int i = 0; i < 18; i++) {
-		m_cAudioEqBand[i] = m_pConfig->SetupAudioEqBand[i];
+		m_cAudioEqBand[i] = m_pConfig->ConfigAudioEqBand[i];
 	}
 
 	Create();
@@ -392,7 +392,7 @@ void cMenuSetupSoft::Store(void)
 	//
 	// Logging
 	//
-	m_pConfig->ConfigLog =
+	m_pConfig->ConfigLogLevels =
 		(m_cLogDebug_    ? L_DEBUG : 0) |
 		(m_cLogAVSync    ? L_AV_SYNC : 0) |
 		(m_cLogSound     ? L_SOUND : 0) |
@@ -407,14 +407,14 @@ void cMenuSetupSoft::Store(void)
 		(m_cLogGLTimeAll ? L_OPENGL_TIME_ALL : 0) |
 		(m_cLogPacket    ? L_PACKET : 0) |
 		(m_cLogGrab      ? L_GRAB : 0);
-	m_pConfig->LogState = m_cLogDefault;
-	if (m_pConfig->LogState) {
-		SetupStore("LogLevel", m_pConfig->ConfigLog);
-		m_pConfig->PrintLogLevel(m_pConfig->ConfigLog);
-		cSoftHdLogger::GetLogger()->SetLogLevel(m_pConfig->ConfigLog);
+	m_pConfig->ConfigLogState = m_cLogDefault;
+
+	if (m_pConfig->ConfigLogState) {
+		SetupStore("LogLevel", m_pConfig->ConfigLogLevels);
+		m_pConfig->PrintLogLevel(m_pConfig->ConfigLogLevels);
+		cSoftHdLogger::GetLogger()->SetLogLevel(m_pConfig->ConfigLogLevels);
 	} else {
-		SetupStore("LogLevel", -m_pConfig->ConfigLog);
-		m_pConfig->PrintLogLevel(0);
+		SetupStore("LogLevel", -m_pConfig->ConfigLogLevels);
 		cSoftHdLogger::GetLogger()->SetLogLevel(0);
 	}
 
@@ -451,16 +451,16 @@ void cMenuSetupSoft::Store(void)
 	if (m_pConfig->ConfigAudioDownmix != m_cAudioDownmix) {
 		m_pDevice->ResetChannelId();
 	}
-	m_pConfig->ConfigAudioPassthrough = (m_cAudioPassthroughPCM ? CODEC_PCM : 0)
-	                                  | (m_cAudioPassthroughAC3 ? CODEC_AC3 : 0)
-	                                  | (m_cAudioPassthroughEAC3 ? CODEC_EAC3 : 0)
-	                                  | (m_cAudioPassthroughDTS ? CODEC_DTS : 0);
-	m_pConfig->AudioPassthroughState = m_cAudioPassthroughDefault;
-	if (m_pConfig->AudioPassthroughState) {
-		SetupStore("AudioPassthrough", m_pConfig->ConfigAudioPassthrough);
-		m_pDevice->SetPassthrough(m_pConfig->ConfigAudioPassthrough);
+	m_pConfig->ConfigAudioPassthroughMask = (m_cAudioPassthroughPCM ? CODEC_PCM : 0)
+	                                      | (m_cAudioPassthroughAC3 ? CODEC_AC3 : 0)
+	                                      | (m_cAudioPassthroughEAC3 ? CODEC_EAC3 : 0)
+	                                      | (m_cAudioPassthroughDTS ? CODEC_DTS : 0);
+	m_pConfig->ConfigAudioPassthroughState = m_cAudioPassthroughDefault;
+	if (m_pConfig->ConfigAudioPassthroughState) {
+		SetupStore("AudioPassthrough", m_pConfig->ConfigAudioPassthroughMask);
+		m_pDevice->SetPassthrough(m_pConfig->ConfigAudioPassthroughMask);
 	} else {
-		SetupStore("AudioPassthrough", -m_pConfig->ConfigAudioPassthrough);
+		SetupStore("AudioPassthrough", -m_pConfig->ConfigAudioPassthroughMask);
 		m_pDevice->SetPassthrough(0);
 	}
 	SetupStore("AudioAutoAES", m_pConfig->ConfigAudioAutoAES = m_cAudioAutoAES);
@@ -470,23 +470,23 @@ void cMenuSetupSoft::Store(void)
 	// Audio filter
 	//
 	SetupStore("AudioEq", m_pConfig->ConfigAudioEq = m_cAudioEq);
-	SetupStore("AudioEqBand01b", m_pConfig->SetupAudioEqBand[0]  = m_cAudioEqBand[0]);
-	SetupStore("AudioEqBand02b", m_pConfig->SetupAudioEqBand[1]  = m_cAudioEqBand[1]);
-	SetupStore("AudioEqBand03b", m_pConfig->SetupAudioEqBand[2]  = m_cAudioEqBand[2]);
-	SetupStore("AudioEqBand04b", m_pConfig->SetupAudioEqBand[3]  = m_cAudioEqBand[3]);
-	SetupStore("AudioEqBand05b", m_pConfig->SetupAudioEqBand[4]  = m_cAudioEqBand[4]);
-	SetupStore("AudioEqBand06b", m_pConfig->SetupAudioEqBand[5]  = m_cAudioEqBand[5]);
-	SetupStore("AudioEqBand07b", m_pConfig->SetupAudioEqBand[6]  = m_cAudioEqBand[6]);
-	SetupStore("AudioEqBand08b", m_pConfig->SetupAudioEqBand[7]  = m_cAudioEqBand[7]);
-	SetupStore("AudioEqBand09b", m_pConfig->SetupAudioEqBand[8]  = m_cAudioEqBand[8]);
-	SetupStore("AudioEqBand10b", m_pConfig->SetupAudioEqBand[9]  = m_cAudioEqBand[9]);
-	SetupStore("AudioEqBand11b", m_pConfig->SetupAudioEqBand[10] = m_cAudioEqBand[10]);
-	SetupStore("AudioEqBand12b", m_pConfig->SetupAudioEqBand[11] = m_cAudioEqBand[11]);
-	SetupStore("AudioEqBand13b", m_pConfig->SetupAudioEqBand[12] = m_cAudioEqBand[12]);
-	SetupStore("AudioEqBand14b", m_pConfig->SetupAudioEqBand[13] = m_cAudioEqBand[13]);
-	SetupStore("AudioEqBand15b", m_pConfig->SetupAudioEqBand[14] = m_cAudioEqBand[14]);
-	SetupStore("AudioEqBand16b", m_pConfig->SetupAudioEqBand[15] = m_cAudioEqBand[15]);
-	SetupStore("AudioEqBand17b", m_pConfig->SetupAudioEqBand[16] = m_cAudioEqBand[16]);
-	SetupStore("AudioEqBand18b", m_pConfig->SetupAudioEqBand[17] = m_cAudioEqBand[17]);
-	m_pAudioDevice->SetEq(m_pConfig->SetupAudioEqBand, m_pConfig->ConfigAudioEq);
+	SetupStore("AudioEqBand01b", m_pConfig->ConfigAudioEqBand[0]  = m_cAudioEqBand[0]);
+	SetupStore("AudioEqBand02b", m_pConfig->ConfigAudioEqBand[1]  = m_cAudioEqBand[1]);
+	SetupStore("AudioEqBand03b", m_pConfig->ConfigAudioEqBand[2]  = m_cAudioEqBand[2]);
+	SetupStore("AudioEqBand04b", m_pConfig->ConfigAudioEqBand[3]  = m_cAudioEqBand[3]);
+	SetupStore("AudioEqBand05b", m_pConfig->ConfigAudioEqBand[4]  = m_cAudioEqBand[4]);
+	SetupStore("AudioEqBand06b", m_pConfig->ConfigAudioEqBand[5]  = m_cAudioEqBand[5]);
+	SetupStore("AudioEqBand07b", m_pConfig->ConfigAudioEqBand[6]  = m_cAudioEqBand[6]);
+	SetupStore("AudioEqBand08b", m_pConfig->ConfigAudioEqBand[7]  = m_cAudioEqBand[7]);
+	SetupStore("AudioEqBand09b", m_pConfig->ConfigAudioEqBand[8]  = m_cAudioEqBand[8]);
+	SetupStore("AudioEqBand10b", m_pConfig->ConfigAudioEqBand[9]  = m_cAudioEqBand[9]);
+	SetupStore("AudioEqBand11b", m_pConfig->ConfigAudioEqBand[10] = m_cAudioEqBand[10]);
+	SetupStore("AudioEqBand12b", m_pConfig->ConfigAudioEqBand[11] = m_cAudioEqBand[11]);
+	SetupStore("AudioEqBand13b", m_pConfig->ConfigAudioEqBand[12] = m_cAudioEqBand[12]);
+	SetupStore("AudioEqBand14b", m_pConfig->ConfigAudioEqBand[13] = m_cAudioEqBand[13]);
+	SetupStore("AudioEqBand15b", m_pConfig->ConfigAudioEqBand[14] = m_cAudioEqBand[14]);
+	SetupStore("AudioEqBand16b", m_pConfig->ConfigAudioEqBand[15] = m_cAudioEqBand[15]);
+	SetupStore("AudioEqBand17b", m_pConfig->ConfigAudioEqBand[16] = m_cAudioEqBand[16]);
+	SetupStore("AudioEqBand18b", m_pConfig->ConfigAudioEqBand[17] = m_cAudioEqBand[17]);
+	m_pAudioDevice->SetEq(m_pConfig->ConfigAudioEqBand, m_pConfig->ConfigAudioEq);
 }

--- a/softhdmenu.cpp
+++ b/softhdmenu.cpp
@@ -87,7 +87,6 @@ void cMenuSetupSoft::Create(void)
 	//
 	Add(CollapsedItem(tr("General"), m_cGeneral));
 	if (m_cGeneral) {
-		Add(new cMenuEditBoolItem(tr("Make primary device"), &m_cMakePrimary, trVDR("no"), trVDR("yes")));
 		Add(new cMenuEditBoolItem(tr("Hide main menu entry"), &m_cHideMainMenuEntry, trVDR("no"), trVDR("yes")));
 #ifdef USE_GLES
 		if (!m_pConfig->ConfigDisableOglOsd) {
@@ -286,7 +285,6 @@ cMenuSetupSoft::cMenuSetupSoft(cSoftHdDevice *device)
 	// General
 	//
 	m_cGeneral = 0;
-	m_cMakePrimary = m_pConfig->ConfigMakePrimary;
 	m_cHideMainMenuEntry = m_pConfig->ConfigHideMainMenuEntry;
 #ifdef USE_GLES
 	m_cMaxSizeGPUImageCache = m_pConfig->ConfigMaxSizeGPUImageCache;
@@ -373,7 +371,6 @@ void cMenuSetupSoft::Store(void)
 	//
 	// General
 	//
-	SetupStore("MakePrimary", m_pConfig->ConfigMakePrimary = m_cMakePrimary);
 	SetupStore("HideMainMenuEntry", m_pConfig->ConfigHideMainMenuEntry = m_cHideMainMenuEntry);
 #ifdef USE_GLES
 	SetupStore("MaxSizeGPUImageCache", m_pConfig->ConfigMaxSizeGPUImageCache = m_cMaxSizeGPUImageCache);

--- a/softhdmenu.h
+++ b/softhdmenu.h
@@ -45,7 +45,6 @@ protected:
 
 	// General
 	int m_cGeneral;
-	int m_cMakePrimary;
 	int m_cHideMainMenuEntry;
 #ifdef USE_GLES
 	int m_cMaxSizeGPUImageCache;

--- a/softhdosd.cpp
+++ b/softhdosd.cpp
@@ -29,6 +29,7 @@
 #endif
 #include "softhddevice.h"
 #include "softhdosd.h"
+#include "dummyosd.h"
 
 /*****************************************************************************
  * OSD (software)
@@ -348,6 +349,11 @@ cSoftOsdProvider::~cSoftOsdProvider()
 cOsd *cSoftOsdProvider::CreateOsd(int left, int top, uint level)
 {
 #ifdef USE_GLES
+	if (m_pDevice->IsDetached()) {
+		LOGDEBUG("osdprovider: %s: %d, %d, %d, device detached, using dummy osd", __FUNCTION__, left, top, level);
+		return m_pOsd = new cDummyOsd(left, top, level);
+	}
+
 	if (m_pDevice->OglOsdIsDisabled()) {
 		LOGDEBUG("osdprovider: %s: %d, %d, %d, OpenGL disabled, using software rendering", __FUNCTION__, left, top, level);
 		return m_pOsd = new cSoftOsd(left, top, level, m_pDevice);
@@ -362,6 +368,11 @@ cOsd *cSoftOsdProvider::CreateOsd(int left, int top, uint level)
 	m_pDevice->SetDisableOglOsd();
 	return m_pOsd = new cSoftOsd(left, top, 999, m_pDevice);
 #else
+	if (m_pDevice->IsDetached()) {
+		LOGDEBUG("osdprovider: %s: %d, %d, %d, device detached, using dummy osd", __FUNCTION__, left, top, level);
+		return m_pOsd = new cDummyOsd(left, top, level);
+	}
+
 	LOGDEBUG2(L_OSD, "osdprovider: %s: %d, %d, %d", __FUNCTION__, left, top, level);
 	return m_pOsd = new cSoftOsd(left, top, level, m_pDevice);
 #endif

--- a/softhdosd.h
+++ b/softhdosd.h
@@ -29,6 +29,7 @@
 #include "softhddevice.h"
 
 class cSoftHdDevice;
+class cOglThread;
 
 /*****************************************************************************
  * OSD (software)

--- a/threads.cpp
+++ b/threads.cpp
@@ -37,15 +37,16 @@ extern "C" {
 #include "threads.h"
 #include "videorender.h"
 #include "audio.h"
+#include "videostream.h"
 
 /*****************************************************************************
  * cDecodingThread class
  *
  * This thread decodes the video data
  ****************************************************************************/
-cDecodingThread::cDecodingThread(cSoftHdDevice *device) : cThread("softhd decoding")
+cDecodingThread::cDecodingThread(cVideoStream *stream) : cThread("softhd decoding")
 {
-	m_pDevice = device;
+	m_pStream = stream;
 	Start();
 }
 
@@ -59,7 +60,7 @@ void cDecodingThread::Action(void)
 	while(Running()) {
 		m_mutex.lock();
 
-		m_pDevice->VideoStream()->DecodeInput();
+		m_pStream->DecodeInput();
 
 		m_mutex.unlock();
 

--- a/threads.h
+++ b/threads.h
@@ -28,6 +28,7 @@
 #define VIDEO_SURFACES_MAX 3
 
 class cSoftHdDevice;
+class cVideoStream;
 
 /**
  * Decoding thread class
@@ -35,7 +36,7 @@ class cSoftHdDevice;
 class cDecodingThread : public cThread
 {
 public:
-	cDecodingThread(cSoftHdDevice *);
+	cDecodingThread(cVideoStream *);
 	virtual ~cDecodingThread(void);
 	void Stop(void);
 	void Halt(void) { m_mutex.lock(); };
@@ -43,7 +44,7 @@ public:
 
 private:
 	std::mutex m_mutex;
-	cSoftHdDevice *m_pDevice;
+	cVideoStream *m_pStream;
 
 protected:
 	virtual void Action(void);

--- a/videorender.cpp
+++ b/videorender.cpp
@@ -82,9 +82,6 @@ cVideoRender::cVideoRender(cSoftHdDevice *device)
 	m_pAudio = m_pDevice->Audio();
 	m_pDrmDevice = new cDrmDevice(this, m_pConfig->ConfigDisplayResolution);
 
-#ifdef USE_GLES
-	m_disableOglOsd = m_pConfig->ConfigDisableOglOsd;
-#endif
 	m_startgrab = false;
 	m_startCounter = 0;
 	m_videoIsScaled = false;
@@ -103,7 +100,10 @@ cVideoRender::cVideoRender(cSoftHdDevice *device)
 
 	m_userDisabledDeinterlacer = m_pConfig->ConfigDisableDeint;
 #ifdef USE_GLES
+	m_disableOglOsd = m_pConfig->ConfigDisableOglOsd;
 	m_bo = nullptr;
+	m_pNextBo = nullptr;
+	m_pOldBo = nullptr;
 #endif
 }
 
@@ -117,7 +117,8 @@ cVideoRender::~cVideoRender(void)
 		delete m_pFilterThread;
 	if (m_pDisplayThread)
 		delete m_pDisplayThread;
-	LOGDEBUG2(L_DRM, "videorender: %s", __FUNCTION__);
+
+	delete m_pDrmDevice;
 }
 
 /**
@@ -1616,7 +1617,6 @@ void cVideoRender::Exit(void)
 #endif
 
 	m_pDrmDevice->Close();
-	delete m_pDrmDevice;
 }
 
 /**

--- a/videorender.cpp
+++ b/videorender.cpp
@@ -115,8 +115,6 @@ cVideoRender::~cVideoRender(void)
 		delete m_pFilterThread;
 	if (m_pDisplayThread)
 		delete m_pDisplayThread;
-	if (m_pDecodingThread)
-		delete m_pDecodingThread;
 	LOGDEBUG2(L_DRM, "videorender: %s", __FUNCTION__);
 }
 
@@ -130,14 +128,6 @@ void cVideoRender::Prepare(void)
 
 	atomic_set(&m_framesFilled, 0);
 	m_enqueueBufferIdx = 0;
-}
-
-/**
- * Create and start the decoding thread
- */
-void cVideoRender::CreateDecodingThread(void)
-{
-	m_pDecodingThread = new cDecodingThread(m_pDevice);
 }
 
 /**
@@ -891,17 +881,6 @@ void cVideoRender::OsdDrawARGB(int xi, int yi,
  ****************************************************************************/
 
 /**
- * Stop decoding thread
- */
-void cVideoRender::ExitDecodingThread(void)
-{
-	LOGDEBUG("videorender: %s", __FUNCTION__);
-
-	if (m_pDecodingThread->Active())
-		m_pDecodingThread->Stop();
-}
-
-/**
  * Stop display thread
  */
 void cVideoRender::ExitDisplayThread(void)
@@ -1628,7 +1607,6 @@ void cVideoRender::Exit(void)
 	cDrmPlane *videoPlane = m_pDrmDevice->VideoPlane();
 	cDrmPlane *osdPlane = m_pDrmDevice->OsdPlane();
 
-	ExitDecodingThread();
 	ExitDisplayThread();
 
 	// restore saved CRTC configuration
@@ -1677,13 +1655,3 @@ void cVideoRender::SetVideoOutputPosition(const cRect &rect)
 
 	LOGDEBUG("videorender: %s: %d %d %d %d%s", __FUNCTION__, rect.X(), rect.Y(), rect.Width(), rect.Height(), m_videoIsScaled ? ", video is scaled" : "");
 }
-
-/**
- * Check the decoding thread status
- *
- * @retval     1 if active
- *             0 if stopped
- */
-bool cVideoRender::DecodingThreadIsActive(void) {
-	return m_pDecodingThread->Active();
-};

--- a/videorender.cpp
+++ b/videorender.cpp
@@ -496,22 +496,6 @@ bool cVideoRender::IsInterlacedFrame(AVFrame *frame)
 }
 
 /**
- * Check, if this is a key frame
- *
- * @param frame    AVFrame
- *
- * @return         true, if this frame is a key frame
- */
-bool cVideoRender::IsKeyFrame(AVFrame *frame)
-{
-#if LIBAVUTIL_VERSION_INT < AV_VERSION_INT(58,7,100)
-	return frame->key_frame;
-#else
-	return frame->flags & AV_FRAME_FLAG_KEY;
-#endif
-}
-
-/**
  * Get suitable framebuffer for frame
  *
  * First, search for an already created buffer. If there is no such buffer, create one.

--- a/videorender.cpp
+++ b/videorender.cpp
@@ -82,7 +82,9 @@ cVideoRender::cVideoRender(cSoftHdDevice *device)
 	m_pAudio = m_pDevice->Audio();
 	m_pDrmDevice = new cDrmDevice(this, m_pConfig->ConfigDisplayResolution);
 
-	m_disableOglOsd = false;
+#ifdef USE_GLES
+	m_disableOglOsd = m_pConfig->ConfigDisableOglOsd;
+#endif
 	m_startgrab = false;
 	m_startCounter = 0;
 	m_videoIsScaled = false;
@@ -116,18 +118,6 @@ cVideoRender::~cVideoRender(void)
 	if (m_pDisplayThread)
 		delete m_pDisplayThread;
 	LOGDEBUG2(L_DRM, "videorender: %s", __FUNCTION__);
-}
-
-/**
- * Prepare the threads and process variables
- */
-void cVideoRender::Prepare(void)
-{
-	m_pDisplayThread = new cDisplayThread(this);
-	m_pFilterThread = new cFilterThread(this);
-
-	atomic_set(&m_framesFilled, 0);
-	m_enqueueBufferIdx = 0;
 }
 
 /**
@@ -1495,6 +1485,12 @@ static int ReadHWPlatform(void)
  */
 void cVideoRender::Init(void)
 {
+	m_pDisplayThread = new cDisplayThread(this);
+	m_pFilterThread = new cFilterThread(this);
+
+	atomic_set(&m_framesFilled, 0);
+	m_enqueueBufferIdx = 0;
+
 	if (m_pDrmDevice->Init())
 		LOGFATAL("videorender: %s: failed", __FUNCTION__);
 

--- a/videorender.cpp
+++ b/videorender.cpp
@@ -78,8 +78,9 @@ extern "C" {
 cVideoRender::cVideoRender(cSoftHdDevice *device)
 {
 	m_pDevice = device;
+	m_pConfig = m_pDevice->Config();
 	m_pAudio = m_pDevice->Audio();
-	m_pDrmDevice = new cDrmDevice(this);
+	m_pDrmDevice = new cDrmDevice(this, m_pConfig->ConfigDisplayResolution);
 
 	m_disableOglOsd = false;
 	m_startgrab = false;
@@ -97,6 +98,8 @@ cVideoRender::cVideoRender(cSoftHdDevice *device)
 	m_timebase = av_make_q(1, 90000);
 
 	m_pBufOsd = nullptr;
+
+	m_userDisabledDeinterlacer = m_pConfig->ConfigDisableDeint;
 #ifdef USE_GLES
 	m_bo = nullptr;
 #endif
@@ -135,22 +138,6 @@ void cVideoRender::Prepare(void)
 void cVideoRender::CreateDecodingThread(void)
 {
 	m_pDecodingThread = new cDecodingThread(m_pDevice);
-}
-
-/**
- * Set the display resolution and refresh rate based on a user given string
- *
- * @param resolution       string formatted like "1920x1080@50"
- */
-void cVideoRender::SetDisplayResolution(const char* resolution)
-{
-	int userReqDisplayWidth;
-	int userReqDisplayHeight;
-	int userReqDisplayRefreshRate;
-
-	sscanf(resolution, "%dx%d@%d", &userReqDisplayWidth, &userReqDisplayHeight, &userReqDisplayRefreshRate);
-
-	m_pDrmDevice->SetUserReqDisplayParams(userReqDisplayWidth, userReqDisplayHeight, userReqDisplayRefreshRate);
 }
 
 /**

--- a/videorender.h
+++ b/videorender.h
@@ -56,7 +56,7 @@ extern "C" {
 #include "threads.h"
 #include "grab.h"
 #include "drmplane.h"
-#include "drmdevice.h"
+#include "config.h"
 
 #define RENDERBUFFERS 36                 ///< number of render video buffers
 
@@ -70,6 +70,7 @@ extern "C" {
 #define QUIRK_CODEC_DISABLE_H264_HW     1 << 5     ///< set, if disable h264 hardware decoder
 
 class cDrmDevice;
+class cSoftHdConfig;
 
 /**
  * cVideoRender - Video render class
@@ -87,7 +88,6 @@ public:
 	void DisableOglOsd(void) { m_disableOglOsd = true; };
 	bool OglOsdDisabled(void) { return m_disableOglOsd; };
 
-	void SetDisplayResolution(const char *);
 	void SetVideoOutputPosition(const cRect &);
 	void GetScreenSize(int *, int *, double *);
 	int64_t GetVideoClock(void);
@@ -164,7 +164,8 @@ public:
 
 private:
 	cSoftHdDevice *m_pDevice;           ///< pointer to cSoftHdDevice
-	cSoftHdAudio *m_pAudio;	            ///< pointer to cSoftHdAudio
+	cSoftHdAudio *m_pAudio;             ///< pointer to cSoftHdAudio
+	cSoftHdConfig *m_pConfig;           ///< pointer to cSoftHdConfig
 	cDecodingThread *m_pDecodingThread; ///< pointer to decoding thread
 	cDisplayThread *m_pDisplayThread;   ///< pointer to display thread
 	cFilterThread *m_pFilterThread;     ///< pointer to deinterlace filter thread

--- a/videorender.h
+++ b/videorender.h
@@ -118,13 +118,8 @@ public:
 
 	// Threads
 	void Prepare(void);
-	void CreateDecodingThread(void);
-	bool DecodingThreadIsActive(void);
-	void ExitDecodingThread(void);
 	void ExitDisplayThread(void);
 
-	void DecodingThreadHalt(void) { m_pDecodingThread->Halt(); };
-	void DecodingThreadResume(void) { m_pDecodingThread->Resume(); };
 	void DisplayThreadHalt(void) { m_pDisplayThread->Halt(); };
 	void DisplayThreadResume(void) { m_pDisplayThread->Resume(); };
 
@@ -166,7 +161,6 @@ private:
 	cSoftHdDevice *m_pDevice;           ///< pointer to cSoftHdDevice
 	cSoftHdAudio *m_pAudio;             ///< pointer to cSoftHdAudio
 	cSoftHdConfig *m_pConfig;           ///< pointer to cSoftHdConfig
-	cDecodingThread *m_pDecodingThread; ///< pointer to decoding thread
 	cDisplayThread *m_pDisplayThread;   ///< pointer to display thread
 	cFilterThread *m_pFilterThread;     ///< pointer to deinterlace filter thread
 	cMutex m_waitCleanMutex;            ///< mutex used while display cleanup

--- a/videorender.h
+++ b/videorender.h
@@ -134,7 +134,6 @@ public:
 	void FramesRbLock(void);
 	void FramesRbUnlock(void);
 	bool IsInterlacedFrame(AVFrame *);
-	bool IsKeyFrame(AVFrame *);
 	void ScheduleDisplayBlackFrame(void) { m_displayBlackFrame = true; };
 	void DestroyFrameBuffers(void);
 	void ClearDecoderToDisplayQueue(void);

--- a/videorender.h
+++ b/videorender.h
@@ -147,6 +147,7 @@ public:
 #ifdef USE_GLES
 	// GLES
 	void DisableOglOsd(void) { m_disableOglOsd = true; };
+	void EnableOglOsd(void) { m_disableOglOsd = false; };
 	bool OglOsdDisabled(void) { return m_disableOglOsd; };
 	EGLSurface EglSurface(void) { return m_pDrmDevice->EglSurface(); };
 	EGLDisplay EglDisplay(void) { return m_pDrmDevice->EglDisplay(); };

--- a/videorender.h
+++ b/videorender.h
@@ -85,8 +85,6 @@ public:
 	void Exit(void);
 	int HardwareQuirks(void) { return m_hardwareQuirks; };
 	void DisableDeint(bool disable) { m_userDisabledDeinterlacer = disable; };
-	void DisableOglOsd(void) { m_disableOglOsd = true; };
-	bool OglOsdDisabled(void) { return m_disableOglOsd; };
 
 	void SetVideoOutputPosition(const cRect &);
 	void GetScreenSize(int *, int *, double *);
@@ -117,9 +115,7 @@ public:
 	cSoftHdGrab *GetGrab(int *, int *, int *, int *, int *, int);
 
 	// Threads
-	void Prepare(void);
 	void ExitDisplayThread(void);
-
 	void DisplayThreadHalt(void) { m_pDisplayThread->Halt(); };
 	void DisplayThreadResume(void) { m_pDisplayThread->Resume(); };
 
@@ -151,6 +147,8 @@ public:
 
 #ifdef USE_GLES
 	// GLES
+	void DisableOglOsd(void) { m_disableOglOsd = true; };
+	bool OglOsdDisabled(void) { return m_disableOglOsd; };
 	EGLSurface EglSurface(void) { return m_pDrmDevice->EglSurface(); };
 	EGLDisplay EglDisplay(void) { return m_pDrmDevice->EglDisplay(); };
 	EGLContext EglContext(void) { return m_pDrmDevice->EglContext(); };
@@ -187,8 +185,6 @@ private:
 	bool m_deinterlacerDeactivated = false; ///< set, if the deinterlacer shall be deactivated temporarily (used for trick speed and still picture)
 	bool m_checkFilterThreadNeeded;     ///< set, if we have to check, if filter thread is needed at start of playback
 
-	bool m_disableOglOsd;               ///< set, if ogl osd is disabled
-
 	bool m_startgrab;                   ///< internal flag to trigger grabbing
 	cCondVar m_grabCond;                ///< condition gets signalled, if renederer finished to clone the grabbed buffers
 	cSoftHdGrab m_grabOsd;              ///< keeps the current grabbed osd
@@ -218,6 +214,7 @@ private:
 	bool m_playbackPaused = false;		///< set, if playback is frozen (used for pause)
 
 #ifdef USE_GLES
+	bool m_disableOglOsd;               ///< set, if ogl osd is disabled
 	struct gbm_bo *m_bo;                ///< pointer to current gbm buffer object
 	struct gbm_bo *m_pOldBo;            ///< pointer to old gbm buffer object (for later free)
 	struct gbm_bo *m_pNextBo;           ///< pointer to next gbm buffer object (for later free)

--- a/videostream.cpp
+++ b/videostream.cpp
@@ -117,6 +117,8 @@ void cVideoStream::Exit(void)
 {
 	LOGDEBUG("videostream %s:", __FUNCTION__);
 
+	ExitDecodingThread();
+
 	if (m_pDecoder) {
 		m_pDecoder->Close();
 		delete(m_pDecoder);
@@ -147,9 +149,8 @@ void cVideoStream::StartDecoder(cVideoDecoder *decoder)
 	LOGDEBUG2(L_CODEC, "videostream %s", __FUNCTION__);
 
 	m_pDecoder = decoder;
-	m_pRender->CreateDecodingThread();
+	CreateDecodingThread();
 }
-
 
 /**
  * Close the decoder
@@ -272,4 +273,30 @@ void cVideoStream::Open(AVCodecID codecId, AVCodecParameters *par, AVRational ti
 	m_timebase = timebase;
 	m_codecId = codecId;
 	m_pPar = par;
+}
+
+/*****************************************************************************
+ * Thread
+ ****************************************************************************/
+
+/**
+ * Create and start the decoding thread
+ */
+void cVideoStream::CreateDecodingThread(void)
+{
+	m_pDecodingThread = new cDecodingThread(this);
+}
+
+/**
+ * Stop decoding thread
+ */
+void cVideoStream::ExitDecodingThread(void)
+{
+	LOGDEBUG("videostream: %s", __FUNCTION__);
+
+	if (m_pDecodingThread->Active())
+		m_pDecodingThread->Stop();
+
+	if (m_pDecodingThread)
+		delete m_pDecodingThread;
 }

--- a/videostream.h
+++ b/videostream.h
@@ -64,9 +64,16 @@ public:
 	enum AVCodecID GetCodecId(void) { return m_codecId; };
 	void ResetTrickSpeedFramesSentCounter(void) { m_sentTrickPkts = 0; };
 
+	// decoding thread
+	void CreateDecodingThread(void);
+	void ExitDecodingThread(void);
+	void DecodingThreadHalt(void) { m_pDecodingThread->Halt(); };
+	void DecodingThreadResume(void) { m_pDecodingThread->Resume(); };
+
 private:
 	cVideoDecoder *m_pDecoder;             ///< video decoder
 	cVideoRender *m_pRender;               ///< video renderer
+	cDecodingThread *m_pDecodingThread;    ///< pointer to decoding thread
 
 	cQueue<AVPacket> m_packets{VIDEO_PACKET_MAX}; ///< AVPackets queue
 	std::vector<uint8_t> m_currentCodecPacket;    ///< fragmentation buffer


### PR DESCRIPTION
Though this should be kept as a draft until it's tested enough, it's ready for review.
Commit 1-3 do some refactoring of the classes first
Commit 4 does a reordering in start/stop mechanism
Commit 5 removes cVideoRender as a member of cVideoDecoder... we have a code duplication, which could be done better. At best with introducing a cFrame class...
Commit 6 moves plugin start and stop to the state machine. The plugin starts in attached mode first - which does the init. When the plugin stops, it enters detached state before the real exit - which is a preparation for the next commit.
Commit 7 introduces detach/attach via svdrp

This is only basically tested on rpi4 with start/stop and detach/attach. Needs testing to detach in all other states.