### PR TITLE
fix state DETACHED

### DIFF
--- a/softhddevice.cpp
+++ b/softhddevice.cpp
@@ -1507,7 +1507,7 @@ int cSoftHdDevice::PlayVideoPkts(AVPacket * pkt)
  */
 void cSoftHdDevice::Detach(void)
 {
-	OnEventReceived(DetachEvent{});
+	MakePrimaryDevice(false);
 }
 
 /**
@@ -1518,7 +1518,7 @@ void cSoftHdDevice::Detach(void)
  */
 void cSoftHdDevice::Attach(void)
 {
-	OnEventReceived(AttachEvent{});
+	MakePrimaryDevice(true);
 }
 
 /**


### PR DESCRIPTION
We need to disable the primary device in order to prevent VDR from trying to do channel switches and flooding the log.