### PR TITLE
Use CURSOR plane for OSD as fallback. Disable PIP if no more planes are available

### DIFF
--- a/drmdevice.cpp
+++ b/drmdevice.cpp
@@ -395,8 +395,8 @@ int cDrmDevice::Init(void)
 			continue;
 		}
 
-		uint64_t type;
-		uint64_t zpos;
+		uint64_t type = 0;
+		uint64_t zpos = 0;
 		char pixelformats[256];
 
 		if (plane->possible_crtcs & (1 << m_crtcIndex)) {
@@ -560,8 +560,7 @@ int cDrmDevice::Init(void)
 		m_zposPip = best_overlay_pip_plane.GetZpos();
 		m_pipPlane.SetZpos(m_zposPip);
 	} else {
-		LOGERROR("drmdevice: %s: no suitable pip planes found", __FUNCTION__);
-		return -1;
+		LOGWARNING("drmdevice: %s: No suitable plane for Picture-in-Picture found. PIP will be disabled.", __FUNCTION__);
 	}
 
 	// debug output
@@ -589,7 +588,9 @@ int cDrmDevice::Init(void)
 	// fill the plane's properties to speed up SetPropertyRequest later
 	m_videoPlane.FillProperties(m_fdDrm);
 	m_osdPlane.FillProperties(m_fdDrm);
-	m_pipPlane.FillProperties(m_fdDrm);
+
+	if (m_pipPlane.GetId())
+		m_pipPlane.FillProperties(m_fdDrm);
 
 	// Check, if we can set z-order (meson and rpi have fixed z-order, which cannot be changed)
 	if (m_useZpos && !m_videoPlane.HasZpos(m_fdDrm)) {
@@ -598,7 +599,7 @@ int cDrmDevice::Init(void)
 	if (m_useZpos && !m_osdPlane.HasZpos(m_fdDrm)) {
 		m_useZpos = false;
 	}
-	if (m_useZpos && !m_pipPlane.HasZpos(m_fdDrm)) {
+	if (m_useZpos && m_pipPlane.GetId() && !m_pipPlane.HasZpos(m_fdDrm)) {
 		m_useZpos = false;
 	}
 
@@ -668,6 +669,8 @@ int cDrmDevice::Init(void)
 		return -1;
 	}
 #endif
+
+	InitEvent();
 
 	return 0;
 }

--- a/drmdevice.cpp
+++ b/drmdevice.cpp
@@ -493,6 +493,51 @@ int cDrmDevice::Init(void)
 		m_zposPrimary = best_primary_osd_plane.GetZpos();
 		m_osdPlane.SetZpos(m_zposPrimary);
 		m_useZpos = true;
+	} else if (best_primary_video_plane.GetId() && best_primary_osd_plane.GetId() && best_primary_video_plane.GetId() == best_primary_osd_plane.GetId()) {
+		// fallback using the CURSOR plane for the OSD, e.g. for RockPro64 (RK3399) connected via HDMI, whose CRTC has only a PRIMARY and a CURSOR plane
+		cDrmPlane best_cursor_osd_plane;
+		for (j = 0; j < planeRes->count_planes; j++) {
+			plane = drmModeGetPlane(m_fdDrm, planeRes->planes[j]);
+			if (!plane)
+				continue;
+
+			if (plane->possible_crtcs & (1 << m_crtcIndex)) {
+				uint64_t type = 0;
+				GetPropertyValue(m_fdDrm, planeRes->planes[j], DRM_MODE_OBJECT_PLANE, "type", &type);
+
+				if (type == DRM_PLANE_TYPE_CURSOR) {
+					for (k = 0; k < plane->count_formats; k++) {
+						if (plane->formats[k] == DRM_FORMAT_ARGB8888) {
+							best_cursor_osd_plane.SetId(plane->plane_id);
+							best_cursor_osd_plane.SetType(type);
+							best_cursor_osd_plane.SetZpos(100);
+							break;
+						}
+					}
+				}
+			}
+
+			drmModeFreePlane(plane);
+			if (best_cursor_osd_plane.GetId())
+				break;
+		}
+
+		if (best_cursor_osd_plane.GetId()) {
+			LOGINFO("drmdevice: %s: Using PRIMARY plane for Video and CURSOR plane for OSD", __FUNCTION__);
+			m_videoPlane.SetId(best_primary_video_plane.GetId());
+			m_videoPlane.SetType(best_primary_video_plane.GetType());
+			m_zposPrimary = best_primary_video_plane.GetZpos();
+			m_videoPlane.SetZpos(m_zposPrimary);
+
+			m_osdPlane.SetId(best_cursor_osd_plane.GetId());
+			m_osdPlane.SetType(best_cursor_osd_plane.GetType());
+			m_zposOverlay = best_cursor_osd_plane.GetZpos();
+			m_osdPlane.SetZpos(m_zposOverlay);
+			m_useZpos = true;
+		} else {
+			LOGFATAL("drmdevice: %s: Only one suitable plane found (PRIMARY), and no suitable CURSOR plane for OSD!", __FUNCTION__);
+			return -1;
+		}
 	} else {
 		LOGERROR("drmdevice: %s: No suitable planes found!", __FUNCTION__);
 		return -1;

--- a/drmdevice.h
+++ b/drmdevice.h
@@ -129,11 +129,11 @@ private:
 	uint32_t m_userReqDisplayRefreshRate;  ///< user requested display refresh rate
 
 	bool m_useZpos;                        ///< is set, if drm hardware can use zpos
-	uint64_t m_zposOverlay;                ///< zpos of overlay plane
-	uint64_t m_zposPrimary;                ///< zpos of primary plane
+	uint64_t m_zposOverlay = 0;            ///< zpos of overlay plane
+	uint64_t m_zposPrimary = 0;            ///< zpos of primary plane
 	cDrmPlane m_videoPlane;                ///< the video drm plane
 	cDrmPlane m_osdPlane;                  ///< the osd drm plane
-	uint64_t m_zposPip;                    ///< zpos of pip plane
+	uint64_t m_zposPip = 0;                ///< zpos of pip plane
 	cDrmPlane m_pipPlane;                  ///< the pip drm plane
 
 	int32_t FindCrtcForConnector(const drmModeRes *, const drmModeConnector *);

--- a/drmplane.cpp
+++ b/drmplane.cpp
@@ -136,7 +136,7 @@ int cDrmPlane::SetPropertyRequest(drmModeAtomicReqPtr ModeReq, const char *propN
 	}
 
 	if (id < 0) {
-		LOGERROR("drmplane: %s: Unable to find value for property \'%s\'.",
+		LOGDEBUG("drmplane: %s: Unable to find value for property \'%s\'.",
 			__FUNCTION__, propName);
 		return -EINVAL;
 	}

--- a/drmplane.h
+++ b/drmplane.h
@@ -60,7 +60,7 @@ public:
 	uint64_t GetZpos(void) { return m_zpos; };
 	void SetZpos(uint64_t zpos) { m_zpos = zpos; };
 
-	int GetCountProps(void) { return m_props->count_props; };
+	int GetCountProps(void) { return m_props ? m_props->count_props : 0; };
 	char *GetPropsInfoName(int prop) { return m_propsInfo[prop]->name; };
 	uint32_t GetPropsInfoPropId(int prop) { return m_propsInfo[prop]->prop_id; };
 	drmModeObjectProperties *GetProps(void) { return m_props; };
@@ -69,10 +69,10 @@ public:
 	drmModePropertyRes **GetPropsInfoElem(int elem) { return &m_propsInfo[elem]; };
 
 private:
-	uint32_t m_planeId;                 ///< the plane's ID
-	uint64_t m_type;                    ///< type: DRM_PLANE_TYPE_PRIMARY or
+	uint32_t m_planeId = 0;             ///< the plane's ID
+	uint64_t m_type = 0;                ///< type: DRM_PLANE_TYPE_PRIMARY or
 	                                    ///<       DRM_PLANE_TYPE_OVERLAY
-	drmModeObjectProperties *m_props;
+	drmModeObjectProperties *m_props = nullptr;
 	drmModePropertyRes **m_propsInfo;
 
 	// The modesetting parameters for a drm commit
@@ -86,7 +86,7 @@ private:
 	uint64_t m_srcY;                  ///< SRC_Y
 	uint64_t m_srcW;                  ///< SRC_W
 	uint64_t m_srcH;                  ///< SRC_H
-	uint64_t m_zpos;                  ///< ZPOS
+	uint64_t m_zpos = 0;              ///< ZPOS
 
 	int SetPropertyRequest(drmModeAtomicReqPtr, const char *, uint64_t);
 };

--- a/videorender.cpp
+++ b/videorender.cpp
@@ -103,6 +103,7 @@ cVideoRender::cVideoRender(cSoftHdDevice *device)
 	m_timebase = av_make_q(1, 90000);
 
 	m_pBufOsd = nullptr;
+	m_osdShown = false;
 
 	m_userDisabledDeinterlacer = m_pConfig->ConfigDisableDeint;
 #ifdef USE_GLES
@@ -464,17 +465,19 @@ int cVideoRender::CommitBuffer(cDrmBuffer *buf, cDrmBuffer *pip, int osdOnly)
 	}
 
 	// handle the pip plane
-	if (IsPipActive() && pip) {
-		SetPipBuffer(pip);
-		pipPlane->SetPlane(modeReq);
-		modeSet |= MODESET_PIP;
-	} else if (IsPipActive() && m_pCurrentlyPipDisplayed) {
-		SetPipBuffer(m_pCurrentlyPipDisplayed);
-		pipPlane->SetPlane(modeReq);
-		modeSet |= MODESET_PIP;
-	} else {
-		pipPlane->ClearPlane(modeReq);
-		modeSet |= MODESET_PIP;
+	if (pipPlane->GetId()) {
+		if (IsPipActive() && pip) {
+			SetPipBuffer(pip);
+			pipPlane->SetPlane(modeReq);
+			modeSet |= MODESET_PIP;
+		} else if (IsPipActive() && m_pCurrentlyPipDisplayed) {
+			SetPipBuffer(m_pCurrentlyPipDisplayed);
+			pipPlane->SetPlane(modeReq);
+			modeSet |= MODESET_PIP;
+		} else {
+			pipPlane->ClearPlane(modeReq);
+			modeSet |= MODESET_PIP;
+		}
 	}
 
 	// handle the osd plane


### PR DESCRIPTION
On the RockPro64 board (RK3399), the CRTC connected to the HDMI port has only a primary and a cursor plane, but no overlay planes. This PR uses the cursor plane for OSD.

As there is no plane left for the PIP, it is disabled.

See #129 