### PR TITLE
Decoder drain

### DIFF
--- a/videostream.cpp
+++ b/videostream.cpp
@@ -349,29 +349,25 @@ void cVideoStream::DecodeInput(void)
 
 	ret = m_pDecoder->SendPacket(avpkt);
 
-	if (ret != AVERROR(EAGAIN)) {
+	if (ret != AVERROR(EAGAIN) && ret != AVERROR_EOF) {
 		avpkt = m_packets.Pop();
 		av_packet_free(&avpkt);
 	}
 
 	// in backward trickspeed force the decoder to decode the frame, if minPkts are sent
-	bool flushDecoder = false;
 	if (ret == 0 && m_pRender->IsTrickSpeed() && !m_pRender->IsForwardTrickspeed()) {
 		m_sentTrickPkts++;
 		if (m_sentTrickPkts >= minPkts) {
 			m_pDecoder->SendPacket(NULL);
 			m_sentTrickPkts = 0;
-			flushDecoder = true;
 		}
 	}
 
 	// receive frame from decoder
-	if (!m_newStream) { // this is for mediaplayer?
-		if (m_pDecoder->ReceiveFrame(&frame) == 0)
-			RenderFrame(frame);
-	}
-
-	if (ret == AVERROR_EOF || flushDecoder) {
+	ret = m_pDecoder->ReceiveFrame(&frame);
+	if (ret == 0) {
+		RenderFrame(frame);
+	} else if (ret == AVERROR_EOF) {
 		FlushDecoder();
 		m_sentTrickPkts = 0;
 	}


### PR DESCRIPTION
This is, how i would implement the decoder drain again.
Can you test this again with the buffering merged now? You had issues with the second avcodec_send_packet(NULL) iirc...

An simple alternative would be to set a flag which skips avcodec_send_packet in the next loop iteration.