### PR TITLE
drm: don't display pip if video is scaled

### DIFF
--- a/drmplane.cpp
+++ b/drmplane.cpp
@@ -183,6 +183,7 @@ void cDrmPlane::SetPlane(drmModeAtomicReqPtr ModeReq)
 void cDrmPlane::ClearPlane(drmModeAtomicReqPtr ModeReq)
 {
 	SetPropertyRequest(ModeReq, "FB_ID",   0);
+	SetPropertyRequest(ModeReq, "CRTC_ID", 0);
 }
 
 /**

--- a/videorender.cpp
+++ b/videorender.cpp
@@ -205,7 +205,10 @@ static sRect ComputeFittedRect(AVFrame *frame, uint64_t dispX, uint64_t dispY, u
  */
 void cVideoRender::SetVideoBuffer(cDrmBuffer *buf)
 {
-	AVFrame *frame = buf ? buf->frame : nullptr;
+	if (!buf)
+		return;
+
+	AVFrame *frame = buf->frame;
 
 	// set display dimensions as default
 	uint64_t dispWidth = m_pDrmDevice->DisplayWidth();
@@ -281,7 +284,10 @@ int cVideoRender::SetOsdBuffer(drmModeAtomicReqPtr modeReq)
  */
 void cVideoRender::SetPipBuffer(cDrmBuffer *buf)
 {
-	AVFrame *frame = buf ? buf->frame : nullptr;
+	if (!buf)
+		return;
+
+	AVFrame *frame = buf->frame;
 
 	// set display dimensions as default
 	uint64_t dispWidth = m_pDrmDevice->DisplayWidth();
@@ -355,7 +361,7 @@ void cVideoRender::Grab(cDrmBuffer *buf, cDrmBuffer *pip)
 	}
 
 	cDrmBuffer *pipBuf = pip ? pip : (m_pCurrentlyPipDisplayed ? m_pCurrentlyPipDisplayed : NULL);
-	if (pipBuf) {
+	if (pipBuf && !m_videoIsScaled) {
 		LOGDEBUG2(L_GRAB, "videorender: %s: Trigger pip grab arrived", __FUNCTION__);
 		cDrmBuffer *pipVideoBuf = new cDrmBuffer(pipBuf);
 		// use dimensions which have been set earlier
@@ -412,11 +418,11 @@ int cVideoRender::CommitBuffer(cDrmBuffer *buf, cDrmBuffer *pip)
 
 	// handle the pip plane
 	if (pipPlane->GetId()) {
-		if (IsPipActive() && pip) {
+		if (IsPipActive() && pip && !m_videoIsScaled) {
 			SetPipBuffer(pip);
 			pipPlane->SetPlane(modeReq);
 			modeSet |= MODESET_PIP;
-		} else if (IsPipActive() && m_pCurrentlyPipDisplayed) {
+		} else if (IsPipActive() && m_pCurrentlyPipDisplayed  && !m_videoIsScaled) {
 			SetPipBuffer(m_pCurrentlyPipDisplayed);
 			pipPlane->SetPlane(modeReq);
 			modeSet |= MODESET_PIP;

--- a/videorender.cpp
+++ b/videorender.cpp
@@ -202,11 +202,14 @@ static sRect ComputeFittedRect(AVFrame *frame, uint64_t dispX, uint64_t dispY, u
  * Modesetting for video
  *
  * @param[in] buf    drm video buffer to display
+ *
+ * @retval 1         no modesetting was done
+ * @retval 0         modesetting was done
  */
-void cVideoRender::SetVideoBuffer(cDrmBuffer *buf)
+int cVideoRender::SetVideoBuffer(cDrmBuffer *buf)
 {
 	if (!buf)
-		return;
+		return 1;
 
 	AVFrame *frame = buf->frame;
 
@@ -236,6 +239,8 @@ void cVideoRender::SetVideoBuffer(cDrmBuffer *buf)
 
 	// set dimensions for grab early, because we might skip this at the next frame
 	m_lastVideoGrab.Set(fittedRect.x, fittedRect.y, fittedRect.w, fittedRect.h);
+
+	return 0;
 }
 
 /**
@@ -246,46 +251,48 @@ void cVideoRender::SetVideoBuffer(cDrmBuffer *buf)
  */
 int cVideoRender::SetOsdBuffer(drmModeAtomicReqPtr modeReq)
 {
+	if (!m_pBufOsd || !m_pBufOsd->IsDirty())
+		return 1;
+
 	cDrmPlane *videoPlane = m_pDrmDevice->VideoPlane();
 	cDrmPlane *osdPlane = m_pDrmDevice->OsdPlane();
 
 	// We had draw activity on the osd buffer
-	if (m_pBufOsd && m_pBufOsd->IsDirty()) {
-		if (m_pDrmDevice->UseZpos()) {
-			videoPlane->SetZpos(m_osdShown ? m_pDrmDevice->ZposPrimary() : m_pDrmDevice->ZposOverlay());
-			osdPlane->SetZpos(m_osdShown ? m_pDrmDevice->ZposOverlay() : m_pDrmDevice->ZposPrimary());
-			videoPlane->SetPlaneZpos(modeReq);
-			osdPlane->SetPlaneZpos(modeReq);
+	if (m_pDrmDevice->UseZpos()) {
+		videoPlane->SetZpos(m_osdShown ? m_pDrmDevice->ZposPrimary() : m_pDrmDevice->ZposOverlay());
+		osdPlane->SetZpos(m_osdShown ? m_pDrmDevice->ZposOverlay() : m_pDrmDevice->ZposPrimary());
+		videoPlane->SetPlaneZpos(modeReq);
+		osdPlane->SetPlaneZpos(modeReq);
 
-			LOGDEBUG2(L_DRM, "videorender: %s: SetPlaneZpos: video->plane_id %d -> zpos %" PRIu64 ", osd->plane_id %d -> zpos %" PRIu64 "", __FUNCTION__,
-				videoPlane->GetId(), videoPlane->GetZpos(),
-				osdPlane->GetId(), osdPlane->GetZpos());
-		}
-
-		uint64_t crtcW = m_osdShown ? m_pBufOsd->Width() : 0;
-		uint64_t crtcH = m_osdShown ? m_pBufOsd->Height() : 0;
-
-		// now set the plane parameters
-		osdPlane->SetParams(m_pDrmDevice->CrtcId(), m_pBufOsd->Id(),
-			0, 0, crtcW, crtcH,
-			0, 0, crtcW, crtcH);
-
-		m_pBufOsd->MarkClean();
-		return 0;
+		LOGDEBUG2(L_DRM, "videorender: %s: SetPlaneZpos: video->plane_id %d -> zpos %" PRIu64 ", osd->plane_id %d -> zpos %" PRIu64 "", __FUNCTION__,
+			videoPlane->GetId(), videoPlane->GetZpos(),
+			osdPlane->GetId(), osdPlane->GetZpos());
 	}
 
-	return 1;
+	uint64_t crtcW = m_osdShown ? m_pBufOsd->Width() : 0;
+	uint64_t crtcH = m_osdShown ? m_pBufOsd->Height() : 0;
+
+	// now set the plane parameters
+	osdPlane->SetParams(m_pDrmDevice->CrtcId(), m_pBufOsd->Id(),
+		0, 0, crtcW, crtcH,
+		0, 0, crtcW, crtcH);
+
+	m_pBufOsd->MarkClean();
+	return 0;
 }
 
 /**
  * Modesetting for pip
  *
  * @param[in] buf    drm video buffer to display
+ *
+ * @retval 1         no modesetting was done
+ * @retval 0         modesetting was done
  */
-void cVideoRender::SetPipBuffer(cDrmBuffer *buf)
+int cVideoRender::SetPipBuffer(cDrmBuffer *buf)
 {
-	if (!buf)
-		return;
+	if (!buf || !m_pipActive || m_videoIsScaled)
+		return 1;
 
 	AVFrame *frame = buf->frame;
 
@@ -332,6 +339,8 @@ void cVideoRender::SetPipBuffer(cDrmBuffer *buf)
 
 	// set dimensions for grab early, because we might skip this at the next frame
 	m_lastPipGrab.Set(crtcX, crtcY, crtcW, crtcH);
+
+	return 0;
 }
 
 /**
@@ -402,34 +411,22 @@ int cVideoRender::CommitBuffer(cDrmBuffer *buf, cDrmBuffer *pip)
 	}
 
 	// handle the video plane
-	if (buf) {
-		SetVideoBuffer(buf);
+	// If no new video is available, set the old buffer again, if available.
+	// This is necessary to recognize a size-change in SetVideoBuffer().
+	// Though this is not expensive, maybe we should only call that, if size really changed.
+	if (!SetVideoBuffer(buf) || !SetVideoBuffer(m_pCurrentlyDisplayed)) {
 		videoPlane->SetPlane(modeReq);
 		modeSet |= MODESET_VIDEO;
 //		LOGDEBUG2(L_DRM, "videorender: %s: SetPlane Video (fb = %" PRIu64 ")", __FUNCTION__, videoPlane->GetFbId());
-	} else if (m_pCurrentlyDisplayed) {
-		// If no new video is available, set the old buffer again, if available.
-		// This is necessary to recognize a size-change in SetVideoBuffer().
-		// Though this is not expensive, maybe we should only call that, if size really changed.
-		SetVideoBuffer(m_pCurrentlyDisplayed);
-		videoPlane->SetPlane(modeReq);
-		modeSet |= MODESET_VIDEO;
 	}
 
 	// handle the pip plane
 	if (pipPlane->GetId()) {
-		if (IsPipActive() && pip && !m_videoIsScaled) {
-			SetPipBuffer(pip);
+		if (!SetPipBuffer(pip) || !SetPipBuffer(m_pCurrentlyPipDisplayed))
 			pipPlane->SetPlane(modeReq);
-			modeSet |= MODESET_PIP;
-		} else if (IsPipActive() && m_pCurrentlyPipDisplayed  && !m_videoIsScaled) {
-			SetPipBuffer(m_pCurrentlyPipDisplayed);
-			pipPlane->SetPlane(modeReq);
-			modeSet |= MODESET_PIP;
-		} else {
+		else
 			pipPlane->ClearPlane(modeReq);
-			modeSet |= MODESET_PIP;
-		}
+		modeSet |= MODESET_PIP;
 	}
 
 	// handle the osd plane

--- a/videorender.cpp
+++ b/videorender.cpp
@@ -426,6 +426,7 @@ int cVideoRender::CommitBuffer(cDrmBuffer *buf, cDrmBuffer *pip)
 			pipPlane->SetPlane(modeReq);
 		else
 			pipPlane->ClearPlane(modeReq);
+
 		modeSet |= MODESET_PIP;
 	}
 

--- a/videorender.h
+++ b/videorender.h
@@ -192,7 +192,6 @@ public:
 
 	// PIP
 	void SetPipActive(bool on) { m_pipActive = on; };
-	bool IsPipActive(void) { return m_pipActive; };
 	void ClearPipDecoderToDisplayQueue(void);
 	void SetPipSize(bool);
 
@@ -268,9 +267,9 @@ private:
 	void SetFrameFlags(AVFrame *, int);
 	void SetVideoClock(int64_t);
 	bool PageFlip(cDrmBuffer *, cDrmBuffer *);
-	void SetVideoBuffer(cDrmBuffer *);
+	int SetVideoBuffer(cDrmBuffer *);
 	int SetOsdBuffer(drmModeAtomicReqPtr);
-	void SetPipBuffer(cDrmBuffer *);
+	int SetPipBuffer(cDrmBuffer *);
 	int CommitBuffer(cDrmBuffer *, cDrmBuffer *);
 	void Grab(cDrmBuffer *, cDrmBuffer *);
 	void LogDroppedDuped(int64_t, int64_t, int);


### PR DESCRIPTION
If the main video is scaled within a menu, the pip video is very small. RK3399 has some minimum drm plane size to be set - a width of 160 pixels was found out by testing. Because the pip video is very small and a "normal" user can't multi-task with 2 videos and a menu, we disable it for simplicity.

The minimum scale factor is hardcoded to 10% in the setup menu. So on a display which has a width > 1600px there should be no problem with having the pip area too small.