### PR TITLE
Refactor pip

### DIFF
--- a/pipreceiver.cpp
+++ b/pipreceiver.cpp
@@ -18,6 +18,7 @@
  */
 
 #include <vdr/remux.h>
+#include <vdr/skins.h>
 
 #include "logger.h"
 #include "pipreceiver.h"
@@ -145,4 +146,289 @@ int cPipReceiver::PlayTs(const uchar *data, int size)
 	m_pTsToPesVideo.PutTs(data, size);
 
 	return size;
+}
+
+/*****************************************************************************
+ * cPipHandler class
+ ****************************************************************************/
+
+/**
+ * cPipHandler constructor
+ */
+cPipHandler::cPipHandler(cSoftHdDevice *device)
+	: m_pDevice(device),
+	  m_pEventReceiver(device)
+{
+}
+
+cPipHandler::~cPipHandler(void)
+{
+	Stop();
+}
+
+/*****************************************************************************
+ * Handle events
+ *
+ * The following functions are called from within the state change and must
+ * not trigger any new events. Otherwise we end up in a dead lock!
+ ****************************************************************************/
+
+/**
+ * Handle the pip event
+ */
+void cPipHandler::HandleEvent(enum PipState event)
+{
+	switch (event) {
+		case PIPSTART:
+			HandleEnable(true);
+			break;
+		case PIPSTOP:
+			HandleEnable(false);
+			break;
+		case PIPTOGGLE:
+			HandleEnable(!m_active);
+			break;
+		case PIPCHANUP:
+			HandleChannelChange(1);
+			break;
+		case PIPCHANDOWN:
+			HandleChannelChange(-1);
+			break;
+		case PIPCHANSWAP:
+			Stop();
+			Start(0);
+			break;
+		case PIPSIZECHANGE:
+			m_pDevice->SetRenderPipSize();
+			break;
+		case PIPSWAPPOSITION:
+			m_pDevice->ToggleRenderPipPosition();
+			m_pDevice->SetRenderPipSize();
+			break;
+		default:
+			break;
+	}
+}
+
+/**
+ * Create a new pip receiver and render the pip stream
+ *
+ * @param channelNum    number of the channel to be switched to
+ *                      0 switches to the current main stream channel
+ *
+ * @retval 0     pip was enabled
+ * @retval -1    pip wasn't enabled, no device for channel available
+ *
+ * @note This function is called within the state change and must not trigger any new events!
+ */
+int cPipHandler::Start(int channelNum)
+{
+	if (!channelNum)
+		channelNum = m_pDevice->CurrentChannel();
+
+	LOCK_CHANNELS_READ;
+	const cChannel *channel;
+	cDevice *device;
+	cPipReceiver *receiver;
+
+	if (channelNum && (channel = Channels->GetByNumber(channelNum)) &&
+	   (device = m_pDevice->GetDevice(channel, 0, false, false))) {
+		Stop();
+		device->SwitchChannel(channel, false);
+		receiver = new cPipReceiver(channel, m_pDevice);
+		device->AttachReceiver(receiver);
+		m_pPipReceiver = receiver;
+		m_pPipChannel = channel;
+		m_pipChannelNum = channelNum;
+
+		LOGDEBUG("piphandler: %s: New receiver for channel (%d) %s", __FUNCTION__, channel->Number(), channel->Name());
+
+		m_active = true;
+		return 0;
+	}
+
+	LOGERROR("piphandler: %s: No receiver for channel num %d available", __FUNCTION__, channelNum);
+	return -1;
+}
+
+/**
+ * Delete the pip receiver, clear decoder and display buffers
+ * and disable rendering the pip window.
+ *
+ * We do not need to halt main stream decoder and display thread for this,
+ * so only halt the pip decoding thread here (in m_pDevice->ResetPipStream()) - not in OnEventReceived().
+ *
+ * @note This function is called within the state change and must not trigger any new events!
+ */
+void cPipHandler::Stop(void)
+{
+	m_active = false;
+
+	if (!m_pPipReceiver)
+		return;
+
+	LOGDEBUG("piphandler: %s: deleting receiver for channel (%d) %s", __FUNCTION__, m_pPipChannel->Number(), m_pPipChannel->Name());
+
+	m_pDevice->ResetPipStream();
+
+	delete m_pPipReceiver;
+	m_pPipReceiver = nullptr;
+	m_pPipChannel = nullptr;
+}
+
+/**
+ * Enable/ disable picture-in-picture
+ *
+ * @param on       true, if pip should be enabled
+ *
+ * @note This function is called within the state change and must not trigger any new events!
+ */
+void cPipHandler::HandleEnable(bool on)
+{
+	if (on && m_active) {
+		LOGDEBUG("piphandler: %s: pip is already enabled", __FUNCTION__);
+	} else if (on && !m_active) {
+		LOGDEBUG("piphandler: %s: enabling pip (channel %d)", __FUNCTION__, m_pipChannelNum);
+		if (!Start(0))
+			m_pDevice->SetRenderPipActive(true);
+	} else if (!on && !m_active) {
+		LOGDEBUG("piphandler: %s: pip is already disabled", __FUNCTION__);
+	} else if (!on && m_active){
+		LOGDEBUG("piphandler: %s: disabling pip", __FUNCTION__);
+		m_pDevice->SetRenderPipActive(false);
+		Stop();
+	}
+}
+
+/**
+ * Change the pip channel
+ *
+ * @param direction      1: channel up, -1: channel down
+ *
+ * @note This function is called within the state change and must not trigger any new events!
+ */
+void cPipHandler::HandleChannelChange(int direction)
+{
+	if (!m_active)
+		return;
+
+	const cChannel *channel;
+	const cChannel *first;
+
+	channel = m_pPipChannel;
+	first = channel;
+
+	Stop();
+
+	LOCK_CHANNELS_READ;
+	while (channel) {
+		bool ndr;
+		cDevice *device;
+
+		channel = direction > 0 ? Channels->Next(channel) : Channels->Prev(channel);
+		if (!channel && Setup.ChannelsWrap)
+			channel = direction > 0 ? Channels->First() : Channels->Last();
+
+		if (channel && !channel->GroupSep() && (device = cDevice::GetDevice(channel, 0, false, true)) &&
+			device->ProvidesChannel(channel, 0, &ndr) && !ndr) {
+				Start(channel->Number());
+				return;
+		}
+
+		if (channel == first) {
+			Skins.Message(mtError, tr("Channel not available!"));
+			break;
+		}
+	}
+}
+
+/*****************************************************************************
+ * Trigger events
+ *
+ * These (public) functions are wrapped by cSoftHdDevice and can be called
+ * to trigger a pip event.
+ ****************************************************************************/
+
+/**
+ * Start picture-in-picture
+ */
+void cPipHandler::Enable(void)
+{
+	if (m_active)
+		return;
+
+	m_pEventReceiver->OnEventReceived(PipEvent{PIPSTART});
+}
+
+/**
+ * Stop picture-in-picture
+ */
+void cPipHandler::Disable(void)
+{
+	if (!m_active)
+		return;
+
+	m_pEventReceiver->OnEventReceived(PipEvent{PIPSTOP});
+}
+
+/**
+ * Toggle picture-in-picture
+ */
+void cPipHandler::Toggle(void)
+{
+	m_pEventReceiver->OnEventReceived(PipEvent{PIPTOGGLE});
+}
+
+/**
+ * Change the pip channel
+ *
+ * @param direction      1: channel up, -1: channel down
+ */
+void cPipHandler::ChannelChange(int direction)
+{
+	if (!m_active)
+		return;
+
+	if (direction > 0)
+		m_pEventReceiver->OnEventReceived(PipEvent{PIPCHANUP});
+	else
+		m_pEventReceiver->OnEventReceived(PipEvent{PIPCHANDOWN});
+}
+
+/**
+ * Swap the pip channel with main live channel
+ *
+ * The channel switch of the main stream must be done out of OnEventReceived()
+ * because it triggers a SetPlayMode() which end in a deadlock otherwise.
+ */
+void cPipHandler::ChannelSwap(void)
+{
+	if (!m_active)
+		return;
+
+	const cChannel *channel = m_pPipChannel;
+	if (!channel)
+		return;
+
+	m_pEventReceiver->OnEventReceived(PipEvent{PIPCHANSWAP}); // resets the pip channel to the current channel
+
+	LOCK_CHANNELS_READ;
+	LOGDEBUG("piphandler: %s: switch main stream to %d", __FUNCTION__, channel->Number());
+	Channels->SwitchTo(channel->Number());
+}
+
+/**
+ * Set size and position for the pip window
+ */
+void cPipHandler::SetSize(void)
+{
+	m_pEventReceiver->OnEventReceived(PipEvent{PIPSIZECHANGE});
+}
+
+/**
+ * Swap pip between normal and alternative position
+ */
+void cPipHandler::SwapPosition(void)
+{
+	m_pEventReceiver->OnEventReceived(PipEvent{PIPSWAPPOSITION});
 }

--- a/pipreceiver.h
+++ b/pipreceiver.h
@@ -20,8 +20,11 @@
 #ifndef __PIPRECEIVER_H
 #define __PIPRECEIVER_H
 
+#include <vector>
+
 #include <vdr/receiver.h>
 
+#include "event.h"
 #include "softhddevice.h"
 
 /**
@@ -45,6 +48,39 @@ private:
 
 	int ParseTs(const uchar *, int);
 	int PlayTs(const uchar *, int);
+};
+
+/**
+ * cPipHandler - class for pip
+ */
+class cPipHandler
+{
+public:
+	cPipHandler(cSoftHdDevice *);
+	virtual ~cPipHandler(void);
+
+	bool IsEnabled(void) { return m_active; };
+	void Enable(void);
+	void Disable(void);
+	void Toggle(void);
+	void ChannelChange(int);
+	void ChannelSwap(void);
+	void SetSize(void);
+	void SwapPosition(void);
+	void HandleEvent(enum PipState);
+
+private:
+	cSoftHdDevice *m_pDevice;               ///< pointer to device
+	IEventReceiver *m_pEventReceiver;       ///< pointer to event receiver
+	cPipReceiver *m_pPipReceiver = nullptr; ///< pointer to pip receiver
+	int m_pipChannelNum;                    ///< current pip channel number
+	const cChannel *m_pPipChannel;          ///< current pip channel
+	bool m_active = false;                  ///< true, if pip is active
+
+	int Start(int);
+	void Stop(void);
+	void HandleEnable(bool);
+	void HandleChannelChange(int);
 };
 
 #endif

--- a/po/de_DE.po
+++ b/po/de_DE.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: VDR \n"
 "Report-Msgid-Bugs-To: <see README>\n"
-"POT-Creation-Date: 2025-12-06 08:50+0100\n"
+"POT-Creation-Date: 2026-01-21 08:54+0100\n"
 "PO-Revision-Date: blabla\n"
 "Last-Translator: blabla\n"
 "Language-Team: blabla\n"
@@ -15,6 +15,9 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
+
+msgid "Channel not available!"
+msgstr "Kanal nicht verfügbar!"
 
 msgid "A software and GPU emulated HD device"
 msgstr "HD Device mit software und GPU Unterstützung"
@@ -41,9 +44,6 @@ msgstr ""
 #, c-format
 msgid "Unhandled argument '%s'\n"
 msgstr ""
-
-msgid "Channel not available!"
-msgstr "Kanal nicht verfügbar!"
 
 msgid " Toggle"
 msgstr " Ein/Aus"

--- a/softhddevice.cpp
+++ b/softhddevice.cpp
@@ -242,7 +242,7 @@ void cSoftHdDevice::OnEventReceived(const Event& event)
 					HandleStillPicture(s.data, s.size);
 				},
 				[this, &needsResume](const DetachEvent&) {
-					HandlePip(PIPSTOP);
+					m_pPipHandler->HandleEvent(PIPSTOP);
 					SetState(DETACHED);
 					needsResume = false;
 				},
@@ -250,7 +250,7 @@ void cSoftHdDevice::OnEventReceived(const Event& event)
 				[&invalid](const BufferUnderrunEvent&) { invalid(); },
 				[&invalid](const BufferingThresholdReachedEvent&) { invalid(); },
 				[this](const PipEvent& p) {
-					HandlePip(p.state);
+					m_pPipHandler->HandleEvent(p.state);
 				},
 			}, event);
 			break;
@@ -305,7 +305,7 @@ void cSoftHdDevice::OnEventReceived(const Event& event)
 					SetState(PLAY);
 				},
 				[this](const PipEvent& p) {
-					HandlePip(p.state);
+					m_pPipHandler->HandleEvent(p.state);
 				},
 			}, event);
 			break;
@@ -351,7 +351,7 @@ void cSoftHdDevice::OnEventReceived(const Event& event)
 					HandleStillPicture(s.data, s.size);
 				},
 				[this, &needsResume](const DetachEvent&) {
-					HandlePip(PIPSTOP);
+					m_pPipHandler->HandleEvent(PIPSTOP);
 					SetState(DETACHED);
 					needsResume = false;
 				},
@@ -363,7 +363,7 @@ void cSoftHdDevice::OnEventReceived(const Event& event)
 					// ignore
 				},
 				[this](const PipEvent& p) {
-					HandlePip(p.state);
+					m_pPipHandler->HandleEvent(p.state);
 				},
 			}, event);
 			break;
@@ -388,7 +388,7 @@ void cSoftHdDevice::OnEventReceived(const Event& event)
 					HandleStillPicture(s.data, s.size);
 				},
 				[this, &needsResume](const DetachEvent&) {
-					HandlePip(PIPSTOP);
+					m_pPipHandler->HandleEvent(PIPSTOP);
 					SetState(DETACHED);
 					needsResume = false;
 				},
@@ -398,7 +398,7 @@ void cSoftHdDevice::OnEventReceived(const Event& event)
 				},
 				[&invalid](const BufferingThresholdReachedEvent&) { invalid(); },
 				[this](const PipEvent& p) {
-					HandlePip(p.state);
+					m_pPipHandler->HandleEvent(p.state);
 				},
 			}, event);
 			break;
@@ -462,6 +462,9 @@ void cSoftHdDevice::OnEnteringState(State state) {
 
 			break;
 		case DETACHED:
+			delete m_pPipHandler;
+			m_pPipHandler = nullptr;
+
 			// resume the previously stopped threads
 			m_pVideoStream->DecodingThreadResume();
 			m_pRender->DisplayThreadResume();
@@ -529,6 +532,7 @@ void cSoftHdDevice::OnLeavingState(State state) {
 			m_pVideoStream->StartDecoder(); // starts decoding thread
 			m_pPipStream = new cPipVideoStream(m_pRender, m_pRender->GetPipOutputBuffer(), m_pConfig, std::bind(&cVideoRender::PushPipFrame, m_pRender, std::placeholders::_1));
 			m_pPipStream->StartDecoder(); // starts decoding thread
+			m_pPipHandler = new cPipHandler(this);
 			// Audio is init lazily (includes starting thread)
 
 			break;
@@ -1641,259 +1645,12 @@ int cSoftHdDevice::GetBufferFillLevelThresholdMs() {
 }
 
 /**
- * Start picture-in-picture
+ * Resets pip stream and render pipeline
  */
-void cSoftHdDevice::PipEnable(void)
+void cSoftHdDevice::ResetPipStream(void)
 {
-	OnEventReceived(PipEvent{PIPSTART});
-}
-
-/**
- * Stop picture-in-picture
- */
-void cSoftHdDevice::PipDisable(void)
-{
-	OnEventReceived(PipEvent{PIPSTOP});
-}
-
-/**
- * Toggle picture-in-picture
- */
-void cSoftHdDevice::PipToggle(void)
-{
-	OnEventReceived(PipEvent{PIPTOGGLE});
-}
-
-/**
- * Returns true, if picture-in-picture is running
- */
-bool cSoftHdDevice::PipIsEnabled(void)
-{
-	std::lock_guard<std::mutex> lock(m_mutex);
-	return m_pipActive;
-}
-
-/**
- * Change the pip channel
- *
- * @param direction      1: channel up, -1: channel down
- */
-void cSoftHdDevice::PipChannelChange(int direction)
-{
-	if (direction > 0)
-		OnEventReceived(PipEvent{PIPCHANUP});
-	else
-		OnEventReceived(PipEvent{PIPCHANDOWN});
-}
-
-/**
- * Swap the pip channel with main live channel
- *
- * The channel switch of the main stream must be done out of OnEventReceived()
- * because it triggers a SetPlayMode() which end in a deadlock otherwise.
- */
-void cSoftHdDevice::PipChannelSwap(void)
-{
-	const cChannel *channel = m_pPipChannel;
-	if (!channel)
-		return;
-
-	OnEventReceived(PipEvent{PIPCHANSWAP}); // resets the pip channel to the current channel
-
-	if (channel) {
-		LOCK_CHANNELS_READ;
-		LOGDEBUG("pip: %s: switch main stream to %d", __FUNCTION__, channel->Number());
-		Channels->SwitchTo(channel->Number());
-	}
-}
-
-/**
- * Set size and position for the pip window
- */
-void cSoftHdDevice::PipSetSize(void)
-{
-	OnEventReceived(PipEvent{PIPSIZECHANGE});
-}
-
-/**
- * Swap pip between normal and alternative position
- */
-void cSoftHdDevice::PipSwapPosition(void)
-{
-	OnEventReceived(PipEvent{PIPSWAPPOSITION});
-}
-
-/**
- * Handle the pip event
- */
-void cSoftHdDevice::HandlePip(enum PipState event)
-{
-	switch (event) {
-		case PIPSTART:
-			SetEnablePip(true);
-			break;
-		case PIPSTOP:
-			SetEnablePip(false);
-			break;
-		case PIPTOGGLE:
-			TogglePip();
-			break;
-		case PIPCHANUP:
-			ChangePipChannel(1);
-			break;
-		case PIPCHANDOWN:
-			ChangePipChannel(-1);
-			break;
-		case PIPCHANSWAP:
-			ResetPipChannel();
-			break;
-		case PIPSIZECHANGE:
-			SetPipSize();
-			break;
-		case PIPSWAPPOSITION:
-			SwapPipPosition();
-			break;
-		default:
-			break;
-	}
-}
-
-/**
- * Enable/ disable picture-in-picture
- *
- * @param on       true, if pip should be enabled
- *
- * @note This function is called from HandlePip() within the state change
- */
-void cSoftHdDevice::SetEnablePip(bool on)
-{
-	if (m_pipActive && on) {
-		LOGDEBUG("device: %s: pip is already enabled", __FUNCTION__);
-		return;
-	}
-
-	if (!m_pipActive && !on) {
-		LOGDEBUG("device: %s: pip is already disabled", __FUNCTION__);
-		return;
-	}
-
-	if (!m_pipActive) {
-		LOGDEBUG("device: %s: enabling pip (channel %d)", __FUNCTION__, m_pipChannelNum);
-		NewPip(0);
-		m_pRender->SetPipActive(true);
-	} else {
-		LOGDEBUG("device: %s: disabling pip", __FUNCTION__);
-		m_pRender->SetPipActive(false);
-		DelPip();
-	}
-
-	m_pipActive = on;
-}
-
-/**
- * Toggle picture-in-picture
- *
- * @note This function is called from HandlePip() within the state change
- */
-void cSoftHdDevice::TogglePip(void)
-{
-	SetEnablePip(!m_pipActive);
-}
-
-/**
- * Change the pip channel
- *
- * @param direction      1: channel up, -1: channel down
- *
- * @note This function is called from HandlePip() within the state change
- */
-void cSoftHdDevice::ChangePipChannel(int direction)
-{
-	if (!m_pipActive)
-		return;
-
-	const cChannel *channel;
-	const cChannel *first;
-
-	channel = m_pPipChannel;
-	first = channel;
-
-	DelPip();
-
-	LOCK_CHANNELS_READ;
-	while (channel) {
-		bool ndr;
-		cDevice *device;
-
-		channel = direction > 0 ? Channels->Next(channel) : Channels->Prev(channel);
-		if (!channel && Setup.ChannelsWrap)
-			channel = direction > 0 ? Channels->First() : Channels->Last();
-
-		if (channel && !channel->GroupSep() && (device = cDevice::GetDevice(channel, 0, false, true)) &&
-			device->ProvidesChannel(channel, 0, &ndr) && !ndr) {
-				NewPip(channel->Number());
-				return;
-		}
-
-		if (channel == first) {
-			Skins.Message(mtError, tr("Channel not available!"));
-			break;
-		}
-	}
-}
-
-/**
- * Resets the pip channel to the current live stream channel
- *
- * @note This function is called from HandlePip() within the state change
- */
-void cSoftHdDevice::ResetPipChannel(void)
-{
-	if (!m_pipActive)
-		return;
-
-	DelPip();
-	NewPip(0);
-}
-
-/**
- * Set size and position for the pip window
- *
- * @note This function is called from HandlePip() within the state change
- */
-void cSoftHdDevice::SetPipSize(void)
-{
-	m_pRender->SetPipSize(m_pipUseAlt);
-}
-
-/**
- * Swap pip between normal and alternative position
- *
- * @note This function is called from HandlePip() within the state change
- */
-void cSoftHdDevice::SwapPipPosition(void)
-{
-	m_pipUseAlt = !m_pipUseAlt;
-	m_pRender->SetPipSize(m_pipUseAlt);
-}
-
-/**
- * Delete the pip receiver, clear decoder and display buffers
- * and disable rendering the pip window.
- *
- * We do not need to halt main stream decoder and display thread for this,
- * so only halt the pip decoding thread here - not in OnEventReceived().
- *
- * The last viewed pip channel is remembered and will be used when opening a new pip window.
- */
-void cSoftHdDevice::DelPip(void)
-{
-	if (!m_pPipReceiver)
-		return;
-
-	LOGDEBUG("pip: %s: deleting receiver for channel (%d) %s", __FUNCTION__, m_pPipChannel->Number(), m_pPipChannel->Name());
-
 	m_pPipStream->DecodingThreadHalt();
+
 	m_pPipStream->CancelFilterThread();
 	m_pipReassemblyBuffer.Reset();
 	m_pPipStream->ClearVdrCoreToDecoderQueue();
@@ -1901,39 +1658,28 @@ void cSoftHdDevice::DelPip(void)
 	m_pRender->ResetPipDecodingStrategy();
 	m_pRender->ResetPipBufferReuseStrategy();
 	m_pPipStream->CloseDecoder();
-	m_pPipStream->DecodingThreadResume();
 
-	delete m_pPipReceiver;
-	m_pPipReceiver = nullptr;
-	m_pPipChannel = nullptr;
+	m_pPipStream->DecodingThreadResume();
 }
 
 /**
- * Create a new pip receiver and render the pip stream
- *
- * @param channelNum    number of the channel to be switched to
- *                      0 switches to the current main stream channel
+ * Returns true, if pip is currently enabled
  */
-void cSoftHdDevice::NewPip(int channelNum)
+bool cSoftHdDevice::PipIsEnabled(void)
 {
-	if (!channelNum)
-		channelNum = CurrentChannel();
-
-	LOCK_CHANNELS_READ;
-	const cChannel *channel;
-	cDevice *device;
-	cPipReceiver *receiver;
-
-	if (channelNum && (channel = Channels->GetByNumber(channelNum)) &&
-	   (device = GetDevice(channel, 0, false, false))) {
-		DelPip();
-		device->SwitchChannel(channel, false);
-		receiver = new cPipReceiver(channel, this);
-		device->AttachReceiver(receiver);
-		m_pPipReceiver = receiver;
-		m_pPipChannel = channel;
-		m_pipChannelNum = channelNum;
-
-		LOGDEBUG("pip: %s: New receiver for channel (%d) %s", __FUNCTION__, channel->Number(), channel->Name());
-	}
+	std::lock_guard<std::mutex> lock(m_mutex);
+	return m_pPipHandler->IsEnabled();
 }
+
+/**
+ * Wrapper functions for cVideoRender and cPipHandler
+ */
+void cSoftHdDevice::SetRenderPipSize(void) { m_pRender->SetPipSize(m_pipUseAlt); };
+void cSoftHdDevice::SetRenderPipActive(bool active) { m_pRender->SetPipActive(active); };
+void cSoftHdDevice::PipEnable(void) { m_pPipHandler->Enable(); };
+void cSoftHdDevice::PipDisable(void) { m_pPipHandler->Disable(); };
+void cSoftHdDevice::PipToggle(void) { m_pPipHandler->Toggle(); };
+void cSoftHdDevice::PipChannelChange(int dir) { m_pPipHandler->ChannelChange(dir); };
+void cSoftHdDevice::PipChannelSwap(void) { m_pPipHandler->ChannelSwap(); };
+void cSoftHdDevice::PipSwapPosition(void) { m_pPipHandler->SwapPosition(); };
+void cSoftHdDevice::PipSetSize(void) { m_pPipHandler->SetSize(); };

--- a/softhddevice.cpp
+++ b/softhddevice.cpp
@@ -1102,6 +1102,13 @@ int cSoftHdDevice::PlayPipVideo(const uchar *data, int size)
 {
 //	LOGDEBUG("device: %s: %p %d", __FUNCTION__, data, size);
 
+	// This is a bit hacky:
+	// Because we do no sync with the pip stream, we simply drop data
+	// if the input buffer is full -> this prevents us from having a buffer overflow
+	// caused by the pip stream.
+	if (m_pPipStream->IsInputBufferFull())
+		return size;
+
 	return PlayVideoInternal(m_pPipStream, &m_pipReassemblyBuffer, data, size, false);
 }
 

--- a/softhddevice.h
+++ b/softhddevice.h
@@ -106,6 +106,7 @@ class cVideoRender;
 class cSoftHdAudio;
 class cSoftHdConfig;
 class cPipReceiver;
+class cPipHandler;
 
 class cSoftHdDevice : public cDevice, public IEventReceiver
 {
@@ -214,18 +215,24 @@ public:
 
 	bool IsBufferingThresholdReached(void);
 
-	// pip
+	// pip wrapper functions
+	bool PipIsEnabled(void);
 	void PipEnable(void);
 	void PipDisable(void);
 	void PipToggle(void);
 	void PipChannelChange(int);
 	void PipChannelSwap(void);
-	bool PipIsEnabled(void);
-	int PlayPipVideo(const uchar *, int);
-	void PipSetSize(void);
 	void PipSwapPosition(void);
+	void PipSetSize(void);
+	void SetRenderPipSize(void);
+	void SetRenderPipActive(bool);
+
+	// pip functions
+	int PlayPipVideo(const uchar *, int);
 	void SetDrmCanDisplayPip(bool canDisplay) { m_drmCanDisplayPip = canDisplay; };
-	bool UsePip(void) { return m_drmCanDisplayPip && !m_disablePip; };
+	bool UsePip(void) { return m_drmCanDisplayPip && !m_disablePip && m_pPipHandler; };
+	void ResetPipStream(void);
+	void ToggleRenderPipPosition(void) { m_pipUseAlt = !m_pipUseAlt; };
 
 private:
 	static constexpr int MIN_BUFFER_FILL_LEVEL_THRESHOLD_MS = 450; ///< min buffering threshold in ms
@@ -249,12 +256,9 @@ private:
 	int m_audioChannelID = -1;       ///< current audio channel ID
 	cSoftHdGrab *m_pGrab;            ///< pointer to grabber object
 
-	bool m_pipActive = false;        ///< true, if pip is active
-	int m_pipChannelNum;             ///< current pip channel number
-	const cChannel *m_pPipChannel;   ///< current pip channel
-	cPipReceiver *m_pPipReceiver;    ///< cReceiver for pip stream
 	cVideoStream *m_pPipStream;      ///< pointer to pip video stream
 	cReassemblyBufferVideo m_pipReassemblyBuffer; ///< pip pes reassembly buffer
+	cPipHandler *m_pPipHandler = nullptr; ///< pointer to pip handler
 	mutable std::mutex m_mutex;      ///< mutex to lock the state machine
 	std::mutex m_sizeMutex;          ///< mutex to lock screen size (which is accessed by different threads)
 	std::atomic<bool> m_receivedAudio = false; ///< flag if audio packets have been received
@@ -282,17 +286,6 @@ private:
 	void SetState(State);
 	void OnEnteringState(State);
 	void OnLeavingState(State);
-
-	// PIP
-	void SetEnablePip(bool);
-	void TogglePip(void);
-	void ChangePipChannel(int);
-	void ResetPipChannel(void);
-	void DelPip(void);
-	void NewPip(int);
-	void HandlePip(enum PipState);
-	void SetPipSize(void);
-	void SwapPipPosition(void);
 };
 
 #endif


### PR DESCRIPTION
- move pip bits to own class
- improve pip stability (at least a bit)

What should be done:
There is some problem with Sync/BufferThresoldReachedEvent on a channel switch when pip is active.
We have some wrong video pts for the sync (First received PTS) when starting the new channel stream and if the audio is behind video, we do not wait for starting the video but do frame dups instead. 
It's ok, but not the same behaviour as without pip active.

I guess this is just a small missing bit somewhere, but i couldn't find the reason yet...