### PR TITLE
fix bus error and segfault when GLES is disabled

### DIFF
--- a/videorender.cpp
+++ b/videorender.cpp
@@ -1151,8 +1151,6 @@ void cVideoRender::SetScreenSize(int width, int height, double refreshRateHz)
  */
 void cVideoRender::Init(void)
 {
-	m_pDisplayThread = new cDisplayThread(this);
-
 	if (m_pDrmDevice->Init())
 		LOGFATAL("videorender: %s: failed", __FUNCTION__);
 
@@ -1250,6 +1248,8 @@ void cVideoRender::Init(void)
 
 	// init variables page flip
 	m_pDrmDevice->InitEvent();
+
+	m_pDisplayThread = new cDisplayThread(this);
 }
 
 /**


### PR DESCRIPTION
First do a complete drmdevice init, and then start the display thread. Otherwise the PageFlip wants to access uninitialized objects.

fixes: https://github.com/rellla/vdr-plugin-softhddevice-drm-gles/issues/169

This only occured without GLES, because there we have m_pBufOsd already set and trigger a PageFlip without drm initialized completely.