### PR TITLE
logger: rewrite ffmpeg logging and make it setup configureable

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,6 @@ GRID ?= 0
 CONFIG :=
 #CONFIG += -DMEDIA_DEBUG	# enable mediaplayer dumps
 #CONFIG += -DALSA_DEBUG		# enable alsa logs
-#CONFIG += -DFFMPEG_DEBUG	# enable ffmpeg logs
 
 ifeq ($(GLES),1)
 CONFIG += -DUSE_GLES			# build with OpenGL/ES support

--- a/README.md
+++ b/README.md
@@ -274,20 +274,21 @@ Setup: /etc/vdr/setup.conf
 	softhddevice-drm-gles.LogLevel = 0
 		0 = default (no debug logs)
 		value is the sum of the following levels
-			1    Standard debug logs
-			2    AV-Sync debug logs
-			4    Sound/Audio debug logs
-			8    Osd debug logs
-			16   DRM debug logs
-			32   Codec (audio+video) debug logs
-			64   Stillpicture debug logs
-			128  Trickspeed debug logs
-			256  Mediaplayer debug logs
-			512  OpenGL/ES debug logs
-			1024 OpenGL/ES Osd flush time measurement
-			2048 OpenGL/ES Osd single command time measurement
-			4096 Packet tracking logs (decoder + display)
-			8192 Grabbing debug logs
+			1     Standard debug logs
+			2     AV-Sync debug logs
+			4     Sound/Audio debug logs
+			8     Osd debug logs
+			16    DRM debug logs
+			32    Codec (audio+video) debug logs
+			64    Stillpicture debug logs
+			128   Trickspeed debug logs
+			256   Mediaplayer debug logs
+			512   OpenGL/ES debug logs
+			1024  OpenGL/ES Osd flush time measurement
+			2048  OpenGL/ES Osd single command time measurement
+			4096  Packet tracking logs (decoder + display)
+			8192  Grabbing debug logs
+			16384 FFmpeg debug logs
 
 	softhddevice-drm-gles.DisableDeint = 0
 		0 = deinterlacer active if available

--- a/codec_video.cpp
+++ b/codec_video.cpp
@@ -22,12 +22,6 @@
  * GNU Affero General Public License for more details.}
  */
 
-#ifdef FFMPEG_DEBUG
-#include <sys/syscall.h>
-#include <syslog.h>
-#include <unistd.h>
-#endif
-
 extern "C" {
 #include <libavcodec/avcodec.h>
 #include <libavcodec/bsf.h>
@@ -42,46 +36,12 @@ extern "C" {
 #include "misc.h"
 #include "videostream.h"
 
-
 //#define NUM_CAPTURE_BUFFERS 10
 //#define NUM_OUTPUT_BUFFERS 10
-#define AV_LOGLEVEL AV_LOG_TRACE
 
 /******************************************************************************
  * static functions
  *****************************************************************************/
-
-/**
- * Logging callback, used for ffmpeg logging
- */
-#ifdef FFMPEG_DEBUG
-static void CodecLogCallback(__attribute__ ((unused)) void *ptr,
-                             __attribute__ ((unused)) int level,
-                             __attribute__ ((unused)) const char *fmt,
-                             va_list vl)
-{
-	av_log_set_level(AV_LOG_INFO);
-
-	if (level > AV_LOGLEVEL)
-		return;
-
-	char format[256];
-	char prefix[20] = "";
-	pid_t threadId = syscall(__NR_gettid);
-
-	strcpy(prefix, "[FFMpeg]");
-	snprintf(format, sizeof(format), "[%d] [softhddevice]%s %s", threadId, prefix, fmt);
-
-	vsyslog(LOG_INFO, format, vl);
-}
-#else
-static void CodecLogCallback(__attribute__ ((unused)) void *ptr,
-                             __attribute__ ((unused)) int level,
-                             __attribute__ ((unused)) const char *fmt,
-                             __attribute__ ((unused)) va_list vl)
-{
-}
-#endif
 
 /**
  * Callback to negotiate the PixelFormat
@@ -191,7 +151,7 @@ cVideoDecoder::cVideoDecoder(int hardwareQuirks, const char *identifier)
 	: m_identifier(identifier),
 	  m_hardwareQuirks(hardwareQuirks)
 {
-	av_log_set_callback(CodecLogCallback);
+	av_log_set_callback(cSoftHdLogger::LogFFmpegCallback);
 
 #if LIBAVCODEC_VERSION_INT < AV_VERSION_INT(58,18,100)
 	avcodec_register_all();		// register all formats and codecs

--- a/config.cpp
+++ b/config.cpp
@@ -120,6 +120,8 @@ void cSoftHdConfig::PrintLogLevel(int loglevel)
 		strcat(prefix, " drm,");
 	if (loglevel & L_CODEC)
 		strcat(prefix, " codec,");
+	if (loglevel & L_FFMPEG)
+		strcat(prefix, " ffmpeg,");
 	if (loglevel & L_STILL)
 		strcat(prefix, " stillpicture,");
 	if (loglevel & L_TRICK)

--- a/logger.cpp
+++ b/logger.cpp
@@ -31,6 +31,10 @@
 #include <sys/syscall.h>
 #include <unistd.h>
 
+extern "C" {
+#include <libavutil/log.h>
+}
+
 #include <vdr/tools.h>
 
 #include "logger.h"
@@ -57,7 +61,7 @@ std::shared_ptr<cSoftHdLogger> cSoftHdLogger::GetLogger()
  */
 void cSoftHdLogger::SetLogLevel(int level)
 {
-	logLevel = level;
+	m_logLevel = level;
 }
 
 /**
@@ -143,7 +147,7 @@ void cSoftHdLogger::LogInfo(const char *format, ...)
  */
 void cSoftHdLogger::LogDebug(const char *format, ...)
 {
-	if (!logLevel)
+	if (!m_logLevel)
 		return;
 
 	va_list ap;
@@ -169,7 +173,7 @@ void cSoftHdLogger::LogDebug2(const int cat, const char *format, ...)
 	char fmt[256];
 	char prefix[20] = "";
 
-	switch (logLevel & cat) {
+	switch (m_logLevel & cat) {
 	case L_AV_SYNC:
 		strcpy(prefix, "[AV_Sync]");
 		break;
@@ -215,4 +219,35 @@ void cSoftHdLogger::LogDebug2(const int cat, const char *format, ...)
 	va_start(ap, format);
 	vsyslog(LOG_DEBUG, fmt, ap);
 	va_end(ap);
+}
+
+/**
+ * Log to LOG_DEBUG and add prefix [FFMpeg] to output
+ */
+void cSoftHdLogger::LogFFmpeg(const char *fmt, va_list vl)
+{
+	if (!(m_logLevel & L_FFMPEG))
+		return;
+
+	av_log_set_level(AV_LOGLEVEL);
+
+	char format[256];
+	char prefix[20] = "";
+	pid_t threadId = syscall(__NR_gettid);
+
+	strcpy(prefix, "[FFMpeg]");
+	snprintf(format, sizeof(format), "[%d] [softhddevice]%s %s", threadId, prefix, fmt);
+
+	vsyslog(LOG_DEBUG, format, vl);
+}
+
+/**
+ * Callback for ffmpeg logs
+ *
+ * Log to LOG_DEBUG and add prefix to output
+ */
+void cSoftHdLogger::LogFFmpegCallback([[maybe_unused]] void *ptr, [[maybe_unused]] int level, const char *fmt, va_list vl)
+{
+	if (auto logger = GetLogger())
+		logger->LogFFmpeg(fmt, vl);
 }

--- a/logger.h
+++ b/logger.h
@@ -20,7 +20,11 @@
 #ifndef __LOGGER_H
 #define __LOGGER_H
 
+#include <atomic>
 #include <memory>
+
+// FFmpeg log level
+#define AV_LOGLEVEL AV_LOG_INFO
 
 /**
  * Logger macros
@@ -59,6 +63,7 @@
 #define L_OPENGL_TIME_ALL  (1 << 11)
 #define L_PACKET           (1 << 12)
 #define L_GRAB             (1 << 13)
+#define L_FFMPEG           (1 << 14)
 
 /**
  * cSoftHdLogger - Logger class
@@ -66,12 +71,14 @@
 class cSoftHdLogger {
 public:
 	static std::shared_ptr<cSoftHdLogger> GetLogger();
+	static void LogFFmpegCallback(void *, int, const char *, va_list);
 	void LogFatal(const char *format, ...);
 	void LogError(const char *format, ...);
 	void LogWarning(const char *format, ...);
 	void LogInfo(const char *format, ...);
 	void LogDebug(const char *format, ...);
 	void LogDebug2(const int cat, const char *format, ...);
+	void LogFFmpeg(const char *, va_list);
 	void SetLogLevel(int level);
 
 private:
@@ -79,7 +86,7 @@ private:
 	cSoftHdLogger(const cSoftHdLogger &) = delete;
 	cSoftHdLogger& operator=(const cSoftHdLogger &) = delete;
 
-	int logLevel = 0; ///< loglevel (see Logger flags above)
+	std::atomic<int> m_logLevel = 0; ///< loglevel (see Logger flags above)
 };
 
 #endif

--- a/po/de_DE.po
+++ b/po/de_DE.po
@@ -109,20 +109,29 @@ msgstr "Aktiviere Logs"
 msgid "  Standard debug logs"
 msgstr "  Standard debug Logs"
 
+msgid "  DRM debug logs"
+msgstr "  DRM debug Logs"
+
+msgid "  Codec debug logs"
+msgstr "  Codec debug Logs"
+
 msgid "  AV Sync debug logs"
 msgstr "  AV Sync debug Logs"
 
 msgid "  Sound debug logs"
 msgstr "  Sound debug Logs"
 
+msgid "  FFmpeg debug logs"
+msgstr "  FFMpeg logs"
+
+msgid "  Packet tracking logs"
+msgstr "  Paketverfolgung"
+
 msgid "  OSD debug logs"
 msgstr "  OSD debug Logs"
 
-msgid "  DRM debug logs"
-msgstr "  DRM debug Logs"
-
-msgid "  Codec debug logs"
-msgstr "  Codec debug Logs"
+msgid "  Grabbing debug logs"
+msgstr "  Grabbing debug Logs"
 
 msgid "  Stillpicture debug logs"
 msgstr "  Standbild debug Logs"
@@ -141,12 +150,6 @@ msgstr "  OpenGL OSD Zeitmessung"
 
 msgid "  OpenGL OSD time measurement (extensive)"
 msgstr "  OpenGL OSD Zeitmessung (alles)"
-
-msgid "  Packet tracking logs"
-msgstr "  Paketverfolgung"
-
-msgid "  Grabbing debug logs"
-msgstr "  Grabbing debug Logs"
 
 msgid "Video"
 msgstr "Video"

--- a/softhdsetupmenu.cpp
+++ b/softhdsetupmenu.cpp
@@ -127,19 +127,20 @@ void cMenuSetupSoft::Create(void)
 		Add(new cMenuEditBoolItem(tr("Enable logging"), &m_cLogDefault, trVDR("off"), trVDR("on")));
 		if (m_cLogDefault) {
 			Add(new cMenuEditBoolItem(tr("\040\040Standard debug logs"), &m_cLogDebug_, trVDR("no"), trVDR("yes")));
-			Add(new cMenuEditBoolItem(tr("\040\040AV Sync debug logs"), &m_cLogAVSync, trVDR("no"), trVDR("yes")));
-			Add(new cMenuEditBoolItem(tr("\040\040Sound debug logs"), &m_cLogSound, trVDR("no"), trVDR("yes")));
-			Add(new cMenuEditBoolItem(tr("\040\040OSD debug logs"), &m_cLogOSD, trVDR("no"), trVDR("yes")));
 			Add(new cMenuEditBoolItem(tr("\040\040DRM debug logs"), &m_cLogDRM, trVDR("no"), trVDR("yes")));
 			Add(new cMenuEditBoolItem(tr("\040\040Codec debug logs"), &m_cLogCodec, trVDR("no"), trVDR("yes")));
+			Add(new cMenuEditBoolItem(tr("\040\040AV Sync debug logs"), &m_cLogAVSync, trVDR("no"), trVDR("yes")));
+			Add(new cMenuEditBoolItem(tr("\040\040Sound debug logs"), &m_cLogSound, trVDR("no"), trVDR("yes")));
+			Add(new cMenuEditBoolItem(tr("\040\040FFmpeg debug logs"), &m_cLogFFmpeg, trVDR("no"), trVDR("yes")));
+			Add(new cMenuEditBoolItem(tr("\040\040Packet tracking logs"), &m_cLogPacket, trVDR("no"), trVDR("yes")));
+			Add(new cMenuEditBoolItem(tr("\040\040OSD debug logs"), &m_cLogOSD, trVDR("no"), trVDR("yes")));
+			Add(new cMenuEditBoolItem(tr("\040\040Grabbing debug logs"), &m_cLogGrab, trVDR("no"), trVDR("yes")));
 			Add(new cMenuEditBoolItem(tr("\040\040Stillpicture debug logs"), &m_cLogStill, trVDR("no"), trVDR("yes")));
 			Add(new cMenuEditBoolItem(tr("\040\040Trickspeed debug logs"), &m_cLogTrick, trVDR("no"), trVDR("yes")));
 			Add(new cMenuEditBoolItem(tr("\040\040Mediaplayer debug logs"), &m_cLogMedia, trVDR("no"), trVDR("yes")));
 			Add(new cMenuEditBoolItem(tr("\040\040OpenGL OSD debug logs"), &m_cLogGL, trVDR("no"), trVDR("yes")));
 			Add(new cMenuEditBoolItem(tr("\040\040OpenGL OSD time measurement"), &m_cLogGLTime, trVDR("no"), trVDR("yes")));
 			Add(new cMenuEditBoolItem(tr("\040\040OpenGL OSD time measurement (extensive)"), &m_cLogGLTimeAll, trVDR("no"), trVDR("yes")));
-			Add(new cMenuEditBoolItem(tr("\040\040Packet tracking logs"), &m_cLogPacket, trVDR("no"), trVDR("yes")));
-			Add(new cMenuEditBoolItem(tr("\040\040Grabbing debug logs"), &m_cLogGrab, trVDR("no"), trVDR("yes")));
 		}
 	}
 
@@ -316,6 +317,7 @@ cMenuSetupSoft::cMenuSetupSoft(cSoftHdDevice *device)
 	m_cLogOSD       = m_pConfig->ConfigLogLevels & L_OSD;
 	m_cLogDRM       = m_pConfig->ConfigLogLevels & L_DRM;
 	m_cLogCodec     = m_pConfig->ConfigLogLevels & L_CODEC;
+	m_cLogFFmpeg    = m_pConfig->ConfigLogLevels & L_FFMPEG;
 	m_cLogStill     = m_pConfig->ConfigLogLevels & L_STILL;
 	m_cLogTrick     = m_pConfig->ConfigLogLevels & L_TRICK;
 	m_cLogMedia     = m_pConfig->ConfigLogLevels & L_MEDIA;
@@ -402,6 +404,7 @@ void cMenuSetupSoft::Store(void)
 		(m_cLogOSD       ? L_OSD : 0) |
 		(m_cLogDRM       ? L_DRM : 0) |
 		(m_cLogCodec     ? L_CODEC : 0) |
+		(m_cLogFFmpeg    ? L_FFMPEG : 0) |
 		(m_cLogStill     ? L_STILL : 0) |
 		(m_cLogTrick     ? L_TRICK : 0) |
 		(m_cLogMedia     ? L_MEDIA : 0) |

--- a/softhdsetupmenu.h
+++ b/softhdsetupmenu.h
@@ -72,6 +72,7 @@ protected:
 	int m_cLogOSD;
 	int m_cLogDRM;
 	int m_cLogCodec;
+	int m_cLogFFmpeg;
 	int m_cLogStill;
 	int m_cLogTrick;
 	int m_cLogMedia;


### PR DESCRIPTION
We now can enable ffmpeg logging via setup without rebuilding. May help for debugging.