### PR TITLE
Wait for i frames

### DIFF
--- a/README.md
+++ b/README.md
@@ -294,6 +294,10 @@ Setup: /etc/vdr/setup.conf
 		0 = deinterlacer active if available
 		1 = deinterlacer is disabled
 
+	softhddevice-drm-gles.DecoderNeedsIFrame = 0
+		0 = H.264 HW decoder is started as soon as any frame arrives
+		1 = H.264 HW decoder needs to wait for an I-Frame to start
+
 	softhddevice-drm-gles.PipScalePercent = 25
 		10 - 100 = scale factor for pip (%)
 

--- a/README.md
+++ b/README.md
@@ -298,6 +298,10 @@ Setup: /etc/vdr/setup.conf
 		0 = H.264 HW decoder is started as soon as any frame arrives
 		1 = H.264 HW decoder needs to wait for an I-Frame to start
 
+	softhddevice-drm-gles.ParseH264Dimensions = 0
+		0 = don't parse width and height before decoder start
+		1 = H.264 HW decoder wants decoded width and height before starting
+
 	softhddevice-drm-gles.PipScalePercent = 25
 		10 - 100 = scale factor for pip (%)
 

--- a/config.cpp
+++ b/config.cpp
@@ -57,6 +57,7 @@ bool cSoftHdConfig::SetupParse(const char *name, const char *value)
                                                                  PrintLogLevel(ConfigLogState ? ConfigLogLevels : 0);
 	                                                         cSoftHdLogger::GetLogger()->SetLogLevel(ConfigLogState ? ConfigLogLevels : 0);
 	} else if (!strcasecmp(name, "DisableDeint"))          { ConfigDisableDeint = atoi(value);
+	} else if (!strcasecmp(name, "DecoderNeedsIFrame"))    { ConfigDecoderNeedsIFrame = atoi(value);
 	} else if (!strcasecmp(name, "AudioDelay"))            { ConfigVideoAudioDelayMs = atoi(value);
 	} else if (!strcasecmp(name, "AudioPassthrough"))      { ConfigAudioPassthroughMask = abs(atoi(value)); ConfigAudioPassthroughState = atoi(value) > 0;
 	} else if (!strcasecmp(name, "AudioDownmix"))          { ConfigAudioDownmix = atoi(value);

--- a/config.cpp
+++ b/config.cpp
@@ -58,6 +58,7 @@ bool cSoftHdConfig::SetupParse(const char *name, const char *value)
 	                                                         cSoftHdLogger::GetLogger()->SetLogLevel(ConfigLogState ? ConfigLogLevels : 0);
 	} else if (!strcasecmp(name, "DisableDeint"))          { ConfigDisableDeint = atoi(value);
 	} else if (!strcasecmp(name, "DecoderNeedsIFrame"))    { ConfigDecoderNeedsIFrame = atoi(value);
+	} else if (!strcasecmp(name, "ParseH264Dimensions"))   { ConfigParseH264Dimensions = atoi(value);
 	} else if (!strcasecmp(name, "AudioDelay"))            { ConfigVideoAudioDelayMs = atoi(value);
 	} else if (!strcasecmp(name, "AudioPassthrough"))      { ConfigAudioPassthroughMask = abs(atoi(value)); ConfigAudioPassthroughState = atoi(value) > 0;
 	} else if (!strcasecmp(name, "AudioDownmix"))          { ConfigAudioDownmix = atoi(value);

--- a/config.h
+++ b/config.h
@@ -59,6 +59,7 @@ public:
 	bool ConfigLogState = true;                 ///< flag logging on/off
 	int ConfigLogLevels = 0;                    ///< loglevel config
 	bool ConfigDisableDeint = false;            ///< disable deinterlacer
+	bool ConfigDecoderNeedsIFrame = false;      ///< start h264 decoder only when an I-Frame arrives
 
 	// pip - default position at right top, 25% scaled
 	int ConfigPipScalePercent = 25;             ///< scale factor of pip video

--- a/config.h
+++ b/config.h
@@ -60,6 +60,7 @@ public:
 	int ConfigLogLevels = 0;                    ///< loglevel config
 	bool ConfigDisableDeint = false;            ///< disable deinterlacer
 	bool ConfigDecoderNeedsIFrame = false;      ///< start h264 decoder only when an I-Frame arrives
+	bool ConfigParseH264Dimensions = false;     ///< parse h264 stream for width and height for decoder init
 
 	// pip - default position at right top, 25% scaled
 	int ConfigPipScalePercent = 25;             ///< scale factor of pip video

--- a/h264parser.cpp
+++ b/h264parser.cpp
@@ -29,6 +29,7 @@ extern "C" {
 
 #include "h264parser.h"
 #include "logger.h"
+#include "misc.h"
 
 /*****************************************************************************
  * cH264Parser class
@@ -52,25 +53,75 @@ static void PrintStreamData(const uint8_t *data, int size)
 }
 
 /**
- * Get width and height from stream
- *
- * @param[out] width      video stream width
- * @param[out] height     video stream height
+ * Returns true, if we have a 0x000001 start code
+ * in data at the offset position
  */
-void cH264Parser::GetDimensions(int *width, int *height)
+bool isValidStartCode(const uint8_t *data, int offset)
 {
-	m_pStart = NULL;
+	return ReadBytes(&data[offset], 3) == 0x000001;
+}
+
+/**
+ * Return the nal unit type
+ */
+static int NalUnitType(const uint8_t *data, int i)
+{
+	return data[i + 3] & 0x1F;
+}
+
+/**
+ * Init the h264 parser and detect the nalu types
+ *
+ * @param avpkt      AVPacket to parse
+ */
+cH264Parser::cH264Parser(AVPacket *avpkt)
+	: m_pAvpkt(avpkt)
+{
 	int i;
 
-	for (i = 0; i < m_pAvpkt->size; i++) {
-		if (!m_pAvpkt->data[i] && !m_pAvpkt->data[i + 1] && m_pAvpkt->data[i + 2] == 0x01 &&
-		   (m_pAvpkt->data[i + 3] == 0x67 || m_pAvpkt->data[i + 3] == 0x27)) {
+	// part 1: collect the nalu types in the packet
+	for (i = 0; i < m_pAvpkt->size - 3; i++) {
+		if (!isValidStartCode(m_pAvpkt->data, i))
+			continue;
 
+		switch (NalUnitType(m_pAvpkt->data, i)) {
+			case 1:
+				m_nalutype |= NALU_TYPE_NON_IDR;
+				break;
+			case 5:
+				m_nalutype |= NALU_TYPE_IDR;
+				break;
+			case 6:
+				m_nalutype |= NALU_TYPE_SEI;
+				break;
+			case 7:
+				m_nalutype |= NALU_TYPE_SPS;
+				break;
+			case 8:
+				m_nalutype |= NALU_TYPE_PPS;
+				break;
+			case 9:
+				m_nalutype |= NALU_TYPE_AUD;
+				break;
+			default:
+				break;
+		}
+	}
+
+	// part 2: parse h264 SPS and get width and height
+	m_pStart = NULL;
+	for (i = 0; i < m_pAvpkt->size - 4; i++) {
+		if (!isValidStartCode(m_pAvpkt->data, i))
+			continue;
+
+		if (NalUnitType(m_pAvpkt->data, i) == 7) {
 			m_pStart = &m_pAvpkt->data[i + 4];
 			m_nLength = m_pAvpkt->size - i - 4;
 			break;
 		}
 	}
+
+	// no SPS available
 	if (!m_pStart) {
 		LOGERROR("H264Parser: %s: No m_pStart %p Pkt %p i %d", __FUNCTION__, m_pStart, m_pAvpkt, i);
 		PrintStreamData(m_pAvpkt->data, m_pAvpkt->size);
@@ -152,14 +203,14 @@ void cH264Parser::GetDimensions(int *width, int *height)
 	int subWidthC = 0;
 	int subHeightC = 0;
 
-	if (chromaFormatIdc == 0 && separateColorPlaneFlag == 0) { //monochrome
+	if (chromaFormatIdc == 0 && separateColorPlaneFlag == 0) { // monochrome
 		subWidthC = subHeightC = 2;
-	} else if (chromaFormatIdc == 1 && separateColorPlaneFlag == 0) { //4:2:0
+	} else if (chromaFormatIdc == 1 && separateColorPlaneFlag == 0) { // 4:2:0
 		subWidthC = subHeightC = 2;
-	} else if (chromaFormatIdc == 2 && separateColorPlaneFlag == 0) { //4:2:2
+	} else if (chromaFormatIdc == 2 && separateColorPlaneFlag == 0) { // 4:2:2
 		subWidthC = 2;
 		subHeightC = 1;
-	} else if (chromaFormatIdc == 3) { //4:4:4
+	} else if (chromaFormatIdc == 3) { // 4:4:4
 		if (separateColorPlaneFlag == 0) {
 			subWidthC = subHeightC = 1;
 		} else if (separateColorPlaneFlag == 1) {
@@ -167,11 +218,29 @@ void cH264Parser::GetDimensions(int *width, int *height)
 		}
 	}
 
-	*width = ((picWidthInMbsMinusOne + 1) * 16) -
+	m_width = ((picWidthInMbsMinusOne + 1) * 16) -
 		subWidthC * (frameCropRightOffset + frameCropLeftOffset);
 
-	*height = ((2 - frameMbsOnlyFlag)* (picHeightInMapUnitsMinusOne +1) * 16) -
+	m_height = ((2 - frameMbsOnlyFlag)* (picHeightInMapUnitsMinusOne +1) * 16) -
 		subHeightC * ((frameCropBottomOffset * 2) + (frameCropTopOffset * 2));
+
+	LOGDEBUG2(L_CODEC, "H264Parser: %s %s%s%s%s%s%s width %d height %d", __FUNCTION__,
+		m_nalutype & NALU_TYPE_AUD     ? "AUD " : "",
+		m_nalutype & NALU_TYPE_SPS     ? "SPS " : "",
+		m_nalutype & NALU_TYPE_PPS     ? "PPS " : "",
+		m_nalutype & NALU_TYPE_SEI     ? "SEI " : "",
+		m_nalutype & NALU_TYPE_IDR     ? "IDR " : "",
+		m_nalutype & NALU_TYPE_NON_IDR ? "NON-IDR " : "",
+		m_width, m_height);
+}
+
+/*
+ * Does the parser frame include an I-Frame?
+ */
+bool cH264Parser::IsIFrame(void)
+{
+	return (m_nalutype & NALU_TYPE_IDR) ||
+	      ((m_nalutype & NALU_TYPE_NON_IDR) && (m_nalutype & (NALU_TYPE_PPS | NALU_TYPE_SPS)));
 }
 
 /*

--- a/h264parser.h
+++ b/h264parser.h
@@ -24,19 +24,36 @@ extern "C" {
 #include <libavcodec/avcodec.h>
 }
 
+typedef enum {
+	NALU_TYPE_NON_IDR = (1 << 0),
+	NALU_TYPE_IDR     = (1 << 1),
+	NALU_TYPE_SEI     = (1 << 2),
+	NALU_TYPE_SPS     = (1 << 3),
+	NALU_TYPE_PPS     = (1 << 4),
+	NALU_TYPE_AUD     = (1 << 5)
+} NalUnitTypes;
+
 /**
  * cH264Parser - H264 Parser class
  */
 class cH264Parser
 {
 public:
-	cH264Parser(AVPacket *avpkt) : m_pAvpkt(avpkt) {}
-	void GetDimensions(int *, int *);
+	cH264Parser(AVPacket *);
+	int GetWidth(void) { return m_width; };
+	int GetHeight(void) { return m_height; };
+	bool IsIFrame(void);
+
 private:
 	AVPacket *m_pAvpkt;
 	const unsigned char *m_pStart;
 	unsigned short m_nLength;
 	int m_nCurrentBit;
+
+	int m_nalutype = 0;
+
+	int m_width = 0;
+	int m_height = 0;
 
 	unsigned int ReadBit(void);
 	unsigned int ReadBits(int);

--- a/misc.h
+++ b/misc.h
@@ -107,6 +107,10 @@ static inline const char* av_err2string(int errnum)
 #define av_err2str(err) av_err2string(err)
 #endif
 
+/****************************************************************************************
+ * Misc Helpers
+ ***************************************************************************************/
+
 /**
  * Nice time-stamp string.
  *
@@ -129,6 +133,21 @@ static inline const char *Timestamp2String(int64_t ts, uint8_t divisor)
 		(int)((ts / (1000)) % 60), (int)(ts % 1000));
 
 	return buf[idx];
+}
+
+/**
+ * Return _count_ amount of bytes from data
+ */
+static inline uint32_t ReadBytes(const uint8_t *data, int count)
+{
+	uint32_t value = 0;
+
+	for (int i = 0; i < count; i++) {
+		value <<= 8;
+		value |= data[i];
+	}
+
+	return value;
 }
 
 #endif

--- a/pes.cpp
+++ b/pes.cpp
@@ -21,23 +21,12 @@
 
 #include "pes.h"
 #include "logger.h"
+#include "misc.h"
 
 #include "vdr/remux.h"
 
 extern "C" {
 #include <libavutil/avutil.h>
-}
-
-static uint32_t ReadBytes(const uint8_t *data, int count)
-{
-	uint32_t value = 0;
-
-	for (int i = 0; i < count; i++) {
-		value <<= 8;
-		value |= data[i];
-	}
-
-	return value;
 }
 
 /**
@@ -350,7 +339,6 @@ int cPes::GetPacketLength()
 	return PesLength(m_data);
 }
 
-#include "misc.h"
 /**
  * Pop an AVPacket from the reassembly buffer
  *

--- a/po/de_DE.po
+++ b/po/de_DE.po
@@ -160,6 +160,9 @@ msgstr "Deaktiviere Deinterlacer"
 msgid "H.264 HW decoder needs I-Frame"
 msgstr "H.264 HW Dekoder benötigt I-Frame für Start"
 
+msgid "H.264 HW decoder needs parsed width and height"
+msgstr "H.264 HW Dekoder benötigt Größe für Start"
+
 msgid "Picture-in-picture"
 msgstr "Bild-in-Bild"
 

--- a/po/de_DE.po
+++ b/po/de_DE.po
@@ -157,6 +157,9 @@ msgstr "Video"
 msgid "Disable deinterlacer"
 msgstr "Deaktiviere Deinterlacer"
 
+msgid "H.264 HW decoder needs I-Frame"
+msgstr "H.264 HW Dekoder benötigt I-Frame für Start"
+
 msgid "Picture-in-picture"
 msgstr "Bild-in-Bild"
 

--- a/softhddevice.cpp
+++ b/softhddevice.cpp
@@ -1474,6 +1474,15 @@ void cSoftHdDevice::SetDisableDeint(void)
 }
 
 /**
+ * Forces the h264 decoder to wait for an I-Frame to start
+ */
+void cSoftHdDevice::SetDecoderNeedsIFrame(void)
+{
+	if (m_pVideoStream)
+		m_pVideoStream->SetStartDecodingWithIFrame(m_pConfig->ConfigDecoderNeedsIFrame);
+}
+
+/**
  * Set the passthrough mask (called from setup menu or conf)
  */
 void cSoftHdDevice::SetPassthrough(int mask)

--- a/softhddevice.cpp
+++ b/softhddevice.cpp
@@ -1483,6 +1483,15 @@ void cSoftHdDevice::SetDecoderNeedsIFrame(void)
 }
 
 /**
+ * Parse the h264 stream width and height before starting the decoder
+ */
+void cSoftHdDevice::SetParseH264Dimensions(void)
+{
+	if (m_pVideoStream)
+		m_pVideoStream->SetParseH264Dimensions(m_pConfig->ConfigParseH264Dimensions);
+}
+
+/**
  * Set the passthrough mask (called from setup menu or conf)
  */
 void cSoftHdDevice::SetPassthrough(int mask)

--- a/softhddevice.h
+++ b/softhddevice.h
@@ -175,6 +175,7 @@ public:
 
 	void SetDisableDeint(void);
 	void SetDecoderNeedsIFrame(void);
+	void SetParseH264Dimensions(void);
 
 	// osd
 #ifdef USE_GLES

--- a/softhddevice.h
+++ b/softhddevice.h
@@ -173,6 +173,9 @@ public:
 	cVideoRender *Render(void) { return m_pRender; };
 	cSoftHdAudio *Audio(void) { return m_pAudio; };
 
+	void SetDisableDeint(void);
+	void SetDecoderNeedsIFrame(void);
+
 	// osd
 #ifdef USE_GLES
 #ifdef WRITE_PNG
@@ -183,7 +186,6 @@ public:
 	void SetDisableOglOsd(void);
 	void SetEnableOglOsd(void);
 #endif
-	void SetDisableDeint(void);
 	void OsdClose(void);
 	void OsdDrawARGB(int, int, int, int, int, const uint8_t *, int, int);
 	void SetScreenSize(int, int, double);

--- a/softhdsetupmenu.cpp
+++ b/softhdsetupmenu.cpp
@@ -151,6 +151,7 @@ void cMenuSetupSoft::Create(void)
 	if (m_cVideoMenu) {
 		Add(new cMenuEditBoolItem(tr("Disable deinterlacer"), &m_cDisableDeint, trVDR("no"), trVDR("yes")));
 		Add(new cMenuEditBoolItem(tr("H.264 HW decoder needs I-Frame"), &m_cDecoderNeedsIFrame, trVDR("no"), trVDR("yes")));
+		Add(new cMenuEditBoolItem(tr("H.264 HW decoder needs parsed width and height"), &m_cParseH264Dimensions, trVDR("no"), trVDR("yes")));
 		if (m_pDevice->UsePip()) {
 			Add(SeparatorName(tr("Picture-in-picture")));
 			Add(new cMenuEditIntItem(tr(" video scaling factor (%)"), &m_cPipScalePercent, 10, 100));
@@ -334,6 +335,7 @@ cMenuSetupSoft::cMenuSetupSoft(cSoftHdDevice *device)
 	m_cVideoMenu = 0;
 	m_cDisableDeint = m_pConfig->ConfigDisableDeint;
 	m_cDecoderNeedsIFrame = m_pConfig->ConfigDecoderNeedsIFrame;
+	m_cParseH264Dimensions = m_pConfig->ConfigParseH264Dimensions;
 	m_cPipScalePercent = m_pConfig->ConfigPipScalePercent;
 	m_cPipLeftPercent = m_pConfig->ConfigPipLeftPercent;
 	m_cPipTopPercent = m_pConfig->ConfigPipTopPercent;
@@ -437,6 +439,9 @@ void cMenuSetupSoft::Store(void)
 
 	SetupStore("DecoderNeedsIFrame", m_pConfig->ConfigDecoderNeedsIFrame = m_cDecoderNeedsIFrame);
 	m_pDevice->SetDecoderNeedsIFrame();
+
+	SetupStore("ParseH264Dimensions", m_pConfig->ConfigParseH264Dimensions = m_cParseH264Dimensions);
+	m_pDevice->SetParseH264Dimensions();
 
 	// pip
 	SetupStore("PipScalePercent", m_pConfig->ConfigPipScalePercent = m_cPipScalePercent);

--- a/softhdsetupmenu.cpp
+++ b/softhdsetupmenu.cpp
@@ -150,6 +150,7 @@ void cMenuSetupSoft::Create(void)
 	Add(CollapsedItem(tr("Video"), m_cVideoMenu));
 	if (m_cVideoMenu) {
 		Add(new cMenuEditBoolItem(tr("Disable deinterlacer"), &m_cDisableDeint, trVDR("no"), trVDR("yes")));
+		Add(new cMenuEditBoolItem(tr("H.264 HW decoder needs I-Frame"), &m_cDecoderNeedsIFrame, trVDR("no"), trVDR("yes")));
 		if (m_pDevice->UsePip()) {
 			Add(SeparatorName(tr("Picture-in-picture")));
 			Add(new cMenuEditIntItem(tr(" video scaling factor (%)"), &m_cPipScalePercent, 10, 100));
@@ -332,6 +333,7 @@ cMenuSetupSoft::cMenuSetupSoft(cSoftHdDevice *device)
 	//
 	m_cVideoMenu = 0;
 	m_cDisableDeint = m_pConfig->ConfigDisableDeint;
+	m_cDecoderNeedsIFrame = m_pConfig->ConfigDecoderNeedsIFrame;
 	m_cPipScalePercent = m_pConfig->ConfigPipScalePercent;
 	m_cPipLeftPercent = m_pConfig->ConfigPipLeftPercent;
 	m_cPipTopPercent = m_pConfig->ConfigPipTopPercent;
@@ -432,6 +434,9 @@ void cMenuSetupSoft::Store(void)
 		LOGDEBUG("Disable deinterlacer!");
 	}
 	m_pDevice->SetDisableDeint();
+
+	SetupStore("DecoderNeedsIFrame", m_pConfig->ConfigDecoderNeedsIFrame = m_cDecoderNeedsIFrame);
+	m_pDevice->SetDecoderNeedsIFrame();
 
 	// pip
 	SetupStore("PipScalePercent", m_pConfig->ConfigPipScalePercent = m_cPipScalePercent);

--- a/softhdsetupmenu.h
+++ b/softhdsetupmenu.h
@@ -86,6 +86,7 @@ protected:
 	int m_cVideoMenu;
 	int m_cDisableDeint;
 	int m_cDecoderNeedsIFrame;
+	int m_cParseH264Dimensions;;
 
 	// Audio
 	int m_cAudio;

--- a/softhdsetupmenu.h
+++ b/softhdsetupmenu.h
@@ -85,6 +85,7 @@ protected:
 	// Video
 	int m_cVideoMenu;
 	int m_cDisableDeint;
+	int m_cDecoderNeedsIFrame;
 
 	// Audio
 	int m_cAudio;

--- a/videostream.cpp
+++ b/videostream.cpp
@@ -159,7 +159,8 @@ cVideoStream::cVideoStream(cVideoRender *render, cQueue<cDrmBuffer> *drmBufferQu
 	  m_frameOutput(frameOutput),
 	  m_pDrmBufferQueue(drmBufferQueue),
 	  m_userDisabledDeinterlacer(config->ConfigDisableDeint),
-	  m_deinterlacerDeactivated(isPipStream ? true : false)
+	  m_deinterlacerDeactivated(isPipStream ? true : false),
+	  m_startDecodingWithIFrame(config->ConfigDecoderNeedsIFrame),
 {
 	m_filterThreadName = "shd " + std::string(m_identifier) + " filter";
 	m_pFilterThread = new cFilterThread(render, m_pDrmBufferQueue, m_filterThreadName.c_str(), frameOutput);
@@ -304,12 +305,25 @@ void cVideoStream::DecodeInput(void)
 		int width = 0;
 		int height = 0;
 
-		// amlogic h264 decoder needs width an height for correct decoder open
-		if ((m_codecId == AV_CODEC_ID_H264) && (m_hardwareQuirks & QUIRK_CODEC_NEEDS_EXT_INIT)) {
-			cH264Parser h264Parser(m_packets.Peek());
-			h264Parser.GetDimensions(&width, &height);
+		if (m_codecId == AV_CODEC_ID_H264 &&
+		   (m_startDecodingWithIFrame || m_hardwareQuirks & QUIRK_CODEC_NEEDS_EXT_INIT)) {
 
-			LOGDEBUG2(L_CODEC, "videostream %s: %s: Parsed width %d height %d", m_identifier, __FUNCTION__, width, height);
+			cH264Parser h264Packet(m_packets.Peek());
+
+			// start decoding with an I-Frame only
+			if (!h264Packet.IsIFrame() && m_startDecodingWithIFrame) {
+				LOGDEBUG2(L_CODEC, "videostream %s: %s: Skip h264 packet, no I-Frame!", m_identifier, __FUNCTION__);
+				AVPacket *avpkt = m_packets.Pop();
+				av_packet_free(&avpkt);
+				return;
+			}
+
+			// amlogic h264 decoder needs width an height for correct decoder open
+			if ((m_hardwareQuirks & QUIRK_CODEC_NEEDS_EXT_INIT)) {
+				width = h264Packet.GetWidth();
+				height = h264Packet.GetHeight();
+				LOGDEBUG2(L_CODEC, "videostream %s: %s: Parsed width %d height %d", m_identifier, __FUNCTION__, width, height);
+			}
 		}
 
 		if (m_pDecoder->Open(m_codecId, m_pPar, m_timebase, false, width, height))

--- a/videostream.cpp
+++ b/videostream.cpp
@@ -161,6 +161,7 @@ cVideoStream::cVideoStream(cVideoRender *render, cQueue<cDrmBuffer> *drmBufferQu
 	  m_userDisabledDeinterlacer(config->ConfigDisableDeint),
 	  m_deinterlacerDeactivated(isPipStream ? true : false),
 	  m_startDecodingWithIFrame(config->ConfigDecoderNeedsIFrame),
+	  m_parseH264Dimensions(config->ConfigParseH264Dimensions)
 {
 	m_filterThreadName = "shd " + std::string(m_identifier) + " filter";
 	m_pFilterThread = new cFilterThread(render, m_pDrmBufferQueue, m_filterThreadName.c_str(), frameOutput);
@@ -306,7 +307,7 @@ void cVideoStream::DecodeInput(void)
 		int height = 0;
 
 		if (m_codecId == AV_CODEC_ID_H264 &&
-		   (m_startDecodingWithIFrame || m_hardwareQuirks & QUIRK_CODEC_NEEDS_EXT_INIT)) {
+		   (m_startDecodingWithIFrame || (m_hardwareQuirks & QUIRK_CODEC_NEEDS_EXT_INIT) || m_parseH264Dimensions)) {
 
 			cH264Parser h264Packet(m_packets.Peek());
 
@@ -319,7 +320,7 @@ void cVideoStream::DecodeInput(void)
 			}
 
 			// amlogic h264 decoder needs width an height for correct decoder open
-			if ((m_hardwareQuirks & QUIRK_CODEC_NEEDS_EXT_INIT)) {
+			if ((m_hardwareQuirks & QUIRK_CODEC_NEEDS_EXT_INIT) || m_parseH264Dimensions) {
 				width = h264Packet.GetWidth();
 				height = h264Packet.GetHeight();
 				LOGDEBUG2(L_CODEC, "videostream %s: %s: Parsed width %d height %d", m_identifier, __FUNCTION__, width, height);

--- a/videostream.h
+++ b/videostream.h
@@ -93,6 +93,7 @@ public:
 	bool IsDeinterlacerDeactivated(void) { return m_deinterlacerDeactivated; };
 	int HardwareQuirks(void) { return m_hardwareQuirks; };
 	void DisableDeint(bool disable) { m_userDisabledDeinterlacer = disable; };
+	void SetStartDecodingWithIFrame(bool enable) { m_startDecodingWithIFrame = enable; };
 
 protected:
 	cVideoStream(cVideoRender *, cQueue<cDrmBuffer> *, cSoftHdConfig *, bool, std::function<void(AVFrame *)>);
@@ -112,6 +113,7 @@ private:
 	int m_hardwareQuirks;                           ///< hardware specific quirks
 	bool m_userDisabledDeinterlacer = false;        ///< set, if the user configured the deinterlace to be disabled
 	bool m_deinterlacerDeactivated;                 ///< set, if the deinterlacer should be disabled temporarily (trickspeed, stillpicture, pip)
+	bool m_startDecodingWithIFrame = false;         ///< wait for an I-Frame to start h264 decoding
 
 	cQueue<AVPacket> m_packets{VIDEO_PACKET_MAX};   ///< AVPackets queue
 

--- a/videostream.h
+++ b/videostream.h
@@ -94,6 +94,7 @@ public:
 	int HardwareQuirks(void) { return m_hardwareQuirks; };
 	void DisableDeint(bool disable) { m_userDisabledDeinterlacer = disable; };
 	void SetStartDecodingWithIFrame(bool enable) { m_startDecodingWithIFrame = enable; };
+	void SetParseH264Dimensions(bool enable) { m_parseH264Dimensions = enable; };
 
 protected:
 	cVideoStream(cVideoRender *, cQueue<cDrmBuffer> *, cSoftHdConfig *, bool, std::function<void(AVFrame *)>);
@@ -114,6 +115,7 @@ private:
 	bool m_userDisabledDeinterlacer = false;        ///< set, if the user configured the deinterlace to be disabled
 	bool m_deinterlacerDeactivated;                 ///< set, if the deinterlacer should be disabled temporarily (trickspeed, stillpicture, pip)
 	bool m_startDecodingWithIFrame = false;         ///< wait for an I-Frame to start h264 decoding
+	bool m_parseH264Dimensions = false;             ///< parse width and height when starting an h264 stream
 
 	cQueue<AVPacket> m_packets{VIDEO_PACKET_MAX};   ///< AVPackets queue
 


### PR DESCRIPTION
This PR was made because of the artifacts problem here: https://www.vdr-portal.de/forum/thread/136098-softhddevice-drm-gles-raspberry-4-und-5/?postID=1388411#post1388411

It shouldn't change anything as long as you don't enable further setup options.
This PR is divided in 2 parts:

1) If needed, parse the nal header of the avpkt and determine the nal unit type. In case the option is set, the h264 decoder will wait for an I-Frame to open the decoder. Not sure, this is really related to the problem above, but at least we can easily log the nal unit types which arrive at stream start now. It doesn't hurt, so.... The cH264Parser was rewritten and cleaned up a little bit for this 

2) Amlogic needs to parse the width and height from a h264 stream and provide the info to the decoder in order to start correctly. We add a setup option, to make this possible for other hardware, too - without the need of a rebuild and via setup.