### PR TITLE
fallback for mbaff coded streams

### DIFF
--- a/h264parser.cpp
+++ b/h264parser.cpp
@@ -189,8 +189,9 @@ cH264Parser::cH264Parser(AVPacket *avpkt)
 	int picHeightInMapUnitsMinusOne = ReadExponentialGolombCode();
 	int frameMbsOnlyFlag = ReadBit();
 	if (!frameMbsOnlyFlag) {
-		ReadBit();
+		m_mbaff = ReadBit();
 	}
+
 	ReadBit();
 	int frameCroppingFlag = ReadBit();
 	if (frameCroppingFlag) {

--- a/h264parser.h
+++ b/h264parser.h
@@ -43,6 +43,7 @@ public:
 	int GetWidth(void) { return m_width; };
 	int GetHeight(void) { return m_height; };
 	bool IsIFrame(void);
+	bool IsMbaff(void) { return m_mbaff; };
 
 private:
 	AVPacket *m_pAvpkt;
@@ -54,6 +55,7 @@ private:
 
 	int m_width = 0;
 	int m_height = 0;
+	bool m_mbaff = false;
 
 	unsigned int ReadBit(void);
 	unsigned int ReadBits(int);

--- a/videorender.cpp
+++ b/videorender.cpp
@@ -1004,7 +1004,7 @@ void cVideoRender::Reset()
  */
 void cVideoRender::SetTrickSpeed(double speed, bool active, bool forward)
 {
-	LOGDEBUG2(L_TRICK, "videorender: %s: set trick speed %.3f %s", __FUNCTION__, speed, forward ? "forward" : "backward");
+	LOGDEBUG2(L_TRICK, "videorender: %s: set trick speed %.3f %s %s", __FUNCTION__, speed, speed > 1.0 ? "fast" : "slow", forward ? "forward" : "backward");
 	m_framePresentationCounter = 1;
 	m_trickspeedFactor = speed;
 	m_trickspeed = active;

--- a/videorender.h
+++ b/videorender.h
@@ -133,6 +133,7 @@ public:
 	void SetTrickSpeed(double, bool, bool);
 	bool IsTrickSpeed(void) { return m_trickspeed; };
 	bool IsForwardTrickspeed(void) { return m_forwardTrickspeed; };
+	bool IsFastTrickspeed(void) { return m_trickspeedFactor > 1.0; };
 	void SetStillpicture(bool active) { m_stillpicture = active; };
 	bool IsStillpicture(void) { return m_stillpicture; };
 

--- a/videostream.cpp
+++ b/videostream.cpp
@@ -119,12 +119,14 @@ static int ReadHWPlatform(void)
 		}
 		if (strstr(read_ptr, "bcm2711")) {
 			LOGDEBUG2(L_DRM, "videostream: %s: bcm2711 (Raspberry Pi 4 Model B, Compute Module 4, Pi 400) found", __FUNCTION__);
-			hardwareQuirks |= QUIRK_CODEC_FLUSH_WORKAROUND;
+			hardwareQuirks |= QUIRK_CODEC_FLUSH_WORKAROUND
+			               |  QUIRK_CODEC_NO_MBAFF_SUPPORT;
 			break;
 		}
 		if (strstr(read_ptr, "bcm2712")) {
 			LOGDEBUG2(L_DRM, "videostream: %s: bcm2712 (Raspberry Pi 5, Compute Module 5, Pi 500) found", __FUNCTION__);
-			hardwareQuirks |= QUIRK_CODEC_FLUSH_WORKAROUND;
+			hardwareQuirks |= QUIRK_CODEC_FLUSH_WORKAROUND
+			               |  QUIRK_CODEC_NO_MBAFF_SUPPORT;
 			break;
 		}
 		if (strstr(read_ptr, "amlogic")) {
@@ -298,6 +300,7 @@ void cVideoStream::DecodeInput(void)
 {
 	AVFrame *frame = nullptr;
 	int ret = 0;
+	bool forceSoftwareDecoder = false;
 
 	if (m_codecId == AV_CODEC_ID_NONE || m_packets.IsEmpty() || m_pDrmBufferQueue->IsFull() || m_pFilterThread->IsInputBufferFull())
 		return;
@@ -306,9 +309,12 @@ void cVideoStream::DecodeInput(void)
 		int width = 0;
 		int height = 0;
 
-		if (m_codecId == AV_CODEC_ID_H264 &&
-		   (m_startDecodingWithIFrame || (m_hardwareQuirks & QUIRK_CODEC_NEEDS_EXT_INIT) || m_parseH264Dimensions)) {
+		bool needsParsing = m_startDecodingWithIFrame ||
+		                    m_parseH264Dimensions ||
+		                   (m_hardwareQuirks & QUIRK_CODEC_NEEDS_EXT_INIT) ||
+		                   (m_hardwareQuirks & QUIRK_CODEC_NO_MBAFF_SUPPORT);
 
+		if (needsParsing && m_codecId == AV_CODEC_ID_H264) {
 			cH264Parser h264Packet(m_packets.Peek());
 
 			// start decoding with an I-Frame only
@@ -325,9 +331,16 @@ void cVideoStream::DecodeInput(void)
 				height = h264Packet.GetHeight();
 				LOGDEBUG2(L_CODEC, "videostream %s: %s: Parsed width %d height %d", m_identifier, __FUNCTION__, width, height);
 			}
+
+			// fallback to SW H.264 decoder, if the decoder doesn't support mbaff
+			if (m_hardwareQuirks & QUIRK_CODEC_NO_MBAFF_SUPPORT) {
+				forceSoftwareDecoder = h264Packet.IsMbaff();
+				if (forceSoftwareDecoder)
+					LOGDEBUG2(L_CODEC, "videostream %s: %s: Fallback to H.264 software decoder for mbaff stream", m_identifier, __FUNCTION__);
+			}
 		}
 
-		if (m_pDecoder->Open(m_codecId, m_pPar, m_timebase, false, width, height))
+		if (m_pDecoder->Open(m_codecId, m_pPar, m_timebase, forceSoftwareDecoder, width, height))
 			LOGFATAL("videostream %s: %s: Could not open the decoder!", m_identifier, __FUNCTION__);
 
 		m_pConfig->CurrentDecoderType = m_pDecoder->IsHardwareDecoder() ? "hardware" : "software";

--- a/videostream.cpp
+++ b/videostream.cpp
@@ -294,6 +294,82 @@ void cVideoStream::FlushDecoder(void)
 }
 
 /**
+ * Check, if we need to force the decoder to decode the frame (force a decoder drain)
+ *
+ * Get the number of packets we need to have in the buffer while in interlaced (not mbaff)
+ * trickspeed mode, in order to get a decoded frameout of the decoder.
+ *
+ * In a normal interlaced h264 stream we need to force decoding after sending 2 packets
+ * in backwards trickspeed to get a decoded frame, in an mpeg2 stream 1 packet is enough.
+ *
+ * In mbaff coded h264 streams we also force decoding in fast forward mode. Because VDR does
+ * not send a continous stream, the decoder would wait forever otherwise to decode the packet.
+ *
+ * This minPkts magic guarantees, that we don't drain the decoder too early, but exactly after
+ * the right amount of packets was sent in trickspeed mode.
+ */
+void cVideoStream::CheckForcingFrameDecode(void)
+{
+	int minPkts = (m_interlaced && !m_mbaffStream) ? m_trickpkts : 1;
+
+	if ((!m_pRender->IsForwardTrickspeed() ||
+	     (m_pRender->IsForwardTrickspeed() && m_pRender->IsFastTrickspeed() && m_mbaffStream))) {
+		m_sentTrickPkts++;
+		if (m_sentTrickPkts >= minPkts) {
+			m_pDecoder->SendPacket(NULL);
+			m_sentTrickPkts = 0;
+		}
+	}
+}
+
+/**
+ * Open the decoder including an H.264 parsing if needed
+ */
+void cVideoStream::OpenDecoder(void)
+{
+	int width = 0;
+	int height = 0;
+
+	bool needsParsing = m_startDecodingWithIFrame ||
+	                    m_parseH264Dimensions ||
+	                   (m_hardwareQuirks & QUIRK_CODEC_NEEDS_EXT_INIT) ||
+	                   (m_hardwareQuirks & QUIRK_CODEC_NO_MBAFF_SUPPORT);
+
+	if (needsParsing && m_codecId == AV_CODEC_ID_H264) {
+		cH264Parser h264Packet(m_packets.Peek());
+
+		// start decoding with an I-Frame only
+		if (!h264Packet.IsIFrame() && m_startDecodingWithIFrame) {
+			LOGDEBUG2(L_CODEC, "videostream %s: %s: Skip h264 packet, no I-Frame!", m_identifier, __FUNCTION__);
+			AVPacket *avpkt = m_packets.Pop();
+			av_packet_free(&avpkt);
+			return;
+		}
+
+		// amlogic h264 decoder needs width an height for correct decoder open
+		if ((m_hardwareQuirks & QUIRK_CODEC_NEEDS_EXT_INIT) || m_parseH264Dimensions) {
+			width = h264Packet.GetWidth();
+			height = h264Packet.GetHeight();
+			LOGDEBUG2(L_CODEC, "videostream %s: %s: Parsed width %d height %d", m_identifier, __FUNCTION__, width, height);
+		}
+
+		// fallback to SW H.264 decoder, if the decoder doesn't support mbaff
+		if (m_hardwareQuirks & QUIRK_CODEC_NO_MBAFF_SUPPORT) {
+			m_mbaffStream = h264Packet.IsMbaff();
+			if (m_mbaffStream)
+				LOGDEBUG2(L_CODEC, "videostream %s: %s: Fallback to H.264 software decoder for mbaff stream", m_identifier, __FUNCTION__);
+		}
+	}
+
+	if (m_pDecoder->Open(m_codecId, m_pPar, m_timebase, m_mbaffStream, width, height))
+		LOGFATAL("videostream %s: %s: Could not open the decoder!", m_identifier, __FUNCTION__);
+
+	m_pConfig->CurrentDecoderType = m_pDecoder->IsHardwareDecoder() ? "hardware" : "software";
+	m_pConfig->CurrentDecoderName = m_pDecoder->Name();
+	m_newStream = false;
+}
+
+/**
  * Decodes a reassembled codec packet.
  */
 void cVideoStream::DecodeInput(void)
@@ -304,48 +380,8 @@ void cVideoStream::DecodeInput(void)
 	if (m_codecId == AV_CODEC_ID_NONE || m_packets.IsEmpty() || m_pDrmBufferQueue->IsFull() || m_pFilterThread->IsInputBufferFull())
 		return;
 
-	if (m_newStream) {
-		int width = 0;
-		int height = 0;
-
-		bool needsParsing = m_startDecodingWithIFrame ||
-		                    m_parseH264Dimensions ||
-		                   (m_hardwareQuirks & QUIRK_CODEC_NEEDS_EXT_INIT) ||
-		                   (m_hardwareQuirks & QUIRK_CODEC_NO_MBAFF_SUPPORT);
-
-		if (needsParsing && m_codecId == AV_CODEC_ID_H264) {
-			cH264Parser h264Packet(m_packets.Peek());
-
-			// start decoding with an I-Frame only
-			if (!h264Packet.IsIFrame() && m_startDecodingWithIFrame) {
-				LOGDEBUG2(L_CODEC, "videostream %s: %s: Skip h264 packet, no I-Frame!", m_identifier, __FUNCTION__);
-				AVPacket *avpkt = m_packets.Pop();
-				av_packet_free(&avpkt);
-				return;
-			}
-
-			// amlogic h264 decoder needs width an height for correct decoder open
-			if ((m_hardwareQuirks & QUIRK_CODEC_NEEDS_EXT_INIT) || m_parseH264Dimensions) {
-				width = h264Packet.GetWidth();
-				height = h264Packet.GetHeight();
-				LOGDEBUG2(L_CODEC, "videostream %s: %s: Parsed width %d height %d", m_identifier, __FUNCTION__, width, height);
-			}
-
-			// fallback to SW H.264 decoder, if the decoder doesn't support mbaff
-			if (m_hardwareQuirks & QUIRK_CODEC_NO_MBAFF_SUPPORT) {
-				m_mbaffStream = h264Packet.IsMbaff();
-				if (m_mbaffStream)
-					LOGDEBUG2(L_CODEC, "videostream %s: %s: Fallback to H.264 software decoder for mbaff stream", m_identifier, __FUNCTION__);
-			}
-		}
-
-		if (m_pDecoder->Open(m_codecId, m_pPar, m_timebase, m_mbaffStream, width, height))
-			LOGFATAL("videostream %s: %s: Could not open the decoder!", m_identifier, __FUNCTION__);
-
-		m_pConfig->CurrentDecoderType = m_pDecoder->IsHardwareDecoder() ? "hardware" : "software";
-		m_pConfig->CurrentDecoderName = m_pDecoder->Name();
-		m_newStream = false;
-	}
+	if (m_newStream)
+		OpenDecoder();
 
 	// send packet to decoder
 	AVPacket *avpkt = m_packets.Peek();
@@ -357,32 +393,8 @@ void cVideoStream::DecodeInput(void)
 		av_packet_free(&avpkt);
 	}
 
-	// Check, if we need to force the decoder to decode the frame (force a decoder drain)
-	//
-	// Get the number of packets we need to have in the buffer while in interlaced (not mbaff)
-	// trickspeed mode, in order to get a decoded frameout of the decoder.
-	//
-	// In a normal interlaced h264 stream we need to force decoding after sending 2 packets
-	// in backwards trickspeed to get a decoded frame, in an mpeg2 stream 1 packet is enough.
-	//
-	// In mbaff coded h264 streams we also force decoding in fast forward mode. Because VDR does
-	// not send a continous stream, the decoder would wait forever otherwise to decode the packet.
-	//
-	// This minPkts magic guarantees, that we don't drain the decoder too early, but exactly after
-	// the right amount of packets was sent in trickspeed mode.
-	int minPkts = 1;
-	if (m_pRender->IsTrickSpeed() && m_interlaced && !m_mbaffStream)
-		minPkts = m_trickpkts;
-
-	if (ret == 0 && m_pRender->IsTrickSpeed() &&
-	   (!m_pRender->IsForwardTrickspeed() ||
-	    (m_pRender->IsForwardTrickspeed() && m_pRender->IsFastTrickspeed() && m_mbaffStream))) {
-		m_sentTrickPkts++;
-		if (m_sentTrickPkts >= minPkts) {
-			m_pDecoder->SendPacket(NULL);
-			m_sentTrickPkts = 0;
-		}
-	}
+	if (!ret && m_pRender->IsTrickSpeed())
+		CheckForcingFrameDecode();
 
 	// receive frame from decoder
 	ret = m_pDecoder->ReceiveFrame(&frame);

--- a/videostream.cpp
+++ b/videostream.cpp
@@ -300,7 +300,6 @@ void cVideoStream::DecodeInput(void)
 {
 	AVFrame *frame = nullptr;
 	int ret = 0;
-	bool forceSoftwareDecoder = false;
 
 	if (m_codecId == AV_CODEC_ID_NONE || m_packets.IsEmpty() || m_pDrmBufferQueue->IsFull() || m_pFilterThread->IsInputBufferFull())
 		return;
@@ -334,27 +333,19 @@ void cVideoStream::DecodeInput(void)
 
 			// fallback to SW H.264 decoder, if the decoder doesn't support mbaff
 			if (m_hardwareQuirks & QUIRK_CODEC_NO_MBAFF_SUPPORT) {
-				forceSoftwareDecoder = h264Packet.IsMbaff();
-				if (forceSoftwareDecoder)
+				m_mbaffStream = h264Packet.IsMbaff();
+				if (m_mbaffStream)
 					LOGDEBUG2(L_CODEC, "videostream %s: %s: Fallback to H.264 software decoder for mbaff stream", m_identifier, __FUNCTION__);
 			}
 		}
 
-		if (m_pDecoder->Open(m_codecId, m_pPar, m_timebase, forceSoftwareDecoder, width, height))
+		if (m_pDecoder->Open(m_codecId, m_pPar, m_timebase, m_mbaffStream, width, height))
 			LOGFATAL("videostream %s: %s: Could not open the decoder!", m_identifier, __FUNCTION__);
 
 		m_pConfig->CurrentDecoderType = m_pDecoder->IsHardwareDecoder() ? "hardware" : "software";
 		m_pConfig->CurrentDecoderName = m_pDecoder->Name();
 		m_newStream = false;
 	}
-
-	// wait for m_trickpkts packets
-	//
-	// m_trickpkts is the number of packets we need to have in the buffer
-	// while in interlaced trickspeed mode, needed to get a frame.
-	// This guarantees, that we don't drain the decoder too early, but exactly after
-	// m_trickpkts sent packets
-	int minPkts = (m_pRender->IsTrickSpeed() && m_interlaced) ? m_trickpkts : 1;
 
 	// send packet to decoder
 	AVPacket *avpkt = m_packets.Peek();
@@ -366,8 +357,26 @@ void cVideoStream::DecodeInput(void)
 		av_packet_free(&avpkt);
 	}
 
-	// in backward trickspeed force the decoder to decode the frame, if minPkts are sent
-	if (ret == 0 && m_pRender->IsTrickSpeed() && !m_pRender->IsForwardTrickspeed()) {
+	// Check, if we need to force the decoder to decode the frame (force a decoder drain)
+	//
+	// Get the number of packets we need to have in the buffer while in interlaced (not mbaff)
+	// trickspeed mode, in order to get a decoded frameout of the decoder.
+	//
+	// In a normal interlaced h264 stream we need to force decoding after sending 2 packets
+	// in backwards trickspeed to get a decoded frame, in an mpeg2 stream 1 packet is enough.
+	//
+	// In mbaff coded h264 streams we also force decoding in fast forward mode. Because VDR does
+	// not send a continous stream, the decoder would wait forever otherwise to decode the packet.
+	//
+	// This minPkts magic guarantees, that we don't drain the decoder too early, but exactly after
+	// the right amount of packets was sent in trickspeed mode.
+	int minPkts = 1;
+	if (m_pRender->IsTrickSpeed() && m_interlaced && !m_mbaffStream)
+		minPkts = m_trickpkts;
+
+	if (ret == 0 && m_pRender->IsTrickSpeed() &&
+	   (!m_pRender->IsForwardTrickspeed() ||
+	    (m_pRender->IsForwardTrickspeed() && m_pRender->IsFastTrickspeed() && m_mbaffStream))) {
 		m_sentTrickPkts++;
 		if (m_sentTrickPkts >= minPkts) {
 			m_pDecoder->SendPacket(NULL);

--- a/videostream.cpp
+++ b/videostream.cpp
@@ -285,7 +285,7 @@ void cVideoStream::FlushDecoder(void)
 {
 	LOGDEBUG2(L_CODEC, "videostream %s: %s", m_identifier, __FUNCTION__);
 
-	if (m_hardwareQuirks & QUIRK_CODEC_FLUSH_WORKAROUND) {
+	if ((m_hardwareQuirks & QUIRK_CODEC_FLUSH_WORKAROUND) && m_pDecoder->IsHardwareDecoder()) {
 		if (m_pDecoder->ReopenCodec(m_codecId, m_pPar, m_timebase, 0))
 			LOGFATAL("videostream %s: %s: Could not reopen the decoder (flush)!", m_identifier, __FUNCTION__);
 	} else {

--- a/videostream.h
+++ b/videostream.h
@@ -43,6 +43,7 @@ extern "C" {
 #define QUIRK_CODEC_SKIP_NUM_FRAMES     2          ///< skip QUIRK_CODEC_SKIP_NUM_FRAMES, in case QUIRK_CODEC_SKIP_FIRST_FRAMES is set
 #define QUIRK_CODEC_DISABLE_MPEG_HW     1 << 4     ///< set, if disable mpeg hardware decoder
 #define QUIRK_CODEC_DISABLE_H264_HW     1 << 5     ///< set, if disable h264 hardware decoder
+#define QUIRK_CODEC_NO_MBAFF_SUPPORT    1 << 6     ///< set, if the h264 hardware decoder doesn't support mbaff
 
 class cSoftHdConfig;
 class cVideoDecoder;

--- a/videostream.h
+++ b/videostream.h
@@ -133,6 +133,8 @@ private:
 	int64_t m_inputPts = AV_NOPTS_VALUE;   ///< PTS of the first packet in the input buffer
 
 	void RenderFrame(AVFrame *);
+	void CheckForcingFrameDecode(void);
+	void OpenDecoder(void);
 };
 
 /**

--- a/videostream.h
+++ b/videostream.h
@@ -127,6 +127,7 @@ private:
 	int m_sentTrickPkts = 0;               ///< how many avpkt have been sent to the decoder in trickspeed mode?
 	volatile bool m_newStream = false;     ///< flag for new stream
 	bool m_interlaced;                     ///< flag for interlaced stream
+	bool m_mbaffStream = false;            ///< true, if this stream uses macroblock adaptive frame/field coding
 
 	cDecodingThread *m_pDecodingThread;    ///< pointer to decoding thread
 	int64_t m_inputPts = AV_NOPTS_VALUE;   ///< PTS of the first packet in the input buffer


### PR DESCRIPTION
rpi-ffmpeg's H.264 hardware decoder doesn't seem to support MBAFF (macroblock-adaptive frame/field coding) Always fallback to H.264 software decoder on RPI4/5 if we have a mbaff coded stream.

Questions:
1) should h264 always be parsed at decoder start?
2) what about mbaff support of the other platforms?
3) what about mbaff support of other ffmpeg versions?

Answers:
1) No, keep it depending on the QUIRKS for now. Maybe think about a follow-up commit to make it setup-configureable. But we should keep it simple for "normal" users.
2) Add the necessary QUIRKS as soon as a problem pops up or someone tested it.
3) Currently only rpi4/5 has fallback enabled. Because rpi-ffmpeg is the (only) h.264 hw decoder atm, there is no difference if mainline ffmpeg would use h.264 software decoding.

Problem was reported here:
https://www.vdr-portal.de/forum/thread/136098-softhddevice-drm-gles-raspberry-4-und-5/?postID=1388478#post1388478

Tested on:
- RPI4
- Rockchip RK3399