### PR TITLE
codec: remove special mbaff handling again

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,8 +16,6 @@ DOXYFILE  = doxygen/Doxyfile
 
 # Use OpenGL/ES for OSD? Disable autodetection by setting GLES=1 or GLES=0 with make command
 GLES ?= $(shell pkg-config --exists glesv2 egl gbm && echo 1)
-# enable this to write the OSD as png into /tmp (only GLES mode)
-PNG ?= 0
 # enable this to mark the corners of the rectangles on the OSD
 GRID ?= 0
 
@@ -27,9 +25,6 @@ CONFIG :=
 
 ifeq ($(GLES),1)
 CONFIG += -DUSE_GLES			# build with OpenGL/ES support
-ifeq ($(PNG),1)
-CONFIG += -DWRITE_PNG			# enable writing OSD to png file
-endif
 ifeq ($(GRID),1)
 CONFIG += -DGRIDPOINTS			# mark gridpoints
 endif
@@ -112,10 +107,6 @@ _CFLAGS += $(shell pkg-config --cflags gbm glesv2 egl)
 LIBS += $(shell pkg-config --libs gbm glesv2 egl)
 _CFLAGS += $(shell pkg-config --cflags freetype2)
 LIBS += $(shell pkg-config --libs freetype2)
-ifeq ($(PNG),1)
-_CFLAGS += $(shell pkg-config --cflags libpng)
-LIBS += $(shell pkg-config --libs libpng)
-endif
 endif
 
 ### Includes and Defines (add further entries here):

--- a/README.md
+++ b/README.md
@@ -119,7 +119,6 @@ Requirements:
 	- gbm (Mesa)
 	- freetype2
 	- glm - OpenGL Mathematics (GLM)
-	- libpng (to write debug OSD pngs)
 
 
 Install:
@@ -215,10 +214,6 @@ Setup: /etc/vdr/setup.conf
 
 	softhddevice-drm-gles.MaxSizeGPUImageCache = 128
 		how many GPU memory should be used for image caching
-
-	softhddevíce-drm-gles.WritePngs = 0
-		0 = do nothing, 1 = write osd on every flush to /tmp
-		this is only for debugging purposes
 
 	softhddevice-drm-gles.AdditionalBufferLengthMs = 0
 		0 = default (min 450ms fixed)

--- a/README.md
+++ b/README.md
@@ -297,6 +297,15 @@ Setup: /etc/vdr/setup.conf
 		0 = don't parse width and height before decoder start
 		1 = H.264 HW decoder wants decoded width and height before starting
 
+	softhddevice-drm-gles.DecoderFallbackToSw = 0
+		0 = always use hardware decoder if available
+		1 = fallback to software decoder if hardware decoder
+		    fails after num packets (see below)
+
+	softhddevice-drm-gles.DecoderFallbackToSwNumPkts = 22
+		maximum number of packets sent to the hardware decoder
+		until the software fallback jumps in
+
 	softhddevice-drm-gles.PipScalePercent = 25
 		10 - 100 = scale factor for pip (%)
 

--- a/codec_video.h
+++ b/codec_video.h
@@ -42,6 +42,8 @@ public:
 	AVCodecContext *GetContext(void) { return m_pVideoCtx; };
 	bool IsHardwareDecoder(void) { return m_isHardwareDecoder; };
 	const char *Name(void) { return m_pCodecString; };
+	int GetPacketsSent(void) { return m_cntPacketsSent; };
+	int GetFramesReceived(void) { return m_cntFramesReceived; };
 
 private:
 	AVCodecContext *m_pVideoCtx = nullptr;  ///< video codec context

--- a/config.cpp
+++ b/config.cpp
@@ -59,6 +59,8 @@ bool cSoftHdConfig::SetupParse(const char *name, const char *value)
 	} else if (!strcasecmp(name, "DisableDeint"))          { ConfigDisableDeint = atoi(value);
 	} else if (!strcasecmp(name, "DecoderNeedsIFrame"))    { ConfigDecoderNeedsIFrame = atoi(value);
 	} else if (!strcasecmp(name, "ParseH264Dimensions"))   { ConfigParseH264Dimensions = atoi(value);
+	} else if (!strcasecmp(name, "DecoderFallbackToSw"))   { ConfigDecoderFallbackToSw = atoi(value);
+	} else if (!strcasecmp(name, "DecoderFallbackToSwNumPkts")) { ConfigDecoderFallbackToSwNumPkts = atoi(value);
 	} else if (!strcasecmp(name, "AudioDelay"))            { ConfigVideoAudioDelayMs = atoi(value);
 	} else if (!strcasecmp(name, "AudioPassthrough"))      { ConfigAudioPassthroughMask = abs(atoi(value)); ConfigAudioPassthroughState = atoi(value) > 0;
 	} else if (!strcasecmp(name, "AudioDownmix"))          { ConfigAudioDownmix = atoi(value);

--- a/config.cpp
+++ b/config.cpp
@@ -46,11 +46,6 @@ bool cSoftHdConfig::SetupParse(const char *name, const char *value)
 	//LOGDEBUG("config: %s: '%s' = '%s'", __FUNCTION__, name, value);
 
 	if        (!strcasecmp(name, "HideMainMenuEntry"))     { ConfigHideMainMenuEntry = atoi(value);
-#ifdef USE_GLES
-#ifdef WRITE_PNG
-	} else if (!strcasecmp(name, "WritePngs"))             { ConfigWritePngs = atoi(value);
-#endif
-#endif
 	} else if (!strcasecmp(name, "AdditionalBufferLengthMs")) { ConfigAdditionalBufferLengthMs = atoi(value);
 	} else if (!strcasecmp(name, "LogLevel"))              { ConfigLogLevels = abs(atoi(value));
 	                                                         ConfigLogState = atoi(value) > 0;

--- a/config.cpp
+++ b/config.cpp
@@ -25,6 +25,7 @@
 
 #include <cstring>
 #include <cstdlib>
+#include <mutex>
 
 #include "config.h"
 #include "logger.h"
@@ -137,4 +138,16 @@ void cSoftHdConfig::PrintLogLevel(int loglevel)
 		strcat(prefix, " grabbing");
 
 	LOGINFO("%s", prefix);
+}
+
+void cSoftHdConfig::SetDecoderNeedsMaxPackets(int num)
+{
+	std::lock_guard<std::mutex> lock(m_mutex);
+	m_decoderNeedsMaxPackets = num;
+}
+
+int cSoftHdConfig::GetDecoderNeedsMaxPackets(void)
+{
+	std::lock_guard<std::mutex> lock(m_mutex);
+	return m_decoderNeedsMaxPackets;
 }

--- a/config.h
+++ b/config.h
@@ -61,6 +61,8 @@ public:
 	bool ConfigDisableDeint = false;            ///< disable deinterlacer
 	bool ConfigDecoderNeedsIFrame = false;      ///< start h264 decoder only when an I-Frame arrives
 	bool ConfigParseH264Dimensions = false;     ///< parse h264 stream for width and height for decoder init
+	bool ConfigDecoderFallbackToSw = false;     ///< fallback to software decoder if the hardware decoder fails
+	int ConfigDecoderFallbackToSwNumPkts = 22;  ///< maximum number of packets sent before fallback to sw decoder
 
 	// pip - default position at right top, 25% scaled
 	int ConfigPipScalePercent = 25;             ///< scale factor of pip video

--- a/config.h
+++ b/config.h
@@ -21,6 +21,8 @@
 #ifndef __SOFTHDCONFIG_H
 #define __SOFTHDCONFIG_H
 
+#include <mutex>
+
 /*****************************************************************************
  * Config
  ****************************************************************************/
@@ -83,6 +85,13 @@ public:
 	const char *CurrentDecoderType = "unknown";
 
 	void PrintLogLevel(int);
+
+	void SetDecoderNeedsMaxPackets(int);
+	int GetDecoderNeedsMaxPackets(void);
+
+private:
+	int m_decoderNeedsMaxPackets = 0;
+	std::mutex m_mutex;
 };
 
 #endif

--- a/config.h
+++ b/config.h
@@ -33,9 +33,6 @@ public:
 
 	// setup conf parameters
 #ifdef USE_GLES
-#ifdef WRITE_PNG
-	bool ConfigWritePngs = false;               ///< config write pngs from OSD
-#endif
 	int ConfigMaxSizeGPUImageCache = 128;       ///< config max gpu image cache size
 	int ConfigDisableOglOsd = 0;                ///< config disable ogl osd
 #endif

--- a/openglosd.cpp
+++ b/openglosd.cpp
@@ -32,10 +32,6 @@
 #include <string>
 #endif
 
-#ifdef WRITE_PNG
-#include <png.h>
-#endif
-
 #include <sys/ioctl.h>
 
 #include <GLES2/gl2.h>
@@ -67,102 +63,6 @@
 /****************************************************************************************
  * Helpers
  ***************************************************************************************/
-#ifdef WRITE_PNG
-static int writeImage(char* filename, int width, int height, void *buffer, char* title)
-{
-	int code;
-	FILE *fp;
-	png_structp png_ptr;
-	png_infop info_ptr;
-
-	// Open file for writing (binary mode)
-	fp = fopen(filename, "wb");
-	if (fp == NULL) {
-		LOGERROR("WritePng: Could not open file %s for writing", filename);
-		code = 1;
-		goto finalise;
-	}
-
-	// Initialize write structure
-	png_ptr = png_create_write_struct(PNG_LIBPNG_VER_STRING, NULL, NULL, NULL);
-	if (png_ptr == NULL) {
-		LOGERROR("WritePng: Could not allocate write struct");
-		code = 1;
-		goto finalise;
-	}
-
-	// Initialize info structure
-	info_ptr = png_create_info_struct(png_ptr);
-	if (info_ptr == NULL) {
-		LOGERROR("WritePng: Could not allocate info struct");
-		code = 1;
-		goto finalise;
-	}
-
-	// Setup Exception handling
-	if (setjmp(png_jmpbuf(png_ptr))) {
-		LOGERROR("WritePng: Error during png creation");
-		code = 1;
-		goto finalise;
-	}
-
-	png_init_io(png_ptr, fp);
-
-	// Write header (8 bit colour depth)
-	png_set_IHDR(png_ptr, info_ptr, width, height,
-		8, PNG_COLOR_TYPE_RGB_ALPHA, PNG_INTERLACE_NONE,
-		PNG_COMPRESSION_TYPE_DEFAULT, PNG_FILTER_TYPE_DEFAULT);
-
-	// Set title
-	if (title != NULL) {
-		png_text title_text;
-		title_text.compression = PNG_TEXT_COMPRESSION_NONE;
-		title_text.key = strdup("Title");
-		title_text.text = title;
-		png_set_text(png_ptr, info_ptr, &title_text, 1);
-	}
-
-	png_write_info(png_ptr, info_ptr);
-
-	// Write image data
-	int i;
-	for (i = height - 1; i >= 0; i--) {
-		png_write_row(png_ptr, (png_bytep)buffer + i * width * 4);
-	}
-
-	// End write
-	png_write_end(png_ptr, NULL);
-
-	code = 0;
-finalise:
-	if (fp != NULL) fclose(fp);
-	if (info_ptr != NULL) png_free_data(png_ptr, info_ptr, PNG_FREE_ALL, -1);
-	if (png_ptr != NULL) png_destroy_write_struct(&png_ptr, (png_infopp)NULL);
-
-	return code;
-}
-
-static void writePng(int x, int y, int w, int h, bool oFb) {
-	GL_CHECK(glFinish());
-	GLubyte result[w * h * 4];
-	static int scr_nr = 0;
-	char filename[40];
-
-	GLenum fbstatus;
-	GL_CHECK(fbstatus = glCheckFramebufferStatus(GL_FRAMEBUFFER));
-	if(fbstatus != GL_FRAMEBUFFER_COMPLETE)
-		LOGERROR("WritePng: Framebuffer is not complete! %d", fbstatus);
-
-	GL_CHECK(glReadPixels(x, y, w, h, GL_RGBA, GL_UNSIGNED_BYTE, &result));
-	if (oFb) {
-		snprintf(filename, sizeof(filename), "/tmp/%03doFb.png", scr_nr++);
-	} else {
-		snprintf(filename, sizeof(filename), "/tmp/%03dbFb.png", scr_nr++);
-	}
-	writeImage(filename, w, h, &result, strdup("osd"));
-}
-#endif
-
 static void ConvertColor(const GLint &colARGB, glm::vec4 &col) {
 	col.a = ((colARGB & 0xFF000000) >> 24) / 255.0;
 	col.r = ((colARGB & 0x00FF0000) >> 16) / 255.0;
@@ -1062,11 +962,6 @@ bool cOglCmdRenderFbToBufferFb::Execute(void)
 	GL_CHECK(glDisable(GL_SCISSOR_TEST));
 	VertexBuffers[vbTexture]->Unbind();
 
-#ifdef WRITE_PNG
-	// Read back bFb framebuffer
-//	if (Device->WritePngs())
-//		writePng(0, 0, buffer->Width(), buffer->Height(), false);
-#endif
 	if (!m_alphablending)
 		VertexBuffers[vbTexture]->EnableBlending();
 	m_pBuffer->Unbind();
@@ -1120,11 +1015,6 @@ bool cOglCmdCopyBufferToOutputFb::Execute(void)
 	else
 		m_pDevice->OsdClose();
 
-#ifdef WRITE_PNG
-	// Read back oFb framebuffer
-	if (m_pDevice->WritePngs())
-		writePng(0, 0, m_pOutputFramebuffer->Width(), m_pOutputFramebuffer->Height(), true);
-#endif
 	m_pOutputFramebuffer->Unbind();
 
 	return true;

--- a/po/de_DE.po
+++ b/po/de_DE.po
@@ -67,14 +67,14 @@ msgstr "verstecken"
 msgid "General"
 msgstr "Allgemeines"
 
-msgid "Hide main menu entry"
-msgstr "Verstecke Hauptmenüeintrag"
+msgid " Hide main menu entry"
+msgstr " Verstecke Hauptmenüeintrag"
 
-msgid "GPU mem used for image caching (MB)"
-msgstr "GPU-Speichergröße für Bild-Zwischenspeicher (MB)"
+msgid " GPU mem used for image caching (MB)"
+msgstr " GPU-Speichergröße für Bild-Zwischenspeicher (MB)"
 
-msgid "Additional buffer size (ms)"
-msgstr "Zusätzlicher Puffer (ms)"
+msgid " Additional buffer size (ms)"
+msgstr " Zusätzlicher Puffer (ms)"
 
 msgid "Statistics"
 msgstr "Statistiken"
@@ -98,13 +98,13 @@ msgid "Debug"
 msgstr "Debug"
 
 msgid "Write OSD to file"
-msgstr "OSD in Datei schreiben"
+msgstr " OSD in Datei schreiben"
 
 msgid "Logging"
 msgstr "Logging"
 
-msgid "Enable logging"
-msgstr "Aktiviere Logs"
+msgid " Enable logging"
+msgstr " Aktiviere Logs"
 
 msgid "  Standard debug logs"
 msgstr "  Standard debug Logs"
@@ -154,17 +154,17 @@ msgstr "  OpenGL OSD Zeitmessung (alles)"
 msgid "Video"
 msgstr "Video"
 
-msgid "Disable deinterlacer"
-msgstr "Deaktiviere Deinterlacer"
+msgid " Disable deinterlacer"
+msgstr " Deaktiviere Deinterlacer"
 
-msgid "H.264 HW dec needs I-Frame"
-msgstr "H.264 HW Dek. benötigt I-Frame"
+msgid " H.264 HW dec needs I-Frame"
+msgstr " H.264 HW Dek. benötigt I-Frame"
 
-msgid "H.264 HW dec needs width and height"
-msgstr "H.264 HW Dek. benötigt Größe"
+msgid " H.264 HW dec needs width and height"
+msgstr " H.264 HW Dek. benötigt Größe"
 
-msgid "Enable SW decoder fallback"
-msgstr "Aktiviere SW Dekoder Fallback"
+msgid " Enable SW decoder fallback"
+msgstr " Aktiviere SW Dekoder Fallback"
 
 msgid "  fallback after num packets"
 msgstr "  Fallback nach Anzahl Paketen"
@@ -196,11 +196,11 @@ msgstr " alt. Abstand rechts (%)"
 msgid "Audio"
 msgstr "Audio"
 
-msgid "Audio/Video delay (ms)"
-msgstr "Audio/Video Verzögerung (ms)"
+msgid " Audio/Video delay (ms)"
+msgstr " Audio/Video Verzögerung (ms)"
 
-msgid "Volume control"
-msgstr "Lautstärkesteuerung"
+msgid " Volume control"
+msgstr " Lautstärkesteuerung"
 
 msgid "Hardware"
 msgstr "Hardware"
@@ -208,26 +208,26 @@ msgstr "Hardware"
 msgid "Software"
 msgstr "Software"
 
-msgid "Enable normalize volume"
-msgstr "Aktiviere Lautstärkenormalisierung"
+msgid " Enable normalize volume"
+msgstr " Aktiviere Lautstärkenormalisierung"
 
 msgid "  Max normalize factor (/1000)"
 msgstr "  Max. Normalisierungsfaktor (/1000)"
 
-msgid "Enable volume compression"
-msgstr "Aktiviere Lautstärkekompression"
+msgid " Enable volume compression"
+msgstr " Aktiviere Lautstärkekompression"
 
 msgid "  Max compression factor (/1000)"
 msgstr "  Max. Kompressionsfaktor (/1000)"
 
-msgid "Reduce stereo volume (/1000)"
-msgstr "Reduziere Steropegel (/1000)"
+msgid " Reduce stereo volume (/1000)"
+msgstr " Reduziere Steropegel (/1000)"
 
-msgid "Enable Stereo downmix"
-msgstr "Audio auf Stereo herunterrechnen"
+msgid " Enable Stereo downmix"
+msgstr " Audio auf Stereo herunterrechnen"
 
-msgid "Enable Pass-through"
-msgstr "Aktiviere Passthrough"
+msgid " Enable Pass-through"
+msgstr " Aktiviere Passthrough"
 
 msgid "  AC-3 pass-through"
 msgstr "  Aktiviere AC-3 Passthrough"
@@ -238,7 +238,7 @@ msgstr "  Aktiviere E-AC-3 Passthrough"
 msgid "  DTS pass-through"
 msgstr "  Aktiviere DTS Passthrough"
 
-msgid "Enable automatic AES"
+msgid "  Enable automatic AES"
 msgstr "  Aktiviere automatische AES Parameter"
 
 msgid "Audio Filter"

--- a/po/de_DE.po
+++ b/po/de_DE.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: VDR \n"
 "Report-Msgid-Bugs-To: <see README>\n"
-"POT-Creation-Date: 2026-01-28 11:04+0100\n"
+"POT-Creation-Date: 2026-02-19 09:53+0100\n"
 "PO-Revision-Date: blabla\n"
 "Last-Translator: blabla\n"
 "Language-Team: blabla\n"
@@ -70,143 +70,38 @@ msgstr "Allgemeines"
 msgid " Hide main menu entry"
 msgstr " Verstecke Hauptmenüeintrag"
 
-msgid " GPU mem used for image caching (MB)"
-msgstr " GPU-Speichergröße für Bild-Zwischenspeicher (MB)"
-
-msgid " Additional buffer size (ms)"
-msgstr " Zusätzlicher Puffer (ms)"
-
-msgid "Statistics"
-msgstr "Statistiken"
-
-#, c-format
-msgid " Frames duped(%d) dropped(%d) total(%d)"
-msgstr " Frames verdoppelt(%d) verworfen (%d) gesamt (%d)"
-
-#, c-format
-msgid " OSD: Using %s rendering"
-msgstr " OSD: Benutze %s rendering"
-
-msgid " OSD: Using software rendering"
-msgstr " OSD: Benutze software rendering"
-
-#, c-format
-msgid " Video decoder: %s (%s)"
-msgstr " Video Dekodierer: %s (%s)"
-
-msgid "Debug"
-msgstr "Debug"
-
-msgid "Write OSD to file"
-msgstr " OSD in Datei schreiben"
-
-msgid "Logging"
-msgstr "Logging"
-
-msgid " Enable logging"
-msgstr " Aktiviere Logs"
-
-msgid "  Standard debug logs"
-msgstr "  Standard debug Logs"
-
-msgid "  DRM debug logs"
-msgstr "  DRM debug Logs"
-
-msgid "  Codec debug logs"
-msgstr "  Codec debug Logs"
-
-msgid "  AV Sync debug logs"
-msgstr "  AV Sync debug Logs"
-
-msgid "  Sound debug logs"
-msgstr "  Sound debug Logs"
-
-msgid "  FFmpeg debug logs"
-msgstr "  FFMpeg logs"
-
-msgid "  Packet tracking logs"
-msgstr "  Paketverfolgung"
-
-msgid "  OSD debug logs"
-msgstr "  OSD debug Logs"
-
-msgid "  Grabbing debug logs"
-msgstr "  Grabbing debug Logs"
-
-msgid "  Stillpicture debug logs"
-msgstr "  Standbild debug Logs"
-
-msgid "  Trickspeed debug logs"
-msgstr "  Trickspeed debug Logs"
-
-msgid "  Mediaplayer debug logs"
-msgstr "  Mediaplayer debug Logs"
-
-msgid "  OpenGL OSD debug logs"
-msgstr "  OpenGL OSD debug Logs"
-
-msgid "  OpenGL OSD time measurement"
-msgstr "  OpenGL OSD Zeitmessung"
-
-msgid "  OpenGL OSD time measurement (extensive)"
-msgstr "  OpenGL OSD Zeitmessung (alles)"
-
-msgid "Video"
-msgstr "Video"
-
-msgid " Disable deinterlacer"
-msgstr " Deaktiviere Deinterlacer"
-
-msgid " H.264 HW dec needs I-Frame"
-msgstr " H.264 HW Dek. benötigt I-Frame"
-
-msgid " H.264 HW dec needs width and height"
-msgstr " H.264 HW Dek. benötigt Größe"
-
-msgid " Enable SW decoder fallback"
-msgstr " Aktiviere SW Dekoder Fallback"
-
-msgid "  fallback after num packets"
-msgstr "  Fallback nach Anzahl Paketen"
-
-msgid "Picture-in-picture"
-msgstr "Bild-in-Bild"
-
-msgid " video scaling factor (%)"
-msgstr " Skalierung (%)"
-
-msgid " video left (%)"
-msgstr " Abstand links (%)"
-
-msgid " video top (%)"
-msgstr " Abstand oben (%)"
-
-msgid " use alternative position as default"
-msgstr " Benutze Alternativposition"
-
-msgid " alternative video scaling factor (%)"
-msgstr " alt. Skalierung (%)"
-
-msgid " alternative video left (%)"
-msgstr " alt. Abstand links (%)"
-
-msgid " alternative video top (%)"
-msgstr " alt. Abstand rechts (%)"
-
 msgid "Audio"
 msgstr "Audio"
-
-msgid " Audio/Video delay (ms)"
-msgstr " Audio/Video Verzögerung (ms)"
 
 msgid " Volume control"
 msgstr " Lautstärkesteuerung"
 
-msgid "Hardware"
-msgstr "Hardware"
+msgid "hardware"
+msgstr ""
 
-msgid "Software"
-msgstr "Software"
+msgid "software"
+msgstr ""
+
+msgid " Enable stereo downmix"
+msgstr " Audio auf Stereo herunterrechnen"
+
+msgid " Enable passthrough"
+msgstr " Aktiviere Passthrough"
+
+msgid "  AC-3 passthrough"
+msgstr "  Aktiviere AC-3 Passthrough"
+
+msgid "  E-AC-3 passthrough"
+msgstr "  Aktiviere E-AC-3 Passthrough"
+
+msgid "  DTS passthrough"
+msgstr "  Aktiviere DTS Passthrough"
+
+msgid "  Enable automatic AES"
+msgstr "  Aktiviere automatische AES Parameter"
+
+msgid " Audio/Video delay (ms)"
+msgstr " Audio/Video Verzögerung (ms)"
 
 msgid " Enable normalize volume"
 msgstr " Aktiviere Lautstärkenormalisierung"
@@ -223,28 +118,10 @@ msgstr "  Max. Kompressionsfaktor (/1000)"
 msgid " Reduce stereo volume (/1000)"
 msgstr " Reduziere Steropegel (/1000)"
 
-msgid " Enable Stereo downmix"
-msgstr " Audio auf Stereo herunterrechnen"
+msgid "Audio equalizer"
+msgstr "Audio Equalizer"
 
-msgid " Enable Pass-through"
-msgstr " Aktiviere Passthrough"
-
-msgid "  AC-3 pass-through"
-msgstr "  Aktiviere AC-3 Passthrough"
-
-msgid "  E-AC-3 pass-through"
-msgstr "  Aktiviere E-AC-3 Passthrough"
-
-msgid "  DTS pass-through"
-msgstr "  Aktiviere DTS Passthrough"
-
-msgid "  Enable automatic AES"
-msgstr "  Aktiviere automatische AES Parameter"
-
-msgid "Audio Filter"
-msgstr "Audio-Filter"
-
-msgid " Enable Audio Equalizer"
+msgid " Enable audio equalizer"
 msgstr " Aktiviere Audio Equalizer"
 
 msgid "  60 Hz band gain"
@@ -300,3 +177,129 @@ msgstr "  13500 Hz Frequenzverstärkung"
 
 msgid "  17200 Hz band gain"
 msgstr "  17200 Hz Frequenzverstärkung"
+
+msgid "Picture-in-picture"
+msgstr "Bild-in-Bild"
+
+msgid " video scaling factor (%)"
+msgstr " Skalierung (%)"
+
+msgid " video left (%)"
+msgstr " Abstand links (%)"
+
+msgid " video top (%)"
+msgstr " Abstand oben (%)"
+
+msgid " use alternative position as default"
+msgstr " Benutze Alternativposition"
+
+msgid " alternative video scaling factor (%)"
+msgstr " alt. Skalierung (%)"
+
+msgid " alternative video left (%)"
+msgstr " alt. Abstand links (%)"
+
+msgid " alternative video top (%)"
+msgstr " alt. Abstand rechts (%)"
+
+msgid "Logging"
+msgstr "Logging"
+
+msgid " Enable logging"
+msgstr " Aktiviere Logs"
+
+msgid "  Standard debug logs"
+msgstr "  Standard debug Logs"
+
+msgid "  DRM debug logs"
+msgstr "  DRM debug Logs"
+
+msgid "  Codec debug logs"
+msgstr "  Codec debug Logs"
+
+msgid "  AV Sync debug logs"
+msgstr "  AV Sync debug Logs"
+
+msgid "  Sound debug logs"
+msgstr "  Sound debug Logs"
+
+msgid "  FFmpeg debug logs"
+msgstr "  FFMpeg logs"
+
+msgid "  Packet tracking logs"
+msgstr "  Paketverfolgung"
+
+msgid "  OSD debug logs"
+msgstr "  OSD debug Logs"
+
+msgid "  Grabbing debug logs"
+msgstr "  Grabbing debug Logs"
+
+msgid "  Stillpicture debug logs"
+msgstr "  Standbild debug Logs"
+
+msgid "  Trickspeed debug logs"
+msgstr "  Trickspeed debug Logs"
+
+msgid "  Mediaplayer debug logs"
+msgstr "  Mediaplayer debug Logs"
+
+msgid "  OpenGL OSD debug logs"
+msgstr "  OpenGL OSD debug Logs"
+
+msgid "  OpenGL OSD time measurement"
+msgstr "  OpenGL OSD Zeitmessung"
+
+msgid "  OpenGL OSD time measurement (extensive)"
+msgstr "  OpenGL OSD Zeitmessung (alles)"
+
+msgid "Statistics"
+msgstr "Statistiken"
+
+#, c-format
+msgid " Frames duped(%d) dropped(%d) total(%d)"
+msgstr " Frames verdoppelt(%d) verworfen (%d) gesamt (%d)"
+
+#, c-format
+msgid " OSD: Using %s rendering"
+msgstr " OSD: Benutze %s rendering"
+
+msgid " OSD: Using software rendering"
+msgstr " OSD: Benutze software rendering"
+
+#, c-format
+msgid " Video decoder: %s (%s)"
+msgstr " Video Dekodierer: %s (%s)"
+
+msgid "Expert settings"
+msgstr "Experteneinstellung"
+
+msgid " Audio settings"
+msgstr " Audio Einstellungen"
+
+msgid " Additional buffer size (ms)"
+msgstr " Zusätzlicher Puffer (ms)"
+
+msgid " Video settings"
+msgstr " Video Einstellungen"
+
+msgid " Disable deinterlacer"
+msgstr " Deaktiviere Deinterlacer"
+
+msgid " H.264 HW dec needs I-Frame"
+msgstr " H.264 HW Dek. benötigt I-Frame"
+
+msgid " H.264 HW dec needs width and height"
+msgstr " H.264 HW Dek. benötigt Größe"
+
+msgid " Enable SW decoder fallback"
+msgstr " Aktiviere SW Dekoder Fallback"
+
+msgid "  fallback after num packets"
+msgstr "  Fallback nach Anzahl Paketen"
+
+msgid " OSD settings"
+msgstr " OSD Einstellungen"
+
+msgid " GPU mem used for image caching (MB)"
+msgstr " GPU-Speichergröße für Bild-Zwischenspeicher (MB)"

--- a/po/de_DE.po
+++ b/po/de_DE.po
@@ -157,11 +157,17 @@ msgstr "Video"
 msgid "Disable deinterlacer"
 msgstr "Deaktiviere Deinterlacer"
 
-msgid "H.264 HW decoder needs I-Frame"
-msgstr "H.264 HW Dekoder benötigt I-Frame für Start"
+msgid "H.264 HW dec needs I-Frame"
+msgstr "H.264 HW Dek. benötigt I-Frame"
 
-msgid "H.264 HW decoder needs parsed width and height"
-msgstr "H.264 HW Dekoder benötigt Größe für Start"
+msgid "H.264 HW dec needs width and height"
+msgstr "H.264 HW Dek. benötigt Größe"
+
+msgid "Enable SW decoder fallback"
+msgstr "Aktiviere SW Dekoder Fallback"
+
+msgid "  fallback after num packets"
+msgstr "  Fallback nach Anzahl Paketen"
 
 msgid "Picture-in-picture"
 msgstr "Bild-in-Bild"

--- a/po/de_DE.po
+++ b/po/de_DE.po
@@ -295,6 +295,10 @@ msgstr " H.264 HW Dek. benötigt Größe"
 msgid " Enable SW decoder fallback"
 msgstr " Aktiviere SW Dekoder Fallback"
 
+#, c-format
+msgid "  (minimum: %d)"
+msgstr "  (mindestens: %d)"
+
 msgid "  fallback after num packets"
 msgstr "  Fallback nach Anzahl Paketen"
 

--- a/softhddevice.cpp
+++ b/softhddevice.cpp
@@ -1417,15 +1417,6 @@ void cSoftHdDevice::OsdDrawARGB(int xi, int yi, int height, int width, int pitch
 }
 
 #ifdef USE_GLES
-#ifdef WRITE_PNG
-/**
- * Check, if writing the osd into a png file is enabled
- */
-char cSoftHdDevice::WritePngs(void)
-{
-	return m_pConfig->ConfigWritePngs;
-};
-#endif
 /**
  * Get the maximum GPU image cache size
  */

--- a/softhddevice.cpp
+++ b/softhddevice.cpp
@@ -1492,6 +1492,21 @@ void cSoftHdDevice::SetParseH264Dimensions(void)
 }
 
 /**
+ * Force the decoder to fallback to software if the hardware decoder fails
+ * after the configured amount of packets were sent and no frame was received
+ */
+void cSoftHdDevice::SetDecoderFallbackToSw(bool enable)
+{
+	if (!m_pVideoStream)
+		return;
+
+	if (enable)
+		m_pVideoStream->SetDecoderFallbackToSwNumPkts(m_pConfig->ConfigDecoderFallbackToSwNumPkts);
+	else
+		m_pVideoStream->SetDecoderFallbackToSwNumPkts(0);
+}
+
+/**
  * Set the passthrough mask (called from setup menu or conf)
  */
 void cSoftHdDevice::SetPassthrough(int mask)

--- a/softhddevice.h
+++ b/softhddevice.h
@@ -180,9 +180,6 @@ public:
 
 	// osd
 #ifdef USE_GLES
-#ifdef WRITE_PNG
-	char WritePngs(void);
-#endif
 	int MaxSizeGPUImageCache(void);
 	int OglOsdIsDisabled(void);
 	void SetDisableOglOsd(void);

--- a/softhddevice.h
+++ b/softhddevice.h
@@ -176,6 +176,7 @@ public:
 	void SetDisableDeint(void);
 	void SetDecoderNeedsIFrame(void);
 	void SetParseH264Dimensions(void);
+	void SetDecoderFallbackToSw(bool enable);
 
 	// osd
 #ifdef USE_GLES

--- a/softhdsetupmenu.cpp
+++ b/softhdsetupmenu.cpp
@@ -77,14 +77,14 @@ void cMenuSetupSoft::Create(void)
 	//
 	Add(CollapsedItem(tr("General"), m_cGeneral));
 	if (m_cGeneral) {
-		Add(new cMenuEditBoolItem(tr("Hide main menu entry"), &m_cHideMainMenuEntry, trVDR("no"), trVDR("yes")));
+		Add(new cMenuEditBoolItem(tr(" Hide main menu entry"), &m_cHideMainMenuEntry, trVDR("no"), trVDR("yes")));
 #ifdef USE_GLES
 		if (!m_pConfig->ConfigDisableOglOsd) {
-			Add(new cMenuEditIntItem(tr("GPU mem used for image caching (MB)"), &m_cMaxSizeGPUImageCache, 0, 4000));
+			Add(new cMenuEditIntItem(tr(" GPU mem used for image caching (MB)"), &m_cMaxSizeGPUImageCache, 0, 4000));
 		}
 #endif
 
-		Add(new cMenuEditIntItem(tr("Additional buffer size (ms)"), &m_cAdditionalBufferLengthMs, 0, 1000));
+		Add(new cMenuEditIntItem(tr(" Additional buffer size (ms)"), &m_cAdditionalBufferLengthMs, 0, 1000));
 	}
 
 	//
@@ -113,7 +113,7 @@ void cMenuSetupSoft::Create(void)
 	if (!m_pConfig->ConfigDisableOglOsd) {
 		Add(CollapsedItem(tr("Debug"), m_cDebugMenu));
 		if (m_cDebugMenu) {
-			Add(new cMenuEditBoolItem(tr("Write OSD to file"), &m_cWritePngs, trVDR("no"), trVDR("yes")));
+			Add(new cMenuEditBoolItem(tr(" Write OSD to file"), &m_cWritePngs, trVDR("no"), trVDR("yes")));
 		}
 	}
 #endif
@@ -124,23 +124,23 @@ void cMenuSetupSoft::Create(void)
 	//
 	Add(CollapsedItem(tr("Logging"), m_cLogging));
 	if (m_cLogging) {
-		Add(new cMenuEditBoolItem(tr("Enable logging"), &m_cLogDefault, trVDR("off"), trVDR("on")));
+		Add(new cMenuEditBoolItem(tr(" Enable logging"), &m_cLogDefault, trVDR("off"), trVDR("on")));
 		if (m_cLogDefault) {
-			Add(new cMenuEditBoolItem(tr("\040\040Standard debug logs"), &m_cLogDebug_, trVDR("no"), trVDR("yes")));
-			Add(new cMenuEditBoolItem(tr("\040\040DRM debug logs"), &m_cLogDRM, trVDR("no"), trVDR("yes")));
-			Add(new cMenuEditBoolItem(tr("\040\040Codec debug logs"), &m_cLogCodec, trVDR("no"), trVDR("yes")));
-			Add(new cMenuEditBoolItem(tr("\040\040AV Sync debug logs"), &m_cLogAVSync, trVDR("no"), trVDR("yes")));
-			Add(new cMenuEditBoolItem(tr("\040\040Sound debug logs"), &m_cLogSound, trVDR("no"), trVDR("yes")));
-			Add(new cMenuEditBoolItem(tr("\040\040FFmpeg debug logs"), &m_cLogFFmpeg, trVDR("no"), trVDR("yes")));
-			Add(new cMenuEditBoolItem(tr("\040\040Packet tracking logs"), &m_cLogPacket, trVDR("no"), trVDR("yes")));
-			Add(new cMenuEditBoolItem(tr("\040\040OSD debug logs"), &m_cLogOSD, trVDR("no"), trVDR("yes")));
-			Add(new cMenuEditBoolItem(tr("\040\040Grabbing debug logs"), &m_cLogGrab, trVDR("no"), trVDR("yes")));
-			Add(new cMenuEditBoolItem(tr("\040\040Stillpicture debug logs"), &m_cLogStill, trVDR("no"), trVDR("yes")));
-			Add(new cMenuEditBoolItem(tr("\040\040Trickspeed debug logs"), &m_cLogTrick, trVDR("no"), trVDR("yes")));
-			Add(new cMenuEditBoolItem(tr("\040\040Mediaplayer debug logs"), &m_cLogMedia, trVDR("no"), trVDR("yes")));
-			Add(new cMenuEditBoolItem(tr("\040\040OpenGL OSD debug logs"), &m_cLogGL, trVDR("no"), trVDR("yes")));
-			Add(new cMenuEditBoolItem(tr("\040\040OpenGL OSD time measurement"), &m_cLogGLTime, trVDR("no"), trVDR("yes")));
-			Add(new cMenuEditBoolItem(tr("\040\040OpenGL OSD time measurement (extensive)"), &m_cLogGLTimeAll, trVDR("no"), trVDR("yes")));
+			Add(new cMenuEditBoolItem(tr("  Standard debug logs"), &m_cLogDebug_, trVDR("no"), trVDR("yes")));
+			Add(new cMenuEditBoolItem(tr("  DRM debug logs"), &m_cLogDRM, trVDR("no"), trVDR("yes")));
+			Add(new cMenuEditBoolItem(tr("  Codec debug logs"), &m_cLogCodec, trVDR("no"), trVDR("yes")));
+			Add(new cMenuEditBoolItem(tr("  AV Sync debug logs"), &m_cLogAVSync, trVDR("no"), trVDR("yes")));
+			Add(new cMenuEditBoolItem(tr("  Sound debug logs"), &m_cLogSound, trVDR("no"), trVDR("yes")));
+			Add(new cMenuEditBoolItem(tr("  FFmpeg debug logs"), &m_cLogFFmpeg, trVDR("no"), trVDR("yes")));
+			Add(new cMenuEditBoolItem(tr("  Packet tracking logs"), &m_cLogPacket, trVDR("no"), trVDR("yes")));
+			Add(new cMenuEditBoolItem(tr("  OSD debug logs"), &m_cLogOSD, trVDR("no"), trVDR("yes")));
+			Add(new cMenuEditBoolItem(tr("  Grabbing debug logs"), &m_cLogGrab, trVDR("no"), trVDR("yes")));
+			Add(new cMenuEditBoolItem(tr("  Stillpicture debug logs"), &m_cLogStill, trVDR("no"), trVDR("yes")));
+			Add(new cMenuEditBoolItem(tr("  Trickspeed debug logs"), &m_cLogTrick, trVDR("no"), trVDR("yes")));
+			Add(new cMenuEditBoolItem(tr("  Mediaplayer debug logs"), &m_cLogMedia, trVDR("no"), trVDR("yes")));
+			Add(new cMenuEditBoolItem(tr("  OpenGL OSD debug logs"), &m_cLogGL, trVDR("no"), trVDR("yes")));
+			Add(new cMenuEditBoolItem(tr("  OpenGL OSD time measurement"), &m_cLogGLTime, trVDR("no"), trVDR("yes")));
+			Add(new cMenuEditBoolItem(tr("  OpenGL OSD time measurement (extensive)"), &m_cLogGLTimeAll, trVDR("no"), trVDR("yes")));
 		}
 	}
 
@@ -149,10 +149,10 @@ void cMenuSetupSoft::Create(void)
 	//
 	Add(CollapsedItem(tr("Video"), m_cVideoMenu));
 	if (m_cVideoMenu) {
-		Add(new cMenuEditBoolItem(tr("Disable deinterlacer"), &m_cDisableDeint, trVDR("no"), trVDR("yes")));
-		Add(new cMenuEditBoolItem(tr("H.264 HW dec needs I-Frame"), &m_cDecoderNeedsIFrame, trVDR("no"), trVDR("yes")));
-		Add(new cMenuEditBoolItem(tr("H.264 HW dec needs width and height"), &m_cParseH264Dimensions, trVDR("no"), trVDR("yes")));
-		Add(new cMenuEditBoolItem(tr("Enable SW decoder fallback"), &m_cDecoderFallbackToSw, trVDR("no"), trVDR("yes")));
+		Add(new cMenuEditBoolItem(tr(" Disable deinterlacer"), &m_cDisableDeint, trVDR("no"), trVDR("yes")));
+		Add(new cMenuEditBoolItem(tr(" H.264 HW dec needs I-Frame"), &m_cDecoderNeedsIFrame, trVDR("no"), trVDR("yes")));
+		Add(new cMenuEditBoolItem(tr(" H.264 HW dec needs width and height"), &m_cParseH264Dimensions, trVDR("no"), trVDR("yes")));
+		Add(new cMenuEditBoolItem(tr(" Enable SW decoder fallback"), &m_cDecoderFallbackToSw, trVDR("no"), trVDR("yes")));
 		if (m_cDecoderFallbackToSw)
 			Add(new cMenuEditIntItem(tr("  fallback after num packets"), &m_cDecoderFallbackToSwNumPkts, 22));
 		if (m_pDevice->UsePip()) {
@@ -172,22 +172,22 @@ void cMenuSetupSoft::Create(void)
 	//
 	Add(CollapsedItem(tr("Audio"), m_cAudio));
 	if (m_cAudio) {
-		Add(new cMenuEditIntItem(tr("Audio/Video delay (ms)"), &m_cAudioDelay, -1000, 1000));
-		Add(new cMenuEditBoolItem(tr("Volume control"), &m_cAudioSoftvol, tr("Hardware"), tr("Software")));
-		Add(new cMenuEditBoolItem(tr("Enable normalize volume"), &m_cAudioNormalize, trVDR("no"), trVDR("yes")));
+		Add(new cMenuEditIntItem(tr(" Audio/Video delay (ms)"), &m_cAudioDelay, -1000, 1000));
+		Add(new cMenuEditBoolItem(tr(" Volume control"), &m_cAudioSoftvol, tr("Hardware"), tr("Software")));
+		Add(new cMenuEditBoolItem(tr(" Enable normalize volume"), &m_cAudioNormalize, trVDR("no"), trVDR("yes")));
 		if (m_cAudioNormalize)
 			Add(new cMenuEditIntItem(tr("  Max normalize factor (/1000)"), &m_cAudioMaxNormalize, 0, 10000));
-		Add(new cMenuEditBoolItem(tr("Enable volume compression"), &m_cAudioCompression, trVDR("no"), trVDR("yes")));
+		Add(new cMenuEditBoolItem(tr(" Enable volume compression"), &m_cAudioCompression, trVDR("no"), trVDR("yes")));
 		if (m_cAudioCompression)
 			Add(new cMenuEditIntItem(tr("  Max compression factor (/1000)"), &m_cAudioMaxCompression, 0, 10000));
-		Add(new cMenuEditIntItem(tr("Reduce stereo volume (/1000)"), &m_cAudioStereoDescent, 0, 1000));
-		Add(new cMenuEditBoolItem(tr("Enable Stereo downmix"), &m_cAudioDownmix, trVDR("no"), trVDR("yes")));
-		Add(new cMenuEditBoolItem(tr("Enable Pass-through"), &m_cAudioPassthroughDefault, trVDR("off"), trVDR("on")));
+		Add(new cMenuEditIntItem(tr(" Reduce stereo volume (/1000)"), &m_cAudioStereoDescent, 0, 1000));
+		Add(new cMenuEditBoolItem(tr(" Enable Stereo downmix"), &m_cAudioDownmix, trVDR("no"), trVDR("yes")));
+		Add(new cMenuEditBoolItem(tr(" Enable Pass-through"), &m_cAudioPassthroughDefault, trVDR("off"), trVDR("on")));
 		if (m_cAudioPassthroughDefault) {
-			Add(new cMenuEditBoolItem(tr("\040\040AC-3 pass-through"), &m_cAudioPassthroughAC3, trVDR("no"), trVDR("yes")));
-			Add(new cMenuEditBoolItem(tr("\040\040E-AC-3 pass-through"), &m_cAudioPassthroughEAC3, trVDR("no"), trVDR("yes")));
-			Add(new cMenuEditBoolItem(tr("\040\040DTS pass-through"), &m_cAudioPassthroughDTS, trVDR("no"), trVDR("yes")));
-			Add(new cMenuEditBoolItem(tr("Enable automatic AES"), &m_cAudioAutoAES, trVDR("no"), trVDR("yes")));
+			Add(new cMenuEditBoolItem(tr("  AC-3 pass-through"), &m_cAudioPassthroughAC3, trVDR("no"), trVDR("yes")));
+			Add(new cMenuEditBoolItem(tr("  E-AC-3 pass-through"), &m_cAudioPassthroughEAC3, trVDR("no"), trVDR("yes")));
+			Add(new cMenuEditBoolItem(tr("  DTS pass-through"), &m_cAudioPassthroughDTS, trVDR("no"), trVDR("yes")));
+			Add(new cMenuEditBoolItem(tr("  Enable automatic AES"), &m_cAudioAutoAES, trVDR("no"), trVDR("yes")));
 		}
 	}
 

--- a/softhdsetupmenu.cpp
+++ b/softhdsetupmenu.cpp
@@ -75,91 +75,26 @@ void cMenuSetupSoft::Create(void)
 	//
 	// General
 	//
-	Add(CollapsedItem(tr("General"), m_cGeneral));
-	if (m_cGeneral) {
+	Add(CollapsedItem(tr("General"), m_cGeneralMenu));
+	if (m_cGeneralMenu) {
 		Add(new cMenuEditBoolItem(tr(" Hide main menu entry"), &m_cHideMainMenuEntry, trVDR("no"), trVDR("yes")));
-#ifdef USE_GLES
-		if (!m_pConfig->ConfigDisableOglOsd) {
-			Add(new cMenuEditIntItem(tr(" GPU mem used for image caching (MB)"), &m_cMaxSizeGPUImageCache, 0, 4000));
-		}
-#endif
-
-		Add(new cMenuEditIntItem(tr(" Additional buffer size (ms)"), &m_cAdditionalBufferLengthMs, 0, 1000));
-	}
-
-	//
-	// Statistics
-	//
-	Add(CollapsedItem(tr("Statistics"), m_cStatistics));
-	if (m_cStatistics) {
-		int duped;
-		int dropped;
-		int counter;
-		m_pDevice->GetStats(&duped, &dropped, &counter);
-		Add(new cOsdItem(cString::sprintf(tr(" Frames duped(%d) dropped(%d) total(%d)"), duped, dropped, counter), osUnknown, false));
-#ifdef USE_GLES
-		Add(new cOsdItem(cString::sprintf(tr(" OSD: Using %s rendering"), m_pConfig->ConfigDisableOglOsd ? "software" : "hardware"), osUnknown, false));
-#else
-		Add(new cOsdItem(cString::sprintf(tr(" OSD: Using software rendering")), osUnknown, false));
-#endif
-		Add(new cOsdItem(cString::sprintf(tr(" Video decoder: %s (%s)"), m_pConfig->CurrentDecoderName, m_pConfig->CurrentDecoderType), osUnknown, false));
-	}
-
-	//
-	// Logging
-	//
-	Add(CollapsedItem(tr("Logging"), m_cLogging));
-	if (m_cLogging) {
-		Add(new cMenuEditBoolItem(tr(" Enable logging"), &m_cLogDefault, trVDR("off"), trVDR("on")));
-		if (m_cLogDefault) {
-			Add(new cMenuEditBoolItem(tr("  Standard debug logs"), &m_cLogDebug_, trVDR("no"), trVDR("yes")));
-			Add(new cMenuEditBoolItem(tr("  DRM debug logs"), &m_cLogDRM, trVDR("no"), trVDR("yes")));
-			Add(new cMenuEditBoolItem(tr("  Codec debug logs"), &m_cLogCodec, trVDR("no"), trVDR("yes")));
-			Add(new cMenuEditBoolItem(tr("  AV Sync debug logs"), &m_cLogAVSync, trVDR("no"), trVDR("yes")));
-			Add(new cMenuEditBoolItem(tr("  Sound debug logs"), &m_cLogSound, trVDR("no"), trVDR("yes")));
-			Add(new cMenuEditBoolItem(tr("  FFmpeg debug logs"), &m_cLogFFmpeg, trVDR("no"), trVDR("yes")));
-			Add(new cMenuEditBoolItem(tr("  Packet tracking logs"), &m_cLogPacket, trVDR("no"), trVDR("yes")));
-			Add(new cMenuEditBoolItem(tr("  OSD debug logs"), &m_cLogOSD, trVDR("no"), trVDR("yes")));
-			Add(new cMenuEditBoolItem(tr("  Grabbing debug logs"), &m_cLogGrab, trVDR("no"), trVDR("yes")));
-			Add(new cMenuEditBoolItem(tr("  Stillpicture debug logs"), &m_cLogStill, trVDR("no"), trVDR("yes")));
-			Add(new cMenuEditBoolItem(tr("  Trickspeed debug logs"), &m_cLogTrick, trVDR("no"), trVDR("yes")));
-			Add(new cMenuEditBoolItem(tr("  Mediaplayer debug logs"), &m_cLogMedia, trVDR("no"), trVDR("yes")));
-			Add(new cMenuEditBoolItem(tr("  OpenGL OSD debug logs"), &m_cLogGL, trVDR("no"), trVDR("yes")));
-			Add(new cMenuEditBoolItem(tr("  OpenGL OSD time measurement"), &m_cLogGLTime, trVDR("no"), trVDR("yes")));
-			Add(new cMenuEditBoolItem(tr("  OpenGL OSD time measurement (extensive)"), &m_cLogGLTimeAll, trVDR("no"), trVDR("yes")));
-		}
-	}
-
-	//
-	// Video
-	//
-	Add(CollapsedItem(tr("Video"), m_cVideoMenu));
-	if (m_cVideoMenu) {
-		Add(new cMenuEditBoolItem(tr(" Disable deinterlacer"), &m_cDisableDeint, trVDR("no"), trVDR("yes")));
-		Add(new cMenuEditBoolItem(tr(" H.264 HW dec needs I-Frame"), &m_cDecoderNeedsIFrame, trVDR("no"), trVDR("yes")));
-		Add(new cMenuEditBoolItem(tr(" H.264 HW dec needs width and height"), &m_cParseH264Dimensions, trVDR("no"), trVDR("yes")));
-		Add(new cMenuEditBoolItem(tr(" Enable SW decoder fallback"), &m_cDecoderFallbackToSw, trVDR("no"), trVDR("yes")));
-		if (m_cDecoderFallbackToSw)
-			Add(new cMenuEditIntItem(tr("  fallback after num packets"), &m_cDecoderFallbackToSwNumPkts, 22));
-		if (m_pDevice->UsePip()) {
-			Add(SeparatorName(tr("Picture-in-picture")));
-			Add(new cMenuEditIntItem(tr(" video scaling factor (%)"), &m_cPipScalePercent, 10, 100));
-			Add(new cMenuEditIntItem(tr(" video left (%)"), &m_cPipLeftPercent, 0, 100));
-			Add(new cMenuEditIntItem(tr(" video top (%)"), &m_cPipTopPercent, 0, 100));
-			Add(new cMenuEditBoolItem(tr(" use alternative position as default"), &m_cPipUseAlt, trVDR("no"), trVDR("yes")));
-			Add(new cMenuEditIntItem(tr(" alternative video scaling factor (%)"), &m_cPipAltScalePercent, 10, 100));
-			Add(new cMenuEditIntItem(tr(" alternative video left (%)"), &m_cPipAltLeftPercent, 0, 100));
-			Add(new cMenuEditIntItem(tr(" alternative video top (%)"), &m_cPipAltTopPercent, 0, 100));
-		}
 	}
 
 	//
 	// Audio
 	//
-	Add(CollapsedItem(tr("Audio"), m_cAudio));
-	if (m_cAudio) {
+	Add(CollapsedItem(tr("Audio"), m_cAudioMenu));
+	if (m_cAudioMenu) {
+		Add(new cMenuEditBoolItem(tr(" Volume control"), &m_cAudioSoftvol, tr("hardware"), tr("software")));
+		Add(new cMenuEditBoolItem(tr(" Enable stereo downmix"), &m_cAudioDownmix, trVDR("no"), trVDR("yes")));
+		Add(new cMenuEditBoolItem(tr(" Enable passthrough"), &m_cAudioPassthroughDefault, trVDR("off"), trVDR("on")));
+		if (m_cAudioPassthroughDefault) {
+			Add(new cMenuEditBoolItem(tr("  AC-3 passthrough"), &m_cAudioPassthroughAC3, trVDR("no"), trVDR("yes")));
+			Add(new cMenuEditBoolItem(tr("  E-AC-3 passthrough"), &m_cAudioPassthroughEAC3, trVDR("no"), trVDR("yes")));
+			Add(new cMenuEditBoolItem(tr("  DTS passthrough"), &m_cAudioPassthroughDTS, trVDR("no"), trVDR("yes")));
+			Add(new cMenuEditBoolItem(tr("  Enable automatic AES"), &m_cAudioAutoAES, trVDR("no"), trVDR("yes")));
+		}
 		Add(new cMenuEditIntItem(tr(" Audio/Video delay (ms)"), &m_cAudioDelay, -1000, 1000));
-		Add(new cMenuEditBoolItem(tr(" Volume control"), &m_cAudioSoftvol, tr("Hardware"), tr("Software")));
 		Add(new cMenuEditBoolItem(tr(" Enable normalize volume"), &m_cAudioNormalize, trVDR("no"), trVDR("yes")));
 		if (m_cAudioNormalize)
 			Add(new cMenuEditIntItem(tr("  Max normalize factor (/1000)"), &m_cAudioMaxNormalize, 0, 10000));
@@ -167,22 +102,14 @@ void cMenuSetupSoft::Create(void)
 		if (m_cAudioCompression)
 			Add(new cMenuEditIntItem(tr("  Max compression factor (/1000)"), &m_cAudioMaxCompression, 0, 10000));
 		Add(new cMenuEditIntItem(tr(" Reduce stereo volume (/1000)"), &m_cAudioStereoDescent, 0, 1000));
-		Add(new cMenuEditBoolItem(tr(" Enable Stereo downmix"), &m_cAudioDownmix, trVDR("no"), trVDR("yes")));
-		Add(new cMenuEditBoolItem(tr(" Enable Pass-through"), &m_cAudioPassthroughDefault, trVDR("off"), trVDR("on")));
-		if (m_cAudioPassthroughDefault) {
-			Add(new cMenuEditBoolItem(tr("  AC-3 pass-through"), &m_cAudioPassthroughAC3, trVDR("no"), trVDR("yes")));
-			Add(new cMenuEditBoolItem(tr("  E-AC-3 pass-through"), &m_cAudioPassthroughEAC3, trVDR("no"), trVDR("yes")));
-			Add(new cMenuEditBoolItem(tr("  DTS pass-through"), &m_cAudioPassthroughDTS, trVDR("no"), trVDR("yes")));
-			Add(new cMenuEditBoolItem(tr("  Enable automatic AES"), &m_cAudioAutoAES, trVDR("no"), trVDR("yes")));
-		}
 	}
 
 	//
 	// Audio filter
 	//
-	Add(CollapsedItem(tr("Audio Filter"), m_cAudioFilter));
-	if (m_cAudioFilter) {
-		Add(new cMenuEditBoolItem(tr(" Enable Audio Equalizer"), &m_cAudioEq, trVDR("no"), trVDR("yes")));
+	Add(CollapsedItem(tr("Audio equalizer"), m_cAudioFilterMenu));
+	if (m_cAudioFilterMenu) {
+		Add(new cMenuEditBoolItem(tr(" Enable audio equalizer"), &m_cAudioEq, trVDR("no"), trVDR("yes")));
 		if (m_cAudioEq) {
 			Add(new cMenuEditIntItem(tr("  60 Hz band gain"),   &m_cAudioEqBand[0], -15, 1));
 			Add(new cMenuEditIntItem(tr("  72 Hz band gain"),   &m_cAudioEqBand[1], -15, 1));
@@ -205,6 +132,89 @@ void cMenuSetupSoft::Create(void)
 		}
 	}
 
+	//
+	// PiP
+	//
+	if (m_pDevice->UsePip()) {
+		Add(CollapsedItem(tr("Picture-in-picture"), m_cPipMenu));
+		if (m_cPipMenu) {
+			Add(new cMenuEditIntItem(tr(" video scaling factor (%)"), &m_cPipScalePercent, 10, 100));
+			Add(new cMenuEditIntItem(tr(" video left (%)"), &m_cPipLeftPercent, 0, 100));
+			Add(new cMenuEditIntItem(tr(" video top (%)"), &m_cPipTopPercent, 0, 100));
+			Add(new cMenuEditBoolItem(tr(" use alternative position as default"), &m_cPipUseAlt, trVDR("no"), trVDR("yes")));
+			Add(new cMenuEditIntItem(tr(" alternative video scaling factor (%)"), &m_cPipAltScalePercent, 10, 100));
+			Add(new cMenuEditIntItem(tr(" alternative video left (%)"), &m_cPipAltLeftPercent, 0, 100));
+			Add(new cMenuEditIntItem(tr(" alternative video top (%)"), &m_cPipAltTopPercent, 0, 100));
+		}
+	}
+
+	//
+	// Logging
+	//
+	Add(CollapsedItem(tr("Logging"), m_cLoggingMenu));
+	if (m_cLoggingMenu) {
+		Add(new cMenuEditBoolItem(tr(" Enable logging"), &m_cLogDefault, trVDR("off"), trVDR("on")));
+		if (m_cLogDefault) {
+			Add(new cMenuEditBoolItem(tr("  Standard debug logs"), &m_cLogDebug_, trVDR("no"), trVDR("yes")));
+			Add(new cMenuEditBoolItem(tr("  DRM debug logs"), &m_cLogDRM, trVDR("no"), trVDR("yes")));
+			Add(new cMenuEditBoolItem(tr("  Codec debug logs"), &m_cLogCodec, trVDR("no"), trVDR("yes")));
+			Add(new cMenuEditBoolItem(tr("  AV Sync debug logs"), &m_cLogAVSync, trVDR("no"), trVDR("yes")));
+			Add(new cMenuEditBoolItem(tr("  Sound debug logs"), &m_cLogSound, trVDR("no"), trVDR("yes")));
+			Add(new cMenuEditBoolItem(tr("  FFmpeg debug logs"), &m_cLogFFmpeg, trVDR("no"), trVDR("yes")));
+			Add(new cMenuEditBoolItem(tr("  Packet tracking logs"), &m_cLogPacket, trVDR("no"), trVDR("yes")));
+			Add(new cMenuEditBoolItem(tr("  OSD debug logs"), &m_cLogOSD, trVDR("no"), trVDR("yes")));
+			Add(new cMenuEditBoolItem(tr("  Grabbing debug logs"), &m_cLogGrab, trVDR("no"), trVDR("yes")));
+			Add(new cMenuEditBoolItem(tr("  Stillpicture debug logs"), &m_cLogStill, trVDR("no"), trVDR("yes")));
+			Add(new cMenuEditBoolItem(tr("  Trickspeed debug logs"), &m_cLogTrick, trVDR("no"), trVDR("yes")));
+			Add(new cMenuEditBoolItem(tr("  Mediaplayer debug logs"), &m_cLogMedia, trVDR("no"), trVDR("yes")));
+			Add(new cMenuEditBoolItem(tr("  OpenGL OSD debug logs"), &m_cLogGL, trVDR("no"), trVDR("yes")));
+			Add(new cMenuEditBoolItem(tr("  OpenGL OSD time measurement"), &m_cLogGLTime, trVDR("no"), trVDR("yes")));
+			Add(new cMenuEditBoolItem(tr("  OpenGL OSD time measurement (extensive)"), &m_cLogGLTimeAll, trVDR("no"), trVDR("yes")));
+		}
+	}
+
+	//
+	// Statistics
+	//
+	Add(CollapsedItem(tr("Statistics"), m_cStatisticsMenu));
+	if (m_cStatisticsMenu) {
+		int duped;
+		int dropped;
+		int counter;
+		m_pDevice->GetStats(&duped, &dropped, &counter);
+		Add(new cOsdItem(cString::sprintf(tr(" Frames duped(%d) dropped(%d) total(%d)"), duped, dropped, counter), osUnknown, false));
+#ifdef USE_GLES
+		Add(new cOsdItem(cString::sprintf(tr(" OSD: Using %s rendering"), m_pConfig->ConfigDisableOglOsd ? "software" : "hardware"), osUnknown, false));
+#else
+		Add(new cOsdItem(cString::sprintf(tr(" OSD: Using software rendering")), osUnknown, false));
+#endif
+		Add(new cOsdItem(cString::sprintf(tr(" Video decoder: %s (%s)"), m_pConfig->CurrentDecoderName, m_pConfig->CurrentDecoderType), osUnknown, false));
+	}
+
+	//
+	// Expert settings
+	//
+	Add(CollapsedItem(tr("Expert settings"), m_cExpertMenu));
+	if (m_cExpertMenu) {
+		Add(SeparatorName(tr(" Audio settings")));
+		Add(new cMenuEditIntItem(tr(" Additional buffer size (ms)"), &m_cAdditionalBufferLengthMs, 0, 1000));
+
+		Add(SeparatorName(tr(" Video settings")));
+		Add(new cMenuEditBoolItem(tr(" Disable deinterlacer"), &m_cDisableDeint, trVDR("no"), trVDR("yes")));
+		Add(new cMenuEditBoolItem(tr(" H.264 HW dec needs I-Frame"), &m_cDecoderNeedsIFrame, trVDR("no"), trVDR("yes")));
+		Add(new cMenuEditBoolItem(tr(" H.264 HW dec needs width and height"), &m_cParseH264Dimensions, trVDR("no"), trVDR("yes")));
+		Add(new cMenuEditBoolItem(tr(" Enable SW decoder fallback"), &m_cDecoderFallbackToSw, trVDR("no"), trVDR("yes")));
+		if (m_cDecoderFallbackToSw)
+			Add(new cMenuEditIntItem(tr("  fallback after num packets"), &m_cDecoderFallbackToSwNumPkts, 22));
+
+#ifdef USE_GLES
+		Add(SeparatorName(tr(" OSD settings")));
+		if (!m_pConfig->ConfigDisableOglOsd) {
+			Add(new cMenuEditIntItem(tr(" GPU mem used for image caching (MB)"), &m_cMaxSizeGPUImageCache, 0, 4000));
+		}
+#endif
+	}
+
 	SetCurrent(Get(current));	// restore selected menu entry
 	Display();               	// display build menu
 }
@@ -216,36 +226,38 @@ void cMenuSetupSoft::Create(void)
  */
 eOSState cMenuSetupSoft::ProcessKey(eKeys key)
 {
-	int old_cGeneral = m_cGeneral;
-	int old_cStatistics = m_cStatistics;
-	int old_cLogging = m_cLogging;
-	int old_cLogDefault = m_cLogDefault;
-	int old_cVideoMenu = m_cVideoMenu;
-	int old_cDecoderFallbackToSw = m_cDecoderFallbackToSw;
-	int old_cAudio = m_cAudio;
+	int old_cGeneralMenu = m_cGeneralMenu;
+	int old_cAudioMenu = m_cAudioMenu;
+	int old_cAudioPassthroughDefault = m_cAudioPassthroughDefault;
 	int old_cAudioNormalize = m_cAudioNormalize;
 	int old_cAudioCompression = m_cAudioCompression;
-	int old_cAudioPassthroughDefault = m_cAudioPassthroughDefault;
-	int old_cAudioFilter = m_cAudioFilter;
+	int old_cAudioFilterMenu = m_cAudioFilterMenu;
 	int old_cAudioEq = m_cAudioEq;
+	int old_cPipMenu = m_cPipMenu;
+	int old_cLoggingMenu = m_cLoggingMenu;
+	int old_cLogDefault = m_cLogDefault;
+	int old_cStatisticsMenu = m_cStatisticsMenu;
+	int old_cExpertMenu = m_cExpertMenu;
+	int old_cDecoderFallbackToSw = m_cDecoderFallbackToSw;
 
 	eOSState state = cMenuSetupPage::ProcessKey(key);
 
 	if (key != kNone) {
 		// update menu only, if something on the structure has changed
 		// this is needed because VDR menus are evil slow
-		if (old_cGeneral                 != m_cGeneral ||
-		    old_cStatistics              != m_cStatistics ||
-		    old_cLogging                 != m_cLogging ||
-		    old_cLogDefault              != m_cLogDefault ||
-		    old_cVideoMenu               != m_cVideoMenu ||
-		    old_cDecoderFallbackToSw     != m_cDecoderFallbackToSw ||
-		    old_cAudio                   != m_cAudio ||
-		    old_cAudioFilter             != m_cAudioFilter ||
-		    old_cAudioEq                 != m_cAudioEq ||
+		if (old_cGeneralMenu             != m_cGeneralMenu ||
+		    old_cAudioMenu               != m_cAudioMenu ||
+		    old_cAudioPassthroughDefault != m_cAudioPassthroughDefault ||
 		    old_cAudioNormalize          != m_cAudioNormalize ||
 		    old_cAudioCompression        != m_cAudioCompression ||
-		    old_cAudioPassthroughDefault != m_cAudioPassthroughDefault) {
+		    old_cAudioFilterMenu         != m_cAudioFilterMenu ||
+		    old_cAudioEq                 != m_cAudioEq ||
+		    old_cPipMenu                 != m_cPipMenu ||
+		    old_cLoggingMenu             != m_cLoggingMenu ||
+		    old_cLogDefault              != m_cLogDefault ||
+		    old_cStatisticsMenu          != m_cStatisticsMenu ||
+		    old_cExpertMenu              != m_cExpertMenu ||
+		    old_cDecoderFallbackToSw     != m_cDecoderFallbackToSw) {
 
 			Create();	// update menu
 		}
@@ -267,48 +279,40 @@ cMenuSetupSoft::cMenuSetupSoft(cSoftHdDevice *device)
 	//
 	// General
 	//
-	m_cGeneral = 0;
+	m_cGeneralMenu = 0;
 	m_cHideMainMenuEntry = m_pConfig->ConfigHideMainMenuEntry;
-#ifdef USE_GLES
-	m_cMaxSizeGPUImageCache = m_pConfig->ConfigMaxSizeGPUImageCache;
-#endif
-	m_cAdditionalBufferLengthMs= m_pConfig->ConfigAdditionalBufferLengthMs;
 
 	//
-	// Statistics
+	// Audio
 	//
-	m_cStatistics = 0;
+	m_cAudioMenu = 0;
+	m_cAudioSoftvol            = m_pConfig->ConfigAudioSoftvol;
+	m_cAudioDownmix            = m_pConfig->ConfigAudioDownmix;
+	m_cAudioPassthroughDefault = m_pConfig->ConfigAudioPassthroughState;
+	m_cAudioPassthroughAC3     = m_pConfig->ConfigAudioPassthroughMask & CODEC_AC3;
+	m_cAudioPassthroughEAC3    = m_pConfig->ConfigAudioPassthroughMask & CODEC_EAC3;
+	m_cAudioPassthroughDTS     = m_pConfig->ConfigAudioPassthroughMask & CODEC_DTS;
+	m_cAudioAutoAES            = m_pConfig->ConfigAudioAutoAES;
+	m_cAudioDelay              = m_pConfig->ConfigVideoAudioDelayMs;
+	m_cAudioNormalize          = m_pConfig->ConfigAudioNormalize;
+	m_cAudioMaxNormalize       = m_pConfig->ConfigAudioMaxNormalize;
+	m_cAudioCompression        = m_pConfig->ConfigAudioCompression;
+	m_cAudioMaxCompression     = m_pConfig->ConfigAudioMaxCompression;
+	m_cAudioStereoDescent      = m_pConfig->ConfigAudioStereoDescent;
 
 	//
-	// Logging
+	// Audio equalizer
 	//
-	m_cLogging = 0;
-	m_cLogDefault   = m_pConfig->ConfigLogState;
-	m_cLogDebug_    = m_pConfig->ConfigLogLevels & L_DEBUG;
-	m_cLogAVSync    = m_pConfig->ConfigLogLevels & L_AV_SYNC;
-	m_cLogSound     = m_pConfig->ConfigLogLevels & L_SOUND;
-	m_cLogOSD       = m_pConfig->ConfigLogLevels & L_OSD;
-	m_cLogDRM       = m_pConfig->ConfigLogLevels & L_DRM;
-	m_cLogCodec     = m_pConfig->ConfigLogLevels & L_CODEC;
-	m_cLogFFmpeg    = m_pConfig->ConfigLogLevels & L_FFMPEG;
-	m_cLogStill     = m_pConfig->ConfigLogLevels & L_STILL;
-	m_cLogTrick     = m_pConfig->ConfigLogLevels & L_TRICK;
-	m_cLogMedia     = m_pConfig->ConfigLogLevels & L_MEDIA;
-	m_cLogGL        = m_pConfig->ConfigLogLevels & L_OPENGL;
-	m_cLogGLTime    = m_pConfig->ConfigLogLevels & L_OPENGL_TIME;
-	m_cLogGLTimeAll = m_pConfig->ConfigLogLevels & L_OPENGL_TIME_ALL;
-	m_cLogPacket    = m_pConfig->ConfigLogLevels & L_PACKET;
-	m_cLogGrab      = m_pConfig->ConfigLogLevels & L_GRAB;
+	m_cAudioFilterMenu = 0;
+	m_cAudioEq = m_pConfig->ConfigAudioEq;
+	for (int i = 0; i < 18; i++) {
+		m_cAudioEqBand[i] = m_pConfig->ConfigAudioEqBand[i];
+	}
 
 	//
-	// Video
+	// Picture-in-picture
 	//
-	m_cVideoMenu = 0;
-	m_cDisableDeint = m_pConfig->ConfigDisableDeint;
-	m_cDecoderNeedsIFrame = m_pConfig->ConfigDecoderNeedsIFrame;
-	m_cParseH264Dimensions = m_pConfig->ConfigParseH264Dimensions;
-	m_cDecoderFallbackToSw = m_pConfig->ConfigDecoderFallbackToSw;
-	m_cDecoderFallbackToSwNumPkts = m_pConfig->ConfigDecoderFallbackToSwNumPkts;
+	m_cPipMenu = 0;
 	m_cPipScalePercent = m_pConfig->ConfigPipScalePercent;
 	m_cPipLeftPercent = m_pConfig->ConfigPipLeftPercent;
 	m_cPipTopPercent = m_pConfig->ConfigPipTopPercent;
@@ -318,31 +322,44 @@ cMenuSetupSoft::cMenuSetupSoft(cSoftHdDevice *device)
 	m_cPipAltTopPercent = m_pConfig->ConfigPipAltTopPercent;
 
 	//
-	// Audio
+	// Logging
 	//
-	m_cAudio = 0;
-	m_cAudioDelay              = m_pConfig->ConfigVideoAudioDelayMs;
-	m_cAudioSoftvol            = m_pConfig->ConfigAudioSoftvol;
-	m_cAudioNormalize          = m_pConfig->ConfigAudioNormalize;
-	m_cAudioMaxNormalize       = m_pConfig->ConfigAudioMaxNormalize;
-	m_cAudioCompression        = m_pConfig->ConfigAudioCompression;
-	m_cAudioMaxCompression     = m_pConfig->ConfigAudioMaxCompression;
-	m_cAudioStereoDescent      = m_pConfig->ConfigAudioStereoDescent;
-	m_cAudioDownmix            = m_pConfig->ConfigAudioDownmix;
-	m_cAudioPassthroughDefault = m_pConfig->ConfigAudioPassthroughState;
-	m_cAudioPassthroughAC3     = m_pConfig->ConfigAudioPassthroughMask & CODEC_AC3;
-	m_cAudioPassthroughEAC3    = m_pConfig->ConfigAudioPassthroughMask & CODEC_EAC3;
-	m_cAudioPassthroughDTS     = m_pConfig->ConfigAudioPassthroughMask & CODEC_DTS;
-	m_cAudioAutoAES            = m_pConfig->ConfigAudioAutoAES;
+	m_cLoggingMenu = 0;
+	m_cLogDefault   = m_pConfig->ConfigLogState;
+	m_cLogDebug_    = m_pConfig->ConfigLogLevels & L_DEBUG;
+	m_cLogDRM       = m_pConfig->ConfigLogLevels & L_DRM;
+	m_cLogCodec     = m_pConfig->ConfigLogLevels & L_CODEC;
+	m_cLogAVSync    = m_pConfig->ConfigLogLevels & L_AV_SYNC;
+	m_cLogSound     = m_pConfig->ConfigLogLevels & L_SOUND;
+	m_cLogFFmpeg    = m_pConfig->ConfigLogLevels & L_FFMPEG;
+	m_cLogPacket    = m_pConfig->ConfigLogLevels & L_PACKET;
+	m_cLogOSD       = m_pConfig->ConfigLogLevels & L_OSD;
+	m_cLogGrab      = m_pConfig->ConfigLogLevels & L_GRAB;
+	m_cLogStill     = m_pConfig->ConfigLogLevels & L_STILL;
+	m_cLogTrick     = m_pConfig->ConfigLogLevels & L_TRICK;
+	m_cLogMedia     = m_pConfig->ConfigLogLevels & L_MEDIA;
+	m_cLogGL        = m_pConfig->ConfigLogLevels & L_OPENGL;
+	m_cLogGLTime    = m_pConfig->ConfigLogLevels & L_OPENGL_TIME;
+	m_cLogGLTimeAll = m_pConfig->ConfigLogLevels & L_OPENGL_TIME_ALL;
 
 	//
-	// Audio filter
+	// Statistics
 	//
-	m_cAudioEq = m_pConfig->ConfigAudioEq;
-	m_cAudioFilter = 0;
-	for (int i = 0; i < 18; i++) {
-		m_cAudioEqBand[i] = m_pConfig->ConfigAudioEqBand[i];
-	}
+	m_cStatisticsMenu = 0;
+
+	//
+	// Expert settings
+	//
+	m_cExpertMenu = 0;
+	m_cAdditionalBufferLengthMs= m_pConfig->ConfigAdditionalBufferLengthMs;
+	m_cDisableDeint = m_pConfig->ConfigDisableDeint;
+	m_cDecoderNeedsIFrame = m_pConfig->ConfigDecoderNeedsIFrame;
+	m_cParseH264Dimensions = m_pConfig->ConfigParseH264Dimensions;
+	m_cDecoderFallbackToSw = m_pConfig->ConfigDecoderFallbackToSw;
+	m_cDecoderFallbackToSwNumPkts = m_pConfig->ConfigDecoderFallbackToSwNumPkts;
+#ifdef USE_GLES
+	m_cMaxSizeGPUImageCache = m_pConfig->ConfigMaxSizeGPUImageCache;
+#endif
 
 	Create();
 }
@@ -356,85 +373,12 @@ void cMenuSetupSoft::Store(void)
 	// General
 	//
 	SetupStore("HideMainMenuEntry", m_pConfig->ConfigHideMainMenuEntry = m_cHideMainMenuEntry);
-#ifdef USE_GLES
-	SetupStore("MaxSizeGPUImageCache", m_pConfig->ConfigMaxSizeGPUImageCache = m_cMaxSizeGPUImageCache);
-#endif
-	SetupStore("AdditionalBufferLengthMs", m_pConfig->ConfigAdditionalBufferLengthMs = m_cAdditionalBufferLengthMs);
-
-	//
-	// Logging
-	//
-	m_pConfig->ConfigLogLevels =
-		(m_cLogDebug_    ? L_DEBUG : 0) |
-		(m_cLogAVSync    ? L_AV_SYNC : 0) |
-		(m_cLogSound     ? L_SOUND : 0) |
-		(m_cLogOSD       ? L_OSD : 0) |
-		(m_cLogDRM       ? L_DRM : 0) |
-		(m_cLogCodec     ? L_CODEC : 0) |
-		(m_cLogFFmpeg    ? L_FFMPEG : 0) |
-		(m_cLogStill     ? L_STILL : 0) |
-		(m_cLogTrick     ? L_TRICK : 0) |
-		(m_cLogMedia     ? L_MEDIA : 0) |
-		(m_cLogGL        ? L_OPENGL : 0) |
-		(m_cLogGLTime    ? L_OPENGL_TIME : 0) |
-		(m_cLogGLTimeAll ? L_OPENGL_TIME_ALL : 0) |
-		(m_cLogPacket    ? L_PACKET : 0) |
-		(m_cLogGrab      ? L_GRAB : 0);
-	m_pConfig->ConfigLogState = m_cLogDefault;
-
-	if (m_pConfig->ConfigLogState) {
-		SetupStore("LogLevel", m_pConfig->ConfigLogLevels);
-		m_pConfig->PrintLogLevel(m_pConfig->ConfigLogLevels);
-		cSoftHdLogger::GetLogger()->SetLogLevel(m_pConfig->ConfigLogLevels);
-	} else {
-		SetupStore("LogLevel", -m_pConfig->ConfigLogLevels);
-		cSoftHdLogger::GetLogger()->SetLogLevel(0);
-	}
-
-	//
-	// Video
-	//
-	SetupStore("DisableDeint", m_pConfig->ConfigDisableDeint = m_cDisableDeint);
-	if (m_pConfig->ConfigDisableDeint) {
-		LOGDEBUG("Disable deinterlacer!");
-	}
-	m_pDevice->SetDisableDeint();
-
-	SetupStore("DecoderNeedsIFrame", m_pConfig->ConfigDecoderNeedsIFrame = m_cDecoderNeedsIFrame);
-	m_pDevice->SetDecoderNeedsIFrame();
-
-	SetupStore("ParseH264Dimensions", m_pConfig->ConfigParseH264Dimensions = m_cParseH264Dimensions);
-	m_pDevice->SetParseH264Dimensions();
-
-	SetupStore("DecoderFallbackToSw", m_pConfig->ConfigDecoderFallbackToSw = m_cDecoderFallbackToSw);
-	SetupStore("DecoderFallbackToSwNumPkts", m_pConfig->ConfigDecoderFallbackToSwNumPkts = m_cDecoderFallbackToSwNumPkts);
-	m_pDevice->SetDecoderFallbackToSw(m_pConfig->ConfigDecoderFallbackToSw);
-
-	// pip
-	SetupStore("PipScalePercent", m_pConfig->ConfigPipScalePercent = m_cPipScalePercent);
-	SetupStore("PipLeftPercent", m_pConfig->ConfigPipLeftPercent = m_cPipLeftPercent);
-	SetupStore("PipTopPercent", m_pConfig->ConfigPipTopPercent = m_cPipTopPercent);
-	SetupStore("PipUseAlt", m_pConfig->ConfigPipUseAlt = m_cPipUseAlt);
-	SetupStore("PipAltScalePercent", m_pConfig->ConfigPipAltScalePercent = m_cPipAltScalePercent);
-	SetupStore("PipAltLeftPercent", m_pConfig->ConfigPipAltLeftPercent = m_cPipAltLeftPercent);
-	SetupStore("PipAltTopPercent", m_pConfig->ConfigPipAltTopPercent = m_cPipAltTopPercent);
-	if (m_pDevice->UsePip())
-		m_pDevice->PipSetSize();
 
 	//
 	// Audio
 	//
-	SetupStore("AudioDelay", m_pConfig->ConfigVideoAudioDelayMs = m_cAudioDelay);
 	SetupStore("AudioSoftvol", m_pConfig->ConfigAudioSoftvol = m_cAudioSoftvol);
 	m_pAudioDevice->SetSoftvol(m_pConfig->ConfigAudioSoftvol);
-	SetupStore("AudioNormalize", m_pConfig->ConfigAudioNormalize = m_cAudioNormalize);
-	SetupStore("AudioMaxNormalize", m_pConfig->ConfigAudioMaxNormalize = m_cAudioMaxNormalize);
-	m_pAudioDevice->SetNormalize(m_pConfig->ConfigAudioNormalize, m_pConfig->ConfigAudioMaxNormalize);
-	SetupStore("AudioCompression", m_pConfig->ConfigAudioCompression = m_cAudioCompression);
-	SetupStore("AudioMaxCompression", m_pConfig->ConfigAudioMaxCompression = m_cAudioMaxCompression);
-	m_pAudioDevice->SetCompression(m_pConfig->ConfigAudioCompression, m_pConfig->ConfigAudioMaxCompression);
-	SetupStore("AudioStereoDescent", m_pConfig->ConfigAudioStereoDescent = m_cAudioStereoDescent);
-	m_pAudioDevice->SetStereoDescent(m_pConfig->ConfigAudioStereoDescent);
 	SetupStore("AudioDownmix", m_pConfig->ConfigAudioDownmix = m_cAudioDownmix);
 	m_pAudioDevice->SetDownmix(m_pConfig->ConfigAudioDownmix);
 	// FIXME: can handle more audio state changes here
@@ -455,9 +399,18 @@ void cMenuSetupSoft::Store(void)
 	}
 	SetupStore("AudioAutoAES", m_pConfig->ConfigAudioAutoAES = m_cAudioAutoAES);
 	m_pAudioDevice->SetAutoAES(m_pConfig->ConfigAudioAutoAES);
+	SetupStore("AudioDelay", m_pConfig->ConfigVideoAudioDelayMs = m_cAudioDelay);
+	SetupStore("AudioNormalize", m_pConfig->ConfigAudioNormalize = m_cAudioNormalize);
+	SetupStore("AudioMaxNormalize", m_pConfig->ConfigAudioMaxNormalize = m_cAudioMaxNormalize);
+	m_pAudioDevice->SetNormalize(m_pConfig->ConfigAudioNormalize, m_pConfig->ConfigAudioMaxNormalize);
+	SetupStore("AudioCompression", m_pConfig->ConfigAudioCompression = m_cAudioCompression);
+	SetupStore("AudioMaxCompression", m_pConfig->ConfigAudioMaxCompression = m_cAudioMaxCompression);
+	m_pAudioDevice->SetCompression(m_pConfig->ConfigAudioCompression, m_pConfig->ConfigAudioMaxCompression);
+	SetupStore("AudioStereoDescent", m_pConfig->ConfigAudioStereoDescent = m_cAudioStereoDescent);
+	m_pAudioDevice->SetStereoDescent(m_pConfig->ConfigAudioStereoDescent);
 
 	//
-	// Audio filter
+	// Audio equalizer
 	//
 	SetupStore("AudioEq", m_pConfig->ConfigAudioEq = m_cAudioEq);
 	SetupStore("AudioEqBand01b", m_pConfig->ConfigAudioEqBand[0]  = m_cAudioEqBand[0]);
@@ -479,4 +432,66 @@ void cMenuSetupSoft::Store(void)
 	SetupStore("AudioEqBand17b", m_pConfig->ConfigAudioEqBand[16] = m_cAudioEqBand[16]);
 	SetupStore("AudioEqBand18b", m_pConfig->ConfigAudioEqBand[17] = m_cAudioEqBand[17]);
 	m_pAudioDevice->SetEq(m_pConfig->ConfigAudioEqBand, m_pConfig->ConfigAudioEq);
+
+	//
+	// Picture-in-picture
+	//
+	SetupStore("PipScalePercent", m_pConfig->ConfigPipScalePercent = m_cPipScalePercent);
+	SetupStore("PipLeftPercent", m_pConfig->ConfigPipLeftPercent = m_cPipLeftPercent);
+	SetupStore("PipTopPercent", m_pConfig->ConfigPipTopPercent = m_cPipTopPercent);
+	SetupStore("PipUseAlt", m_pConfig->ConfigPipUseAlt = m_cPipUseAlt);
+	SetupStore("PipAltScalePercent", m_pConfig->ConfigPipAltScalePercent = m_cPipAltScalePercent);
+	SetupStore("PipAltLeftPercent", m_pConfig->ConfigPipAltLeftPercent = m_cPipAltLeftPercent);
+	SetupStore("PipAltTopPercent", m_pConfig->ConfigPipAltTopPercent = m_cPipAltTopPercent);
+	if (m_pDevice->UsePip())
+		m_pDevice->PipSetSize();
+
+	//
+	// Logging
+	//
+	m_pConfig->ConfigLogLevels =
+		(m_cLogDebug_    ? L_DEBUG : 0) |
+		(m_cLogDRM       ? L_DRM : 0) |
+		(m_cLogCodec     ? L_CODEC : 0) |
+		(m_cLogAVSync    ? L_AV_SYNC : 0) |
+		(m_cLogSound     ? L_SOUND : 0) |
+		(m_cLogFFmpeg    ? L_FFMPEG : 0) |
+		(m_cLogPacket    ? L_PACKET : 0) |
+		(m_cLogOSD       ? L_OSD : 0) |
+		(m_cLogGrab      ? L_GRAB : 0) |
+		(m_cLogStill     ? L_STILL : 0) |
+		(m_cLogTrick     ? L_TRICK : 0) |
+		(m_cLogMedia     ? L_MEDIA : 0) |
+		(m_cLogGL        ? L_OPENGL : 0) |
+		(m_cLogGLTime    ? L_OPENGL_TIME : 0) |
+		(m_cLogGLTimeAll ? L_OPENGL_TIME_ALL : 0);
+	m_pConfig->ConfigLogState = m_cLogDefault;
+	if (m_pConfig->ConfigLogState) {
+		SetupStore("LogLevel", m_pConfig->ConfigLogLevels);
+		m_pConfig->PrintLogLevel(m_pConfig->ConfigLogLevels);
+		cSoftHdLogger::GetLogger()->SetLogLevel(m_pConfig->ConfigLogLevels);
+	} else {
+		SetupStore("LogLevel", -m_pConfig->ConfigLogLevels);
+		cSoftHdLogger::GetLogger()->SetLogLevel(0);
+	}
+
+	//
+	// Expert settings
+	//
+	SetupStore("AdditionalBufferLengthMs", m_pConfig->ConfigAdditionalBufferLengthMs = m_cAdditionalBufferLengthMs);
+	SetupStore("DisableDeint", m_pConfig->ConfigDisableDeint = m_cDisableDeint);
+	if (m_pConfig->ConfigDisableDeint) {
+		LOGDEBUG("Disable deinterlacer!");
+	}
+	m_pDevice->SetDisableDeint();
+	SetupStore("DecoderNeedsIFrame", m_pConfig->ConfigDecoderNeedsIFrame = m_cDecoderNeedsIFrame);
+	m_pDevice->SetDecoderNeedsIFrame();
+	SetupStore("ParseH264Dimensions", m_pConfig->ConfigParseH264Dimensions = m_cParseH264Dimensions);
+	m_pDevice->SetParseH264Dimensions();
+	SetupStore("DecoderFallbackToSw", m_pConfig->ConfigDecoderFallbackToSw = m_cDecoderFallbackToSw);
+	SetupStore("DecoderFallbackToSwNumPkts", m_pConfig->ConfigDecoderFallbackToSwNumPkts = m_cDecoderFallbackToSwNumPkts);
+	m_pDevice->SetDecoderFallbackToSw(m_pConfig->ConfigDecoderFallbackToSw);
+#ifdef USE_GLES
+	SetupStore("MaxSizeGPUImageCache", m_pConfig->ConfigMaxSizeGPUImageCache = m_cMaxSizeGPUImageCache);
+#endif
 }

--- a/softhdsetupmenu.cpp
+++ b/softhdsetupmenu.cpp
@@ -150,8 +150,11 @@ void cMenuSetupSoft::Create(void)
 	Add(CollapsedItem(tr("Video"), m_cVideoMenu));
 	if (m_cVideoMenu) {
 		Add(new cMenuEditBoolItem(tr("Disable deinterlacer"), &m_cDisableDeint, trVDR("no"), trVDR("yes")));
-		Add(new cMenuEditBoolItem(tr("H.264 HW decoder needs I-Frame"), &m_cDecoderNeedsIFrame, trVDR("no"), trVDR("yes")));
-		Add(new cMenuEditBoolItem(tr("H.264 HW decoder needs parsed width and height"), &m_cParseH264Dimensions, trVDR("no"), trVDR("yes")));
+		Add(new cMenuEditBoolItem(tr("H.264 HW dec needs I-Frame"), &m_cDecoderNeedsIFrame, trVDR("no"), trVDR("yes")));
+		Add(new cMenuEditBoolItem(tr("H.264 HW dec needs width and height"), &m_cParseH264Dimensions, trVDR("no"), trVDR("yes")));
+		Add(new cMenuEditBoolItem(tr("Enable SW decoder fallback"), &m_cDecoderFallbackToSw, trVDR("no"), trVDR("yes")));
+		if (m_cDecoderFallbackToSw)
+			Add(new cMenuEditIntItem(tr("  fallback after num packets"), &m_cDecoderFallbackToSwNumPkts, 22));
 		if (m_pDevice->UsePip()) {
 			Add(SeparatorName(tr("Picture-in-picture")));
 			Add(new cMenuEditIntItem(tr(" video scaling factor (%)"), &m_cPipScalePercent, 10, 100));
@@ -237,6 +240,7 @@ eOSState cMenuSetupSoft::ProcessKey(eKeys key)
 	int old_cLogging = m_cLogging;
 	int old_cLogDefault = m_cLogDefault;
 	int old_cVideoMenu = m_cVideoMenu;
+	int old_cDecoderFallbackToSw = m_cDecoderFallbackToSw;
 	int old_cAudio = m_cAudio;
 	int old_cAudioNormalize = m_cAudioNormalize;
 	int old_cAudioCompression = m_cAudioCompression;
@@ -259,6 +263,7 @@ eOSState cMenuSetupSoft::ProcessKey(eKeys key)
 		    old_cLogging                 != m_cLogging ||
 		    old_cLogDefault              != m_cLogDefault ||
 		    old_cVideoMenu               != m_cVideoMenu ||
+		    old_cDecoderFallbackToSw     != m_cDecoderFallbackToSw ||
 		    old_cAudio                   != m_cAudio ||
 		    old_cAudioFilter             != m_cAudioFilter ||
 		    old_cAudioEq                 != m_cAudioEq ||
@@ -336,6 +341,8 @@ cMenuSetupSoft::cMenuSetupSoft(cSoftHdDevice *device)
 	m_cDisableDeint = m_pConfig->ConfigDisableDeint;
 	m_cDecoderNeedsIFrame = m_pConfig->ConfigDecoderNeedsIFrame;
 	m_cParseH264Dimensions = m_pConfig->ConfigParseH264Dimensions;
+	m_cDecoderFallbackToSw = m_pConfig->ConfigDecoderFallbackToSw;
+	m_cDecoderFallbackToSwNumPkts = m_pConfig->ConfigDecoderFallbackToSwNumPkts;
 	m_cPipScalePercent = m_pConfig->ConfigPipScalePercent;
 	m_cPipLeftPercent = m_pConfig->ConfigPipLeftPercent;
 	m_cPipTopPercent = m_pConfig->ConfigPipTopPercent;
@@ -442,6 +449,10 @@ void cMenuSetupSoft::Store(void)
 
 	SetupStore("ParseH264Dimensions", m_pConfig->ConfigParseH264Dimensions = m_cParseH264Dimensions);
 	m_pDevice->SetParseH264Dimensions();
+
+	SetupStore("DecoderFallbackToSw", m_pConfig->ConfigDecoderFallbackToSw = m_cDecoderFallbackToSw);
+	SetupStore("DecoderFallbackToSwNumPkts", m_pConfig->ConfigDecoderFallbackToSwNumPkts = m_cDecoderFallbackToSwNumPkts);
+	m_pDevice->SetDecoderFallbackToSw(m_pConfig->ConfigDecoderFallbackToSw);
 
 	// pip
 	SetupStore("PipScalePercent", m_pConfig->ConfigPipScalePercent = m_cPipScalePercent);

--- a/softhdsetupmenu.cpp
+++ b/softhdsetupmenu.cpp
@@ -204,9 +204,10 @@ void cMenuSetupSoft::Create(void)
 		Add(new cMenuEditBoolItem(tr(" H.264 HW dec needs I-Frame"), &m_cDecoderNeedsIFrame, trVDR("no"), trVDR("yes")));
 		Add(new cMenuEditBoolItem(tr(" H.264 HW dec needs width and height"), &m_cParseH264Dimensions, trVDR("no"), trVDR("yes")));
 		Add(new cMenuEditBoolItem(tr(" Enable SW decoder fallback"), &m_cDecoderFallbackToSw, trVDR("no"), trVDR("yes")));
-		if (m_cDecoderFallbackToSw)
+		if (m_cDecoderFallbackToSw) {
+			Add(new cOsdItem(cString::sprintf(tr("  (minimum: %d)"), m_pConfig->GetDecoderNeedsMaxPackets() + 1), osUnknown, false));
 			Add(new cMenuEditIntItem(tr("  fallback after num packets"), &m_cDecoderFallbackToSwNumPkts, 22));
-
+		}
 #ifdef USE_GLES
 		Add(SeparatorName(tr(" OSD settings")));
 		if (!m_pConfig->ConfigDisableOglOsd) {

--- a/softhdsetupmenu.cpp
+++ b/softhdsetupmenu.cpp
@@ -105,20 +105,6 @@ void cMenuSetupSoft::Create(void)
 		Add(new cOsdItem(cString::sprintf(tr(" Video decoder: %s (%s)"), m_pConfig->CurrentDecoderName, m_pConfig->CurrentDecoderType), osUnknown, false));
 	}
 
-#ifdef USE_GLES
-#ifdef WRITE_PNG
-	//
-	//	debug
-	//
-	if (!m_pConfig->ConfigDisableOglOsd) {
-		Add(CollapsedItem(tr("Debug"), m_cDebugMenu));
-		if (m_cDebugMenu) {
-			Add(new cMenuEditBoolItem(tr(" Write OSD to file"), &m_cWritePngs, trVDR("no"), trVDR("yes")));
-		}
-	}
-#endif
-#endif
-
 	//
 	// Logging
 	//
@@ -231,11 +217,6 @@ void cMenuSetupSoft::Create(void)
 eOSState cMenuSetupSoft::ProcessKey(eKeys key)
 {
 	int old_cGeneral = m_cGeneral;
-#ifdef USE_GLES
-#ifdef WRITE_PNG
-	int old_cDebugMenu = m_cDebugMenu;
-#endif
-#endif
 	int old_cStatistics = m_cStatistics;
 	int old_cLogging = m_cLogging;
 	int old_cLogDefault = m_cLogDefault;
@@ -254,11 +235,6 @@ eOSState cMenuSetupSoft::ProcessKey(eKeys key)
 		// update menu only, if something on the structure has changed
 		// this is needed because VDR menus are evil slow
 		if (old_cGeneral                 != m_cGeneral ||
-#ifdef USE_GLES
-#ifdef WRITE_PNG
-		    old_cDebugMenu               != m_cDebugMenu ||
-#endif
-#endif
 		    old_cStatistics              != m_cStatistics ||
 		    old_cLogging                 != m_cLogging ||
 		    old_cLogDefault              != m_cLogDefault ||
@@ -297,16 +273,6 @@ cMenuSetupSoft::cMenuSetupSoft(cSoftHdDevice *device)
 	m_cMaxSizeGPUImageCache = m_pConfig->ConfigMaxSizeGPUImageCache;
 #endif
 	m_cAdditionalBufferLengthMs= m_pConfig->ConfigAdditionalBufferLengthMs;
-
-	//
-	//	Debug
-	//
-#ifdef USE_GLES
-#ifdef WRITE_PNG
-	m_cDebugMenu = 0;
-	m_cWritePngs = m_pConfig->ConfigWritePngs;
-#endif
-#endif
 
 	//
 	// Statistics
@@ -394,16 +360,6 @@ void cMenuSetupSoft::Store(void)
 	SetupStore("MaxSizeGPUImageCache", m_pConfig->ConfigMaxSizeGPUImageCache = m_cMaxSizeGPUImageCache);
 #endif
 	SetupStore("AdditionalBufferLengthMs", m_pConfig->ConfigAdditionalBufferLengthMs = m_cAdditionalBufferLengthMs);
-
-	//
-	// Debug
-	//
-#ifdef USE_GLES
-#ifdef WRITE_PNG
-	m_pConfig->ConfigWritePngs = m_cWritePngs;
-	SetupStore("WritePngs", m_pConfig->ConfigWritePngs);
-#endif
-#endif
 
 	//
 	// Logging

--- a/softhdsetupmenu.h
+++ b/softhdsetupmenu.h
@@ -86,7 +86,9 @@ protected:
 	int m_cVideoMenu;
 	int m_cDisableDeint;
 	int m_cDecoderNeedsIFrame;
-	int m_cParseH264Dimensions;;
+	int m_cParseH264Dimensions;
+	int m_cDecoderFallbackToSw;
+	int m_cDecoderFallbackToSwNumPkts;
 
 	// Audio
 	int m_cAudio;

--- a/softhdsetupmenu.h
+++ b/softhdsetupmenu.h
@@ -45,63 +45,32 @@ protected:
 	// local copies of global setup variables:
 
 	// General
-	int m_cGeneral;
+	int m_cGeneralMenu;
 	int m_cHideMainMenuEntry;
-#ifdef USE_GLES
-	int m_cMaxSizeGPUImageCache;
-#endif
-	int m_cAdditionalBufferLengthMs;
-
-	// Statistics
-	int m_cStatistics;
-
-	// Logging
-	int m_cLogging;
-	int m_cLogDefault;
-	int m_cLogDebug_;
-	int m_cLogAVSync;
-	int m_cLogSound;
-	int m_cLogOSD;
-	int m_cLogDRM;
-	int m_cLogCodec;
-	int m_cLogFFmpeg;
-	int m_cLogStill;
-	int m_cLogTrick;
-	int m_cLogMedia;
-	int m_cLogGL;
-	int m_cLogGLTime;
-	int m_cLogGLTimeAll;
-	int m_cLogPacket;
-	int m_cLogGrab;
-
-	// Video
-	int m_cVideoMenu;
-	int m_cDisableDeint;
-	int m_cDecoderNeedsIFrame;
-	int m_cParseH264Dimensions;
-	int m_cDecoderFallbackToSw;
-	int m_cDecoderFallbackToSwNumPkts;
 
 	// Audio
-	int m_cAudio;
-	int m_cAudioDelay;
+	int m_cAudioMenu;
 	int m_cAudioSoftvol;
-	int m_cAudioNormalize;
-	int m_cAudioMaxNormalize;
-	int m_cAudioCompression;
-	int m_cAudioMaxCompression;
-	int m_cAudioStereoDescent;
 	int m_cAudioDownmix;
 	int m_cAudioPassthroughDefault;
 	int m_cAudioPassthroughAC3;
 	int m_cAudioPassthroughEAC3;
 	int m_cAudioPassthroughDTS;
 	int m_cAudioAutoAES;
-	int m_cAudioFilter;
+	int m_cAudioDelay;
+	int m_cAudioNormalize;
+	int m_cAudioMaxNormalize;
+	int m_cAudioCompression;
+	int m_cAudioMaxCompression;
+	int m_cAudioStereoDescent;
+
+	// Audio equalizer
+	int m_cAudioFilterMenu;
 	int m_cAudioEq;
 	int m_cAudioEqBand[18];
 
-	// pip
+	// Picture-in-Picture
+	int m_cPipMenu;
 	int m_cPipScalePercent;
 	int m_cPipLeftPercent;
 	int m_cPipTopPercent;
@@ -109,6 +78,40 @@ protected:
 	int m_cPipAltScalePercent;
 	int m_cPipAltLeftPercent;
 	int m_cPipAltTopPercent;
+
+	// Logging
+	int m_cLoggingMenu;
+	int m_cLogDefault;
+	int m_cLogDebug_;
+	int m_cLogDRM;
+	int m_cLogCodec;
+	int m_cLogAVSync;
+	int m_cLogSound;
+	int m_cLogFFmpeg;
+	int m_cLogPacket;
+	int m_cLogOSD;
+	int m_cLogGrab;
+	int m_cLogStill;
+	int m_cLogTrick;
+	int m_cLogMedia;
+	int m_cLogGL;
+	int m_cLogGLTime;
+	int m_cLogGLTimeAll;
+
+	// Statistics
+	int m_cStatisticsMenu;
+
+	// Expert settings
+	int m_cExpertMenu;
+	int m_cAdditionalBufferLengthMs;
+	int m_cDisableDeint;
+	int m_cDecoderNeedsIFrame;
+	int m_cParseH264Dimensions;
+	int m_cDecoderFallbackToSw;
+	int m_cDecoderFallbackToSwNumPkts;
+#ifdef USE_GLES
+	int m_cMaxSizeGPUImageCache;
+#endif
 
 private:
 	cSoftHdDevice *m_pDevice;

--- a/softhdsetupmenu.h
+++ b/softhdsetupmenu.h
@@ -55,14 +55,6 @@ protected:
 	// Statistics
 	int m_cStatistics;
 
-	// Debug
-#ifdef USE_GLES
-#ifdef WRITE_PNG
-	int m_cDebugMenu;
-	int m_cWritePngs;
-#endif
-#endif
-
 	// Logging
 	int m_cLogging;
 	int m_cLogDefault;

--- a/videorender.h
+++ b/videorender.h
@@ -133,7 +133,6 @@ public:
 	void SetTrickSpeed(double, bool, bool);
 	bool IsTrickSpeed(void) { return m_trickspeed; };
 	bool IsForwardTrickspeed(void) { return m_forwardTrickspeed; };
-	bool IsFastTrickspeed(void) { return m_trickspeedFactor > 1.0; };
 	void SetStillpicture(bool active) { m_stillpicture = active; };
 	bool IsStillpicture(void) { return m_stillpicture; };
 

--- a/videostream.cpp
+++ b/videostream.cpp
@@ -119,14 +119,12 @@ static int ReadHWPlatform(void)
 		}
 		if (strstr(read_ptr, "bcm2711")) {
 			LOGDEBUG2(L_DRM, "videostream: %s: bcm2711 (Raspberry Pi 4 Model B, Compute Module 4, Pi 400) found", __FUNCTION__);
-			hardwareQuirks |= QUIRK_CODEC_FLUSH_WORKAROUND
-			               |  QUIRK_CODEC_NO_MBAFF_SUPPORT;
+			hardwareQuirks |= QUIRK_CODEC_FLUSH_WORKAROUND;
 			break;
 		}
 		if (strstr(read_ptr, "bcm2712")) {
 			LOGDEBUG2(L_DRM, "videostream: %s: bcm2712 (Raspberry Pi 5, Compute Module 5, Pi 500) found", __FUNCTION__);
-			hardwareQuirks |= QUIRK_CODEC_FLUSH_WORKAROUND
-			               |  QUIRK_CODEC_NO_MBAFF_SUPPORT;
+			hardwareQuirks |= QUIRK_CODEC_FLUSH_WORKAROUND;
 			break;
 		}
 		if (strstr(read_ptr, "amlogic")) {
@@ -296,24 +294,20 @@ void cVideoStream::FlushDecoder(void)
 /**
  * Check, if we need to force the decoder to decode the frame (force a decoder drain)
  *
- * Get the number of packets we need to have in the buffer while in interlaced (not mbaff)
+ * Get the number of packets we need to have in the buffer while in interlaced
  * trickspeed mode, in order to get a decoded frameout of the decoder.
  *
- * In a normal interlaced h264 stream we need to force decoding after sending 2 packets
- * in backwards trickspeed to get a decoded frame, in an mpeg2 stream 1 packet is enough.
- *
- * In mbaff coded h264 streams we also force decoding in fast forward mode. Because VDR does
- * not send a continous stream, the decoder would wait forever otherwise to decode the packet.
+ * In a normal interlaced h264 stream we need to force decoding after sending 2 packets in
+ * backwards trickspeed to get a decoded frame, in an mpeg2 stream 1 packet is enough.
  *
  * This minPkts magic guarantees, that we don't drain the decoder too early, but exactly after
  * the right amount of packets was sent in trickspeed mode.
  */
 void cVideoStream::CheckForcingFrameDecode(void)
 {
-	int minPkts = (m_interlaced && !m_mbaffStream) ? m_trickpkts : 1;
+	int minPkts = m_interlaced ? m_trickpkts : 1;
 
-	if ((!m_pRender->IsForwardTrickspeed() ||
-	     (m_pRender->IsForwardTrickspeed() && m_pRender->IsFastTrickspeed() && m_mbaffStream))) {
+	if (!m_pRender->IsForwardTrickspeed()) {
 		m_sentTrickPkts++;
 		if (m_sentTrickPkts >= minPkts) {
 			m_pDecoder->SendPacket(NULL);
@@ -332,8 +326,7 @@ void cVideoStream::OpenDecoder(void)
 
 	bool needsParsing = m_startDecodingWithIFrame ||
 	                    m_parseH264Dimensions ||
-	                   (m_hardwareQuirks & QUIRK_CODEC_NEEDS_EXT_INIT) ||
-	                   (m_hardwareQuirks & QUIRK_CODEC_NO_MBAFF_SUPPORT);
+	                   (m_hardwareQuirks & QUIRK_CODEC_NEEDS_EXT_INIT);
 
 	if (needsParsing && m_codecId == AV_CODEC_ID_H264) {
 		cH264Parser h264Packet(m_packets.Peek());
@@ -352,16 +345,9 @@ void cVideoStream::OpenDecoder(void)
 			height = h264Packet.GetHeight();
 			LOGDEBUG2(L_CODEC, "videostream %s: %s: Parsed width %d height %d", m_identifier, __FUNCTION__, width, height);
 		}
-
-		// fallback to SW H.264 decoder, if the decoder doesn't support mbaff
-		if (m_hardwareQuirks & QUIRK_CODEC_NO_MBAFF_SUPPORT) {
-			m_mbaffStream = h264Packet.IsMbaff();
-			if (m_mbaffStream)
-				LOGDEBUG2(L_CODEC, "videostream %s: %s: Fallback to H.264 software decoder for mbaff stream", m_identifier, __FUNCTION__);
-		}
 	}
 
-	if (m_pDecoder->Open(m_codecId, m_pPar, m_timebase, m_mbaffStream, width, height))
+	if (m_pDecoder->Open(m_codecId, m_pPar, m_timebase, false, width, height))
 		LOGFATAL("videostream %s: %s: Could not open the decoder!", m_identifier, __FUNCTION__);
 
 	m_pConfig->CurrentDecoderType = m_pDecoder->IsHardwareDecoder() ? "hardware" : "software";

--- a/videostream.cpp
+++ b/videostream.cpp
@@ -166,8 +166,11 @@ cVideoStream::cVideoStream(cVideoRender *render, cQueue<cDrmBuffer> *drmBufferQu
 	m_filterThreadName = "shd " + std::string(m_identifier) + " filter";
 	m_pFilterThread = new cFilterThread(render, m_pDrmBufferQueue, m_filterThreadName.c_str(), frameOutput);
 	m_hardwareQuirks = ReadHWPlatform();
+	m_decoderFallbackToSwNumPkts = config->ConfigDecoderFallbackToSw ? config->ConfigDecoderFallbackToSwNumPkts : 0;
 
 	LOGDEBUG("videostream %s: %s", __FUNCTION__, m_identifier);
+	if (m_decoderFallbackToSwNumPkts)
+		LOGDEBUG2(L_CODEC, "videostream %s: %s: fallback to sw decoder after %d packets sent", __FUNCTION__, m_identifier, m_decoderFallbackToSwNumPkts);
 }
 
 /**
@@ -389,6 +392,15 @@ void cVideoStream::DecodeInput(void)
 	} else if (ret == AVERROR_EOF) {
 		FlushDecoder();
 		m_sentTrickPkts = 0;
+	}
+
+	// fallback to software decoder if configured and hw decoder fails
+	if (m_pDecoder->IsHardwareDecoder() && m_decoderFallbackToSwNumPkts &&
+	   !m_pDecoder->GetFramesReceived() && m_pDecoder->GetPacketsSent() > m_decoderFallbackToSwNumPkts) {
+
+		LOGWARNING("videostream %s: %s: Could not decode frame after %d packets sent, fallback to software decoder!", m_identifier, __FUNCTION__, m_decoderFallbackToSwNumPkts);
+		if (m_pDecoder->ReopenCodec(m_codecId, m_pPar, m_timebase, m_decoderFallbackToSwNumPkts))
+			LOGFATAL("videostream %s: %s: Could not reopen the decoder (sw fallback)!", m_identifier, __FUNCTION__);
 	}
 }
 

--- a/videostream.cpp
+++ b/videostream.cpp
@@ -394,13 +394,17 @@ void cVideoStream::DecodeInput(void)
 		m_sentTrickPkts = 0;
 	}
 
-	// fallback to software decoder if configured and hw decoder fails
-	if (m_pDecoder->IsHardwareDecoder() && m_decoderFallbackToSwNumPkts &&
-	   !m_pDecoder->GetFramesReceived() && m_pDecoder->GetPacketsSent() > m_decoderFallbackToSwNumPkts) {
+	if (m_pDecoder->IsHardwareDecoder() && !m_pDecoder->GetFramesReceived()) {
+		// log maximum number of packets needed for the hw decoder to deliver a frame
+		if (m_pConfig->GetDecoderNeedsMaxPackets() < m_pDecoder->GetPacketsSent())
+			m_pConfig->SetDecoderNeedsMaxPackets(m_pDecoder->GetPacketsSent());
 
-		LOGWARNING("videostream %s: %s: Could not decode frame after %d packets sent, fallback to software decoder!", m_identifier, __FUNCTION__, m_decoderFallbackToSwNumPkts);
-		if (m_pDecoder->ReopenCodec(m_codecId, m_pPar, m_timebase, m_decoderFallbackToSwNumPkts))
-			LOGFATAL("videostream %s: %s: Could not reopen the decoder (sw fallback)!", m_identifier, __FUNCTION__);
+		// fallback to software decoder if configured and hw decoder fails
+		if (m_decoderFallbackToSwNumPkts && m_pDecoder->GetPacketsSent() > m_decoderFallbackToSwNumPkts) {
+			LOGWARNING("videostream %s: %s: Could not decode frame after %d packets sent, fallback to software decoder!", m_identifier, __FUNCTION__, m_decoderFallbackToSwNumPkts);
+			if (m_pDecoder->ReopenCodec(m_codecId, m_pPar, m_timebase, m_decoderFallbackToSwNumPkts))
+				LOGFATAL("videostream %s: %s: Could not reopen the decoder (sw fallback)!", m_identifier, __FUNCTION__);
+		}
 	}
 }
 

--- a/videostream.h
+++ b/videostream.h
@@ -95,6 +95,7 @@ public:
 	void DisableDeint(bool disable) { m_userDisabledDeinterlacer = disable; };
 	void SetStartDecodingWithIFrame(bool enable) { m_startDecodingWithIFrame = enable; };
 	void SetParseH264Dimensions(bool enable) { m_parseH264Dimensions = enable; };
+	void SetDecoderFallbackToSwNumPkts(int numPackets) { m_decoderFallbackToSwNumPkts = numPackets; };
 
 protected:
 	cVideoStream(cVideoRender *, cQueue<cDrmBuffer> *, cSoftHdConfig *, bool, std::function<void(AVFrame *)>);
@@ -116,6 +117,7 @@ private:
 	bool m_deinterlacerDeactivated;                 ///< set, if the deinterlacer should be disabled temporarily (trickspeed, stillpicture, pip)
 	bool m_startDecodingWithIFrame = false;         ///< wait for an I-Frame to start h264 decoding
 	bool m_parseH264Dimensions = false;             ///< parse width and height when starting an h264 stream
+	int m_decoderFallbackToSwNumPkts = 22;          ///< fallback to sw decoder if hw decoder fails after the given number of packets sent
 
 	cQueue<AVPacket> m_packets{VIDEO_PACKET_MAX};   ///< AVPackets queue
 

--- a/videostream.h
+++ b/videostream.h
@@ -43,7 +43,6 @@ extern "C" {
 #define QUIRK_CODEC_SKIP_NUM_FRAMES     2          ///< skip QUIRK_CODEC_SKIP_NUM_FRAMES, in case QUIRK_CODEC_SKIP_FIRST_FRAMES is set
 #define QUIRK_CODEC_DISABLE_MPEG_HW     1 << 4     ///< set, if disable mpeg hardware decoder
 #define QUIRK_CODEC_DISABLE_H264_HW     1 << 5     ///< set, if disable h264 hardware decoder
-#define QUIRK_CODEC_NO_MBAFF_SUPPORT    1 << 6     ///< set, if the h264 hardware decoder doesn't support mbaff
 
 class cSoftHdConfig;
 class cVideoDecoder;
@@ -127,7 +126,6 @@ private:
 	int m_sentTrickPkts = 0;               ///< how many avpkt have been sent to the decoder in trickspeed mode?
 	volatile bool m_newStream = false;     ///< flag for new stream
 	bool m_interlaced;                     ///< flag for interlaced stream
-	bool m_mbaffStream = false;            ///< true, if this stream uses macroblock adaptive frame/field coding
 
 	cDecodingThread *m_pDecodingThread;    ///< pointer to decoding thread
 	int64_t m_inputPts = AV_NOPTS_VALUE;   ///< PTS of the first packet in the input buffer


### PR DESCRIPTION
The rpi H.264 hw decoder can handle mbaff coded H.264 in general. There is a problem with one example stream though. The reason for this is still unknown.
Because it's expensive we don't force sw decoding for every other (working) stream.

Keep the mbaff flag in the h264 parser though.