### PR TITLE
detect stream discontinuity

### DIFF
--- a/audio.cpp
+++ b/audio.cpp
@@ -654,8 +654,17 @@ void cSoftHdAudio::Enqueue(uint16_t *buffer, int count, AVFrame *frame)
 
 	m_fillLevel.ReceivedFrames(snd_pcm_bytes_to_frames(m_pAlsaPCMHandle, bytesWritten));
 
-	if (frame->pts != AV_NOPTS_VALUE)
+	if (frame->pts != AV_NOPTS_VALUE) {
+		// discontinuity check, force a resync if the new pts differs more than AV_SYNC_BORDER to the last
+		if (m_inputPts != AV_NOPTS_VALUE && (std::abs(PtsToMs(m_inputPts) - PtsToMs(frame->pts))) > AV_SYNC_BORDER) {
+			LOGDEBUG2(L_AV_SYNC, "audio: %s: discontinuity detected in audio PTS %s -> %s%s", __FUNCTION__,
+				Timestamp2String(PtsToMs(m_inputPts), 1), Timestamp2String(PtsToMs(frame->pts), 1),
+				PtsToMs(m_inputPts) > PtsToMs(frame->pts) ? " (PTS wrapped)" : "");
+			m_eventQueue.push_back(ScheduleResyncAtPtsMsEvent{PtsToMs(frame->pts)});
+		}
+
 		m_inputPts = frame->pts;
+	}
 }
 
 /**

--- a/audio.h
+++ b/audio.h
@@ -38,7 +38,8 @@ extern "C" {
 #include "pidcontroller.h"
 #include "ringbuffer.h"
 
-#define NORMALIZE_MAX_INDEX 128		///< number of average values
+#define NORMALIZE_MAX_INDEX 128 ///< number of average values
+#define AV_SYNC_BORDER 5000     ///< absolute max a/v difference in ms which should trigger a resync
 
 class cAudioThread;
 class cSoftHdConfig;

--- a/event.h
+++ b/event.h
@@ -58,6 +58,10 @@ struct BufferingThresholdReachedEvent {};
 struct PipEvent {
 	PipState state;
 };
+struct ScheduleResyncAtPtsMsEvent {
+	int64_t pts;
+};
+struct ResyncEvent {};
 
 using Event = std::variant<
 	PlayEvent,
@@ -69,7 +73,9 @@ using Event = std::variant<
 	AttachEvent,
 	BufferUnderrunEvent,
 	BufferingThresholdReachedEvent,
-	PipEvent
+	PipEvent,
+	ScheduleResyncAtPtsMsEvent,
+	ResyncEvent
 >;
 
 class IEventReceiver

--- a/softhddevice.cpp
+++ b/softhddevice.cpp
@@ -207,6 +207,8 @@ void cSoftHdDevice::OnEventReceived(const Event& event)
 				[&invalid](const BufferUnderrunEvent&) { invalid(); },
 				[&invalid](const BufferingThresholdReachedEvent&) { invalid(); },
 				[&invalid](const PipEvent&) { invalid(); },
+				[&invalid](const ScheduleResyncAtPtsMsEvent&) { invalid(); },
+				[&invalid](const ResyncEvent&) { invalid(); },
 			}, event);
 			needsResume = false;
 			break;
@@ -235,6 +237,8 @@ void cSoftHdDevice::OnEventReceived(const Event& event)
 				[this](const PipEvent& p) {
 					m_pPipHandler->HandleEvent(p.state);
 				},
+				[&invalid](const ScheduleResyncAtPtsMsEvent&) { invalid(); },
+				[&invalid](const ResyncEvent&) { invalid(); },
 			}, event);
 			break;
 		case State::BUFFERING:
@@ -290,6 +294,11 @@ void cSoftHdDevice::OnEventReceived(const Event& event)
 				[this](const PipEvent& p) {
 					m_pPipHandler->HandleEvent(p.state);
 				},
+				[this](const ScheduleResyncAtPtsMsEvent& s) {
+					SetState(PLAY);
+					m_pRender->ScheduleResyncAtPtsMs(s.pts);
+				},
+				[&invalid](const ResyncEvent&) { invalid(); },
 			}, event);
 			break;
 		case State::PLAY:
@@ -348,6 +357,12 @@ void cSoftHdDevice::OnEventReceived(const Event& event)
 				[this](const PipEvent& p) {
 					m_pPipHandler->HandleEvent(p.state);
 				},
+				[this](const ScheduleResyncAtPtsMsEvent& s) {
+					m_pRender->ScheduleResyncAtPtsMs(s.pts);
+				},
+				[this](const ResyncEvent&) {
+					SetState(BUFFERING);
+				},
 			}, event);
 			break;
 		case State::TRICK_SPEED:
@@ -383,6 +398,8 @@ void cSoftHdDevice::OnEventReceived(const Event& event)
 				[this](const PipEvent& p) {
 					m_pPipHandler->HandleEvent(p.state);
 				},
+				[&invalid](const ScheduleResyncAtPtsMsEvent&) { invalid(); },
+				[&invalid](const ResyncEvent&) { invalid(); },
 			}, event);
 			break;
 	}
@@ -1188,10 +1205,10 @@ bool cSoftHdDevice::IsBufferingThresholdReached()
 
 	if (reached) {
 		LOGDEBUG2(L_AV_SYNC, "First received PTS: %s (audio), %s (video) buffer fill levels: %ldms (audio) %ldms (video)",
-		Timestamp2String(m_pAudio->GetOutputPtsMs(), 1),
-		Timestamp2String(m_pRender->GetOutputPtsMs(), 1),
-		syncedAudioBufferFillLevelMs,
-		syncedVideoBufferFillLevelMs);
+			Timestamp2String(m_pAudio->GetOutputPtsMs(), 1),
+			Timestamp2String(m_pRender->GetOutputPtsMs(), 1),
+			syncedAudioBufferFillLevelMs,
+			syncedVideoBufferFillLevelMs);
 	}
 
 	return reached;

--- a/softhddevice.h
+++ b/softhddevice.h
@@ -68,6 +68,8 @@ inline const char* EventToString(const Event& e) {
 		[](const BufferUnderrunEvent& e) -> const char* { return e.type == AUDIO ? "BufferUnderrunEvent: Audio" : "BufferUnderrunEvent: Video"; },
 		[](const BufferingThresholdReachedEvent&) -> const char* { return "BufferingThresholdReachedEvent"; },
 		[](const PipEvent&) -> const char* { return "PipEvent"; },
+		[](const ScheduleResyncAtPtsMsEvent&) -> const char* { return "ScheduleResyncAtPtsMsEvent"; },
+		[](const ResyncEvent&) -> const char* { return "ResyncEvent"; },
 	}, e);
 }
 

--- a/videorender.cpp
+++ b/videorender.cpp
@@ -25,6 +25,7 @@
 #include <cerrno>
 #include <cinttypes>
 #include <cstdint>
+#include <mutex>
 #include <vector>
 
 #ifdef USE_GLES
@@ -544,26 +545,38 @@ bool cVideoRender::DisplayFrame()
 			if (audioPtsMs != AV_NOPTS_VALUE) {
 				int audioBehindVideoByMs = videoPtsMs - audioPtsMs - m_pDevice->GetVideoAudioDelayMs();
 
-				if (m_resumeAudioScheduled && audioBehindVideoByMs >= 0) { // resume audio from pause
+				bool skipSync = m_scheduleResyncAtPtsMs != AV_NOPTS_VALUE;
+				if (m_scheduleResyncAtPtsMs != AV_NOPTS_VALUE &&
+				    m_scheduleResyncAtPtsMs <= videoPtsMs &&
+				    std::abs(PtsToMs(m_scheduleResyncAtPtsMs) - PtsToMs(videoPtsMs)) < AV_SYNC_BORDER) {
+
+					LOGDEBUG2(L_AV_SYNC, "videorender: resync schedule arrived at %s, current audio pts %s video pts %s",
+						Timestamp2String(m_scheduleResyncAtPtsMs, 1), Timestamp2String(audioPtsMs, 1), Timestamp2String(videoPtsMs, 1));
+					m_eventQueue.push_back(ResyncEvent{});
+					m_scheduleResyncAtPtsMs = AV_NOPTS_VALUE;
+				}
+
+				if (m_resumeAudioScheduled && audioBehindVideoByMs >= 0 && !skipSync) { // resume audio from pause
 					LOGDEBUG2(L_AV_SYNC, "videorender: resuming audio playback: video %s, audio %s", Timestamp2String(videoPtsMs, 1), Timestamp2String(audioPtsMs, 1));
 					m_pAudio->SetPaused(false);
 					m_resumeAudioScheduled = false;
-				} else if (!m_pAudio->IsPaused() && audioBehindVideoByMs > AV_SYNC_THRESHOLD_AUDIO_BEHIND_VIDEO_MS) { // duplicate frame
+				} else if (!m_pAudio->IsPaused() && !skipSync && audioBehindVideoByMs > AV_SYNC_THRESHOLD_AUDIO_BEHIND_VIDEO_MS) { // duplicate frame
 					LogDroppedDuped(audioPtsMs, videoPtsMs, audioBehindVideoByMs);
-
 					m_framePresentationCounter++; // display the current video frame one period longer
-				} else if (!m_pAudio->IsPaused() && !m_lastFrameWasDropped && audioBehindVideoByMs < -AV_SYNC_THRESHOLD_AUDIO_AHEAD_VIDEO_MS) { // drop frame
+				} else if (!m_pAudio->IsPaused() && !skipSync && audioBehindVideoByMs < -AV_SYNC_THRESHOLD_AUDIO_AHEAD_VIDEO_MS) { // drop frame
 					// Drop max every second frame. Otherwise, the buffer gets drained immediately, if multiple frames in a row are dropped.
-					LogDroppedDuped(audioPtsMs, videoPtsMs, audioBehindVideoByMs);
+				        if (!m_lastFrameWasDropped) {
+						LogDroppedDuped(audioPtsMs, videoPtsMs, audioBehindVideoByMs);
 
-					if (pipBuf)
-						pipBuf->PresentationFinished();
+						if (pipBuf)
+							pipBuf->PresentationFinished();
 
-					drmBuffer->PresentationFinished();
-					m_framePresentationCounter--; // skip this pageflip
-					m_lastFrameWasDropped = true;
+						drmBuffer->PresentationFinished();
+						m_framePresentationCounter--; // skip this pageflip
+						m_lastFrameWasDropped = true;
 
-					return true;
+						return true;
+					}
 				}
 
 				m_startCounter++;
@@ -622,11 +635,9 @@ void cVideoRender::DisplayBlackFrame(void)
 
 int64_t cVideoRender::PtsToMs(int64_t pts)
 {
-	m_timebaseMutex.Lock();
-	int64_t videoPtsMs = pts * 1000 * av_q2d(m_timebase);
-	m_timebaseMutex.Unlock();
+	std::lock_guard<std::mutex> lock(m_timebaseMutex);
 
-	return videoPtsMs;
+	return pts * 1000 * av_q2d(m_timebase);
 }
 
 /**
@@ -912,8 +923,13 @@ void cVideoRender::PushFrame(
 	}
 
 	// Store the PTS of the first frame to be presented. The first frame might not have a valid PTS, if gone through a HW deinterlacer.
-	if (m_pts == AV_NOPTS_VALUE && frame->pts != AV_NOPTS_VALUE)
-		m_pts = frame->pts;
+	//
+	// @note: This is the only place outside of the display thread, where the video pts is set
+	// (except setting it to AV_NOPTS_VALUE in cSofthdDevice::Clear() and SetState(STOP))
+	// We only store here, if the stream recently started and the clock wasn't set already in the display thread
+
+	if (GetVideoClock() == AV_NOPTS_VALUE && frame->pts != AV_NOPTS_VALUE)
+		SetVideoClock(frame->pts);
 
 	AVDRMFrameDescriptor *primedata = (AVDRMFrameDescriptor *)frame->data[0];
 	cDrmBuffer *buf = bufferReuseStrategy.load()->GetBuffer(drmBufferPool, primedata);
@@ -938,14 +954,12 @@ void cVideoRender::PushFrame(
  */
 int64_t cVideoRender::GetOutputPtsMs(void)
 {
-	if (m_pts == AV_NOPTS_VALUE)
+	if (GetVideoClock() == AV_NOPTS_VALUE)
 		return AV_NOPTS_VALUE;
 
-	m_timebaseMutex.Lock();
-	int64_t pts = m_pts * 1000 * av_q2d(m_timebase);
-	m_timebaseMutex.Unlock();
+	std::lock_guard<std::mutex> lock(m_timebaseMutex);
 
-	return pts;
+	return GetVideoClock() * 1000 * av_q2d(m_timebase);
 }
 
 /**
@@ -955,9 +969,9 @@ int64_t cVideoRender::GetOutputPtsMs(void)
  */
 void cVideoRender::SetVideoClock(int64_t pts)
 {
-	m_videoClockMutex.Lock();
+	std::lock_guard<std::mutex> lock(m_videoClockMutex);
+
 	m_pts = pts;
-	m_videoClockMutex.Unlock();
 }
 
 /**
@@ -967,11 +981,9 @@ void cVideoRender::SetVideoClock(int64_t pts)
  */
 int64_t cVideoRender::GetVideoClock(void)
 {
-	int64_t pts;
-	m_videoClockMutex.Lock();
-	pts = m_pts;
-	m_videoClockMutex.Unlock();
-	return pts;
+	std::lock_guard<std::mutex> lock(m_videoClockMutex);
+
+	return m_pts;
 }
 
 /**
@@ -989,7 +1001,7 @@ void cVideoRender::Reset()
 	m_framesDuped = 0;
 	m_framesDropped = 0;
 	m_numWrongProgressive = 0;
-	m_pts = AV_NOPTS_VALUE;
+	SetVideoClock(AV_NOPTS_VALUE);
 
 	delete m_decodingStrategy;
 	m_decodingStrategy = nullptr;

--- a/videorender.h
+++ b/videorender.h
@@ -24,6 +24,7 @@
 
 #include <atomic>
 #include <cstdint>
+#include <mutex>
 #include <vector>
 
 #include <xf86drmMode.h>
@@ -163,6 +164,7 @@ public:
 	bool IsOutputBufferFull(void);
 	void SetDisplayOneFrameThenPause(bool pause) { m_displayOneFrameThenPause = pause; };
 	void SchedulePlaybackStartAtPtsMs(int64_t ptsMs) { m_schedulePlaybackStartAtPtsMs = ptsMs; };
+	void ScheduleResyncAtPtsMs(int64_t ptsMs) { m_scheduleResyncAtPtsMs = ptsMs; };
 	cQueue<cDrmBuffer> *GetMainOutputBuffer(void) { return &m_drmBufferQueue; };
 	cQueue<cDrmBuffer> *GetPipOutputBuffer(void) { return &m_pipDrmBufferQueue; };
 
@@ -187,7 +189,7 @@ private:
 	cSoftHdAudio *m_pAudio;             ///< pointer to cSoftHdAudio
 	cSoftHdConfig *m_pConfig;           ///< pointer to cSoftHdConfig
 	cDisplayThread *m_pDisplayThread;   ///< pointer to display thread
-	cMutex m_videoClockMutex;           ///< mutex used around m_pts
+	std::mutex m_videoClockMutex;       ///< mutex used around m_pts
 	std::vector<Event> m_eventQueue;    ///< event queue for incoming events
 	double m_refreshRateHz;             ///< screen refresh rate in Hz
 
@@ -212,7 +214,7 @@ private:
 	int m_framesDropped = 0;            ///< number of frames dropped
 	bool m_lastFrameWasDropped = false; ///< true, if the last frame was dropped
 	AVRational m_timebase;              ///< timebase used for pts, set by first RenderFrame()
-	cMutex m_timebaseMutex;             ///< mutex used around m_timebase
+	std::mutex m_timebaseMutex;         ///< mutex used around m_timebase
 	int64_t m_pts = AV_NOPTS_VALUE;     ///< current video PTS
 
 	cRect m_videoRect;                  ///< rect of the currently displayed video
@@ -231,6 +233,7 @@ private:
 	std::atomic<bool> m_resumeAudioScheduled = false;                     ///< set, if audio resume is scheduled after a pause
 	std::atomic<bool> m_displayOneFrameThenPause = false;                 ///< set, if only one frame shall be displayed and then pause playback
 	std::atomic<int64_t> m_schedulePlaybackStartAtPtsMs = AV_NOPTS_VALUE; ///< if set, frames with PTS older than this will be dropped
+	std::atomic<int64_t> m_scheduleResyncAtPtsMs = AV_NOPTS_VALUE;        ///< if set, a resync (enter state BUFFERING) will be forced at the given pts
 
 	IEventReceiver *m_pEventReceiver;                                     ///< pointer to event receiver
 	cDrmBufferPool m_drmBufferPool;                                       ///< pool of drm buffers


### PR DESCRIPTION
A discontinuity happens when a cutted area should be skipped in a replay.
We now detect at the audio side, if the next pts is more than 5s away from the last one.
In this case the renderer skips sync until this timestamp arrives to be rendered and then
invokes a resync by entering BUFFERING.

Todo: If the pts wraps in a jump, this doesn't work atm. -> done