### PR TITLE
Parse h264 frames

### DIFF
--- a/README.md
+++ b/README.md
@@ -340,7 +340,8 @@ Setup: /etc/vdr/setup.conf
 		until the software fallback jumps in
 
 	softhddevice-drm-gles.ParseH264StreamStart = 0
-		parse and log the packets of an H.264 stream at stream start up to the second I-Frame
+		0 = disable parsing, 1-20 = parse up to the given number of I-Frames
+		parse and log the frames of a H.264 stream
 
 	softhddevice-drm-gles.DropInvalidH264PFrames = 0
 		drop p-frames of ah H.264 stream, that have an invalid reference

--- a/README.md
+++ b/README.md
@@ -339,6 +339,9 @@ Setup: /etc/vdr/setup.conf
 		maximum number of packets sent to the hardware decoder
 		until the software fallback jumps in
 
+	softhddevice-drm-gles.ParseH264StreamStart = 0
+		parse and log the packets of an H.264 stream at stream start up to the second I-Frame
+
 	softhddevice-drm-gles.PipScalePercent = 25
 		10 - 100 = scale factor for pip (%)
 

--- a/README.md
+++ b/README.md
@@ -342,6 +342,9 @@ Setup: /etc/vdr/setup.conf
 	softhddevice-drm-gles.ParseH264StreamStart = 0
 		parse and log the packets of an H.264 stream at stream start up to the second I-Frame
 
+	softhddevice-drm-gles.DropInvalidH264PFrames = 0
+		drop p-frames of ah H.264 stream, that have an invalid reference
+
 	softhddevice-drm-gles.PipScalePercent = 25
 		10 - 100 = scale factor for pip (%)
 

--- a/README.md
+++ b/README.md
@@ -340,11 +340,10 @@ Setup: /etc/vdr/setup.conf
 		until the software fallback jumps in
 
 	softhddevice-drm-gles.ParseH264StreamStart = 0
-		0 = disable parsing, 1-20 = parse up to the given number of I-Frames
-		parse and log the frames of a H.264 stream
+		0 = disable parsing, 1-20 = parse H.264 stream up to the given number of I-Frames
 
 	softhddevice-drm-gles.DropInvalidH264PFrames = 0
-		drop p-frames of ah H.264 stream, that have an invalid reference
+		1 = drop H.264 P-Frames with an invalid backwards reference
 
 	softhddevice-drm-gles.PipScalePercent = 25
 		10 - 100 = scale factor for pip (%)

--- a/README.md
+++ b/README.md
@@ -242,6 +242,9 @@ Setup: /etc/vdr/setup.conf
 	softhddevice-drm-gles.HideMainMenuEntry = 0
 		0 = show softhddevice main menu entry, 1 = hide entry
 
+	softhddevice-drm-gles.VideoEnableHdr = 0
+		0 = disable HDR, 1 = enable HDR
+
 	softhddevice-drm-gles.MaxSizeGPUImageCache = 128
 		how many GPU memory should be used for image caching
 

--- a/config.cpp
+++ b/config.cpp
@@ -58,6 +58,7 @@ bool cSoftHdConfig::SetupParse(const char *name, const char *value)
 	} else if (!strcasecmp(name, "DecoderFallbackToSw"))   { ConfigDecoderFallbackToSw = atoi(value);
 	} else if (!strcasecmp(name, "DecoderFallbackToSwNumPkts")) { ConfigDecoderFallbackToSwNumPkts = atoi(value);
 	} else if (!strcasecmp(name, "VideoEnableHDR"))        { ConfigVideoEnableHDR = atoi(value);
+	} else if (!strcasecmp(name, "ParseH264StreamStart"))  { ConfigParseH264StreamStart = atoi(value);
 	} else if (!strcasecmp(name, "AudioDelay"))            { ConfigVideoAudioDelayMs = atoi(value);
 	} else if (!strcasecmp(name, "AudioPassthrough"))      { ConfigAudioPassthroughMask = abs(atoi(value)); ConfigAudioPassthroughState = atoi(value) > 0;
 	} else if (!strcasecmp(name, "AudioDownmix"))          { ConfigAudioDownmix = atoi(value);

--- a/config.cpp
+++ b/config.cpp
@@ -59,6 +59,7 @@ bool cSoftHdConfig::SetupParse(const char *name, const char *value)
 	} else if (!strcasecmp(name, "DecoderFallbackToSwNumPkts")) { ConfigDecoderFallbackToSwNumPkts = atoi(value);
 	} else if (!strcasecmp(name, "VideoEnableHDR"))        { ConfigVideoEnableHDR = atoi(value);
 	} else if (!strcasecmp(name, "ParseH264StreamStart"))  { ConfigParseH264StreamStart = atoi(value);
+	} else if (!strcasecmp(name, "DropInvalidH264PFrames")){ ConfigDropInvalidH264PFrames = atoi(value);
 	} else if (!strcasecmp(name, "AudioDelay"))            { ConfigVideoAudioDelayMs = atoi(value);
 	} else if (!strcasecmp(name, "AudioPassthrough"))      { ConfigAudioPassthroughMask = abs(atoi(value)); ConfigAudioPassthroughState = atoi(value) > 0;
 	} else if (!strcasecmp(name, "AudioDownmix"))          { ConfigAudioDownmix = atoi(value);

--- a/config.h
+++ b/config.h
@@ -65,7 +65,7 @@ public:
 	bool ConfigDecoderFallbackToSw = false;     ///< fallback to software decoder if the hardware decoder fails
 	int ConfigDecoderFallbackToSwNumPkts = 22;  ///< maximum number of packets sent before fallback to sw decoder
 	int ConfigParseH264StreamStart = 0;         ///< log frames at stream start up to the given number of I-Frames
-	int ConfigDropInvalidH264PFrames = 0;      ///< drop P-Frames with invalid references on stream start up to the given number of I-Frames
+	int ConfigDropInvalidH264PFrames = 0;       ///< drop P-Frames with invalid references on stream start up to the given number of I-Frames
 
 	// pip - default position at right top, 25% scaled
 	int ConfigPipScalePercent = 25;             ///< scale factor of pip video

--- a/config.h
+++ b/config.h
@@ -64,7 +64,7 @@ public:
 	bool ConfigParseH264Dimensions = false;     ///< parse h264 stream for width and height for decoder init
 	bool ConfigDecoderFallbackToSw = false;     ///< fallback to software decoder if the hardware decoder fails
 	int ConfigDecoderFallbackToSwNumPkts = 22;  ///< maximum number of packets sent before fallback to sw decoder
-	bool ConfigParseH264StreamStart = false;    ///< log the nal units at stream start until a second i-Frame arrives
+	int ConfigParseH264StreamStart = 0;         ///< log the nal units at stream start up to the given number of i-Frames
 	bool ConfigDropInvalidH264PFrames = false;  ///< drop H.264 P-Frames with invalid references on stream start
 
 	// pip - default position at right top, 25% scaled

--- a/config.h
+++ b/config.h
@@ -64,8 +64,8 @@ public:
 	bool ConfigParseH264Dimensions = false;     ///< parse h264 stream for width and height for decoder init
 	bool ConfigDecoderFallbackToSw = false;     ///< fallback to software decoder if the hardware decoder fails
 	int ConfigDecoderFallbackToSwNumPkts = 22;  ///< maximum number of packets sent before fallback to sw decoder
-	int ConfigParseH264StreamStart = 0;         ///< log the nal units at stream start up to the given number of i-Frames
-	bool ConfigDropInvalidH264PFrames = false;  ///< drop H.264 P-Frames with invalid references on stream start
+	int ConfigParseH264StreamStart = 0;         ///< log frames at stream start up to the given number of I-Frames
+	int ConfigDropInvalidH264PFrames = 0;      ///< drop P-Frames with invalid references on stream start up to the given number of I-Frames
 
 	// pip - default position at right top, 25% scaled
 	int ConfigPipScalePercent = 25;             ///< scale factor of pip video

--- a/config.h
+++ b/config.h
@@ -65,6 +65,7 @@ public:
 	bool ConfigDecoderFallbackToSw = false;     ///< fallback to software decoder if the hardware decoder fails
 	int ConfigDecoderFallbackToSwNumPkts = 22;  ///< maximum number of packets sent before fallback to sw decoder
 	bool ConfigParseH264StreamStart = false;    ///< log the nal units at stream start until a second i-Frame arrives
+	bool ConfigDropInvalidH264PFrames = false;  ///< drop H.264 P-Frames with invalid references on stream start
 
 	// pip - default position at right top, 25% scaled
 	int ConfigPipScalePercent = 25;             ///< scale factor of pip video

--- a/config.h
+++ b/config.h
@@ -64,6 +64,7 @@ public:
 	bool ConfigParseH264Dimensions = false;     ///< parse h264 stream for width and height for decoder init
 	bool ConfigDecoderFallbackToSw = false;     ///< fallback to software decoder if the hardware decoder fails
 	int ConfigDecoderFallbackToSwNumPkts = 22;  ///< maximum number of packets sent before fallback to sw decoder
+	bool ConfigParseH264StreamStart = false;    ///< log the nal units at stream start until a second i-Frame arrives
 
 	// pip - default position at right top, 25% scaled
 	int ConfigPipScalePercent = 25;             ///< scale factor of pip video

--- a/h264parser.cpp
+++ b/h264parser.cpp
@@ -39,31 +39,43 @@ extern "C" {
  ****************************************************************************/
 
 /**
- * Returns true, if we have a 0x000001 start code
+ * Returns true, if we have a 0x000001 or 0x00000001 start code
  * in data at the offset position
  */
-bool isValidStartCode(const uint8_t *data, int offset)
+bool isValidStartCode(const uint8_t *data, int offset, int size, int &startCodeLength)
 {
-	return ReadBytes(&data[offset], 3) == 0x000001;
+	if (offset + 4 <= size && ReadBytes(&data[offset], 4) == 0x00000001) {
+		startCodeLength = 4;
+		return true;
+	}
+
+	if (offset + 3 <= size && ReadBytes(&data[offset], 3) == 0x000001) {
+		startCodeLength = 3;
+		return true;
+	}
+
+	return false;
 }
 
 /**
  * Return the nal unit type
  */
-static int NalUnitType(const uint8_t *data, int i)
+static int NalUnitType(const uint8_t *data, int offset, int startCodeLength)
 {
-	return data[i + 3] & 0x1F;
+	return data[offset + startCodeLength] & 0x1F;
 }
 
 int cH264Parser::GetSPSOffset(void)
 {
 	int offset = -1;
 
-	for (int i = 0; i < m_pAvpkt->size - 4; i++) {
-		if (!isValidStartCode(m_pAvpkt->data, i))
+	for (int i = 0; i < m_pAvpkt->size; i++) {
+		int startCodeLength = 0;
+
+		if (!isValidStartCode(m_pAvpkt->data, i, m_pAvpkt->size, startCodeLength))
 			continue;
 
-		if (NalUnitType(m_pAvpkt->data, i) == 7) {
+		if (NalUnitType(m_pAvpkt->data, i, startCodeLength) == 7) {
 			offset = i;
 			break;
 		}
@@ -76,11 +88,13 @@ int cH264Parser::GetPPSOffset(void)
 {
 	int offset = -1;
 
-	for (int i = 0; i < m_pAvpkt->size - 4; i++) {
-		if (!isValidStartCode(m_pAvpkt->data, i))
+	for (int i = 0; i < m_pAvpkt->size; i++) {
+		int startCodeLength = 0;
+
+		if (!isValidStartCode(m_pAvpkt->data, i, m_pAvpkt->size, startCodeLength))
 			continue;
 
-		if (NalUnitType(m_pAvpkt->data, i) == 8) {
+		if (NalUnitType(m_pAvpkt->data, i, startCodeLength) == 8) {
 			offset = i;
 			break;
 		}
@@ -93,11 +107,13 @@ int cH264Parser::GetSliceOffset(void)
 {
 	int offset = -1;
 
-	for (int i = 0; i < m_pAvpkt->size - 4; i++) {
-		if (!isValidStartCode(m_pAvpkt->data, i))
+	for (int i = 0; i < m_pAvpkt->size; i++) {
+		int startCodeLength = 0;
+
+		if (!isValidStartCode(m_pAvpkt->data, i, m_pAvpkt->size, startCodeLength))
 			continue;
 
-		if (NalUnitType(m_pAvpkt->data, i) == 1 || NalUnitType(m_pAvpkt->data, i) == 5) {
+		if (NalUnitType(m_pAvpkt->data, i, startCodeLength) == 1 || NalUnitType(m_pAvpkt->data, i, startCodeLength) == 5) {
 			offset = i;
 			break;
 		}
@@ -120,61 +136,46 @@ cH264Parser::cH264Parser(AVPacket *avpkt, int maxFrameNum, int refIdxL0, int ref
 	int i;
 
 	// part 1: collect the nalu types in the packet
-	for (i = 0; i < m_pAvpkt->size - 3; i++) {
-		if (!isValidStartCode(m_pAvpkt->data, i))
+	for (i = 0; i < m_pAvpkt->size; i++) {
+		int startCodeLength = 0;
+
+		if (!isValidStartCode(m_pAvpkt->data, i, m_pAvpkt->size, startCodeLength))
 			continue;
 
-		switch (NalUnitType(m_pAvpkt->data, i)) {
-			case 1:
-				m_naluString += " NON-IDR";
-				m_nalutype |= NALU_TYPE_NON_IDR;
-				break;
-			case 2:
-				m_naluString += " PART_A";
-				m_nalutype |= NALU_TYPE_PART_A;
-				break;
-			case 3:
-				m_naluString += " PART_B";
-				m_nalutype |= NALU_TYPE_PART_B;
-				break;
-			case 4:
-				m_naluString += " PART_C";
-				m_nalutype |= NALU_TYPE_PART_C;
-				break;
-			case 5:
-				m_naluString += " IDR";
-				m_nalutype |= NALU_TYPE_IDR;
-				break;
-			case 6:
-				m_naluString += " SEI";
-				m_nalutype |= NALU_TYPE_SEI;
-				break;
-			case 7:
-				m_naluString += " SPS";
-				m_nalutype |= NALU_TYPE_SPS;
-				break;
-			case 8:
-				m_naluString += " PPS";
-				m_nalutype |= NALU_TYPE_PPS;
-				break;
-			case 9:
-				m_naluString += " AUD";
-				m_nalutype |= NALU_TYPE_AUD;
-				break;
-			default:
-				break;
+		int naluType = NalUnitType(m_pAvpkt->data, i, startCodeLength);
+		switch (naluType) {
+			case 1: m_naluString += " NON-IDR"; m_nalutype |= NALU_TYPE_NON_IDR; break;
+			case 2: m_naluString += " PART_A";  m_nalutype |= NALU_TYPE_PART_A;  break;
+			case 3: m_naluString += " PART_B";  m_nalutype |= NALU_TYPE_PART_B;  break;
+			case 4: m_naluString += " PART_C";  m_nalutype |= NALU_TYPE_PART_C;  break;
+			case 5: m_naluString += " IDR";     m_nalutype |= NALU_TYPE_IDR;     break;
+			case 6: m_naluString += " SEI";     m_nalutype |= NALU_TYPE_SEI;     break;
+			case 7: m_naluString += " SPS";     m_nalutype |= NALU_TYPE_SPS;     break;
+			case 8: m_naluString += " PPS";     m_nalutype |= NALU_TYPE_PPS;     break;
+			case 9: m_naluString += " AUD";     m_nalutype |= NALU_TYPE_AUD;     break;
+			default: break;
 		}
+
+		i += startCodeLength - 1;
 	}
 
 	// part 2: parse h264 SPS and get width and height
 	int spsOffset = GetSPSOffset();
+	m_parseError = false;
 
 	// SPS is available
 	if (spsOffset != -1) {
 		m_hasSPS = true;
+		int startCodeLength = 0;
+		isValidStartCode(m_pAvpkt->data, spsOffset, m_pAvpkt->size, startCodeLength);
 
-		m_pStart = &m_pAvpkt->data[spsOffset + 4];
-		m_nLength = m_pAvpkt->size - spsOffset - 4;
+		const uint8_t *nalPayload = &m_pAvpkt->data[spsOffset + startCodeLength + 1];
+		int nalLength = m_pAvpkt->size - spsOffset - startCodeLength -1;
+
+		ConvertEBSPtoRBSP(nalPayload, nalLength);
+		m_pStart = m_rbsp.data();
+		m_nLength = m_rbsp.size();
+
 		m_nCurrentBit = 0;
 
 		int frameCropLeftOffset = 0;
@@ -272,17 +273,29 @@ cH264Parser::cH264Parser(AVPacket *avpkt, int maxFrameNum, int refIdxL0, int ref
 
 		m_height = ((2 - frameMbsOnlyFlag)* (picHeightInMapUnitsMinusOne +1) * 16) -
 			subHeightC * ((frameCropBottomOffset * 2) + (frameCropTopOffset * 2));
+
+//		if (m_parseError)
+//			LOGWARNING("SPS parsing error");
 	}
 
 	// part 3: parse h264 PPS
 	int ppsOffset = GetPPSOffset();
+	m_parseError = false;
 
 	// PPS is available
 	if (ppsOffset != -1) {
 		m_hasPPS = true;
 
-		m_pStart = &m_pAvpkt->data[ppsOffset + 4];
-		m_nLength = m_pAvpkt->size - ppsOffset - 4;
+		int startCodeLength = 0;
+		isValidStartCode(m_pAvpkt->data, ppsOffset, m_pAvpkt->size, startCodeLength);
+
+		const uint8_t *nalPayload = &m_pAvpkt->data[ppsOffset + startCodeLength + 1];
+		int nalLength = m_pAvpkt->size - ppsOffset - startCodeLength -1;
+
+		ConvertEBSPtoRBSP(nalPayload, nalLength);
+
+		m_pStart = m_rbsp.data();
+		m_nLength = m_rbsp.size();
 		m_nCurrentBit = 0;
 
 		ReadExponentialGolombCode(); // PicParameterSetId
@@ -329,20 +342,32 @@ cH264Parser::cH264Parser(AVPacket *avpkt, int maxFrameNum, int refIdxL0, int ref
 
 		m_numRefIdxL0Active = m_ppsNumRefIdxL0DefaultActiveMinus1 + 1;
 		m_numRefIdxL1Active = m_ppsNumRefIdxL1DefaultActiveMinus1 + 1;
+
+//		if (m_parseError)
+//			LOGWARNING("PPS parsing error");
 	}
 
 	// part 4: parse slice header
 	int sliceOffset = GetSliceOffset();
+	m_parseError = false;
 
 	// slice is available
 	if (sliceOffset != -1) {
-		m_pStart = &m_pAvpkt->data[sliceOffset + 4];
-		m_nLength = m_pAvpkt->size - sliceOffset - 4;
-		uint8_t nalHeader = m_pAvpkt->data[sliceOffset + 3];
+		int startCodeLength = 0;
+		isValidStartCode(m_pAvpkt->data, sliceOffset, m_pAvpkt->size, startCodeLength);
 
+		const uint8_t *nalPayload = &m_pAvpkt->data[sliceOffset + startCodeLength + 1];
+		int nalLength = m_pAvpkt->size - sliceOffset - startCodeLength - 1;
+
+		ConvertEBSPtoRBSP(nalPayload, nalLength);
+
+		m_pStart = m_rbsp.data();
+		m_nLength = m_rbsp.size();
+
+		uint8_t nalHeader = m_pAvpkt->data[sliceOffset + startCodeLength];
 		m_nalRefIdc = (nalHeader >> 5) & 0x03;
 		m_isReference = (m_nalRefIdc != 0);
-		m_isIDR = (NalUnitType(m_pAvpkt->data, sliceOffset) == 5);
+		m_isIDR = ((nalHeader & 0x1F) == 5);
 
 		m_nCurrentBit = 0;
 
@@ -355,6 +380,10 @@ cH264Parser::cH264Parser(AVPacket *avpkt, int maxFrameNum, int refIdxL0, int ref
 
 		int frame_num_bits = m_log2MaxFrameNumMinus4 + 4;
 		m_frameNum = ReadBits(frame_num_bits);
+//		if (m_parseError) {
+//			LOGWARNING("Slice parsing error -> frameNum");
+//			return;
+//		}
 
 		if (m_isIDR)
 			ReadExponentialGolombCode(); // idr_pic_id
@@ -466,9 +495,11 @@ cH264Parser::cH264Parser(AVPacket *avpkt, int maxFrameNum, int refIdxL0, int ref
 			m_naluString += " -I-    ";
 		} else if (m_sliceType == 3) { // SP-slice
 			m_naluString += "       -SP-   ";
-		} else if (m_sliceType == 5) { // SI-slice
+		} else if (m_sliceType == 4) { // SI-slice
 			m_naluString += " -SI-   ";
 		}
+//		if (m_parseError)
+//			LOGWARNING("Slice parsing error");
 	}
 }
 
@@ -555,36 +586,59 @@ void cH264Parser::PrintNalUnits(void)
  */
 unsigned int cH264Parser::ReadBit()
 {
-	assert(m_nCurrentBit <= m_nLength * 8);
-	int nIndex = m_nCurrentBit / 8;
-	int nOffset = m_nCurrentBit % 8 + 1;
+	if (m_nCurrentBit >= m_nLength * 8) {
+		m_parseError = true;
+		return 0;
+	}
+
+	int nIndex  = m_nCurrentBit / 8;
+	int nOffset = m_nCurrentBit % 8;
 
 	m_nCurrentBit++;
-	return (m_pStart[nIndex] >> (8-nOffset)) & 0x01;
+	return (m_pStart[nIndex] >> (7 - nOffset)) & 0x01;
 }
 
 unsigned int cH264Parser::ReadBits(int n)
 {
-	int r = 0;
+	if (m_nCurrentBit + n > m_nLength * 8) {
+		m_parseError = true;
+		return 0;
+	}
+
+	unsigned int r = 0;
 
 	for (int i = 0; i < n; i++) {
-		r |= ( ReadBit() << ( n - i - 1 ) );
+		r = (r << 1) | ReadBit();
 	}
 	return r;
 }
 
 unsigned int cH264Parser::ReadExponentialGolombCode()
 {
-	int r = 0;
-	int i = 0;
+	int zeros = 0;
 
-	while((ReadBit() == 0) && (i < 32)) {
-		i++;
+	while (zeros < 32) {
+	if (m_nCurrentBit >= m_nLength * 8) {
+		m_parseError = true;
+		return 0;
 	}
 
-	r = ReadBits(i);
-	r += (1 << i) - 1;
-	return r;
+	if (ReadBit() == 0)
+		zeros++;
+	else
+		break;
+	}
+
+	if (zeros == 32) {
+		m_parseError = true;
+		return 0;
+	}
+
+	unsigned int suffix = 0;
+	if (zeros > 0)
+		suffix = ReadBits(zeros);
+
+	return ((1u << zeros) - 1) + suffix;
 }
 
 unsigned int cH264Parser::ReadSE()
@@ -597,4 +651,27 @@ unsigned int cH264Parser::ReadSE()
 		r = -(r/2);
 	}
 	return r;
+}
+
+void cH264Parser::ConvertEBSPtoRBSP(const uint8_t *src, int length)
+{
+	m_rbsp.clear();
+	m_rbsp.reserve(length);
+
+	int zeroCount = 0;
+
+	for (int i = 0; i < length; i++) {
+		if (zeroCount == 2 && src[i] == 0x03) {
+			// skip emulation prevention byte
+			zeroCount = 0;
+			continue;
+		}
+
+		m_rbsp.push_back(src[i]);
+
+		if (src[i] == 0x00)
+			zeroCount++;
+		else
+			zeroCount = 0;
+	}
 }

--- a/h264parser.cpp
+++ b/h264parser.cpp
@@ -22,6 +22,7 @@
  */
 
 #include <cassert>
+#include <string>
 
 extern "C" {
 #include <libavcodec/avcodec.h>
@@ -34,23 +35,6 @@ extern "C" {
 /*****************************************************************************
  * cH264Parser class
  ****************************************************************************/
-
-/**
- * Print raw stream data
- *
- * @param data        pointer to stream data
- * @param size        data size
- */
-static void PrintStreamData(const uint8_t *data, int size)
-{
-	LOGDEBUG("Stream: %02x %02x %02x %02x %02x %02x %02x %02x %02x "
-	         "%02x %02x %02x %02x %02x %02x %02x %02x %02x %02x %02x %02x %02x %02x "
-	         "%02x %02x %02x %02x %02x %02x %02x %02x %02x %02x %02x %02x size %d",
-	         data[0], data[1], data[2], data[3], data[4], data[5], data[6], data[7], data[8],
-	         data[9], data[10], data[11], data[12], data[13], data[14], data[15], data[16], data[17],
-	         data[18], data[19], data[20], data[21], data[22], data[23], data[24], data[25], data[26],
-	         data[27], data[28], data[29], data[30], data[31], data[32], data[33], data[34], size);
-}
 
 /**
  * Returns true, if we have a 0x000001 start code
@@ -86,21 +70,39 @@ cH264Parser::cH264Parser(AVPacket *avpkt)
 
 		switch (NalUnitType(m_pAvpkt->data, i)) {
 			case 1:
+				m_naluString += " NON-IDR";
 				m_nalutype |= NALU_TYPE_NON_IDR;
 				break;
+			case 2:
+				m_naluString += " PART_A";
+				m_nalutype |= NALU_TYPE_PART_A;
+				break;
+			case 3:
+				m_naluString += " PART_B";
+				m_nalutype |= NALU_TYPE_PART_B;
+				break;
+			case 4:
+				m_naluString += " PART_C";
+				m_nalutype |= NALU_TYPE_PART_C;
+				break;
 			case 5:
+				m_naluString += " IDR";
 				m_nalutype |= NALU_TYPE_IDR;
 				break;
 			case 6:
+				m_naluString += " SEI";
 				m_nalutype |= NALU_TYPE_SEI;
 				break;
 			case 7:
+				m_naluString += " SPS";
 				m_nalutype |= NALU_TYPE_SPS;
 				break;
 			case 8:
+				m_naluString += " PPS";
 				m_nalutype |= NALU_TYPE_PPS;
 				break;
 			case 9:
+				m_naluString += " AUD";
 				m_nalutype |= NALU_TYPE_AUD;
 				break;
 			default:
@@ -122,11 +124,10 @@ cH264Parser::cH264Parser(AVPacket *avpkt)
 	}
 
 	// no SPS available
-	if (!m_pStart) {
-		LOGERROR("H264Parser: %s: No m_pStart %p Pkt %p i %d", __FUNCTION__, m_pStart, m_pAvpkt, i);
-		PrintStreamData(m_pAvpkt->data, m_pAvpkt->size);
+	if (!m_pStart)
 		return;
-	}
+
+	m_hasSPS = true;
 
 	m_nCurrentBit = 0;
 	int frameCropLeftOffset = 0;
@@ -224,15 +225,28 @@ cH264Parser::cH264Parser(AVPacket *avpkt)
 
 	m_height = ((2 - frameMbsOnlyFlag)* (picHeightInMapUnitsMinusOne +1) * 16) -
 		subHeightC * ((frameCropBottomOffset * 2) + (frameCropTopOffset * 2));
+}
 
-	LOGDEBUG2(L_CODEC, "H264Parser: %s %s%s%s%s%s%s width %d height %d", __FUNCTION__,
-		m_nalutype & NALU_TYPE_AUD     ? "AUD " : "",
-		m_nalutype & NALU_TYPE_SPS     ? "SPS " : "",
-		m_nalutype & NALU_TYPE_PPS     ? "PPS " : "",
-		m_nalutype & NALU_TYPE_SEI     ? "SEI " : "",
-		m_nalutype & NALU_TYPE_IDR     ? "IDR " : "",
-		m_nalutype & NALU_TYPE_NON_IDR ? "NON-IDR " : "",
-		m_width, m_height);
+/**
+ * Print raw stream data of the first 35 bytes
+ */
+void cH264Parser::PrintStreamData(void)
+{
+	const uint8_t *data = m_pAvpkt->data;
+
+	LOGDEBUG("Stream: %02x %02x %02x %02x %02x %02x %02x %02x %02x "
+	         "%02x %02x %02x %02x %02x %02x %02x %02x %02x %02x %02x %02x %02x %02x "
+	         "%02x %02x %02x %02x %02x %02x %02x %02x %02x %02x %02x %02x size %d",
+	         data[0], data[1], data[2], data[3], data[4], data[5], data[6], data[7], data[8],
+	         data[9], data[10], data[11], data[12], data[13], data[14], data[15], data[16], data[17],
+	         data[18], data[19], data[20], data[21], data[22], data[23], data[24], data[25], data[26],
+	         data[27], data[28], data[29], data[30], data[31], data[32], data[33], data[34], m_pAvpkt->size);
+}
+
+void cH264Parser::PrintNalUnits(void)
+{
+	LOGDEBUG2(L_CODEC, "H264Parser: %s %s (%d x %d)", __FUNCTION__,
+		m_naluString.c_str(), m_width, m_height);
 }
 
 /*

--- a/h264parser.cpp
+++ b/h264parser.cpp
@@ -537,15 +537,6 @@ void cH264Parser::PrintNalUnits(void)
 }
 
 /*
- * Does the parser frame include an I-Frame?
- */
-bool cH264Parser::IsIFrame(void)
-{
-	return (m_nalutype & NALU_TYPE_IDR) ||
-	      ((m_nalutype & NALU_TYPE_NON_IDR) && (m_nalutype & (NALU_TYPE_PPS | NALU_TYPE_SPS)));
-}
-
-/*
  * helper functions to parse resolution from stream
  */
 unsigned int cH264Parser::ReadBit()

--- a/h264parser.cpp
+++ b/h264parser.cpp
@@ -23,6 +23,7 @@
 
 #include <cassert>
 #include <string>
+#include <vector>
 
 extern "C" {
 #include <libavcodec/avcodec.h>
@@ -51,6 +52,40 @@ bool isValidStartCode(const uint8_t *data, int offset)
 static int NalUnitType(const uint8_t *data, int i)
 {
 	return data[i + 3] & 0x1F;
+}
+
+int cH264Parser::GetSPSOffset(void)
+{
+	int offset = -1;
+
+	for (int i = 0; i < m_pAvpkt->size - 4; i++) {
+		if (!isValidStartCode(m_pAvpkt->data, i))
+			continue;
+
+		if (NalUnitType(m_pAvpkt->data, i) == 7) {
+			offset = i;
+			break;
+		}
+	}
+
+	return offset;
+}
+
+int cH264Parser::GetSliceOffset(void)
+{
+	int offset = -1;
+
+	for (int i = 0; i < m_pAvpkt->size - 4; i++) {
+		if (!isValidStartCode(m_pAvpkt->data, i))
+			continue;
+
+		if (NalUnitType(m_pAvpkt->data, i) == 1 || NalUnitType(m_pAvpkt->data, i) == 5) {
+			offset = i;
+			break;
+		}
+	}
+
+	return offset;
 }
 
 /**
@@ -111,120 +146,182 @@ cH264Parser::cH264Parser(AVPacket *avpkt)
 	}
 
 	// part 2: parse h264 SPS and get width and height
-	m_pStart = NULL;
-	for (i = 0; i < m_pAvpkt->size - 4; i++) {
-		if (!isValidStartCode(m_pAvpkt->data, i))
-			continue;
+	int spsOffset = GetSPSOffset();
 
-		if (NalUnitType(m_pAvpkt->data, i) == 7) {
-			m_pStart = &m_pAvpkt->data[i + 4];
-			m_nLength = m_pAvpkt->size - i - 4;
-			break;
-		}
-	}
+	// SPS is available
+	if (spsOffset != -1) {
+		m_hasSPS = true;
 
-	// no SPS available
-	if (!m_pStart)
-		return;
+		m_pStart = &m_pAvpkt->data[spsOffset + 4];
+		m_nLength = m_pAvpkt->size - spsOffset - 4;
 
-	m_hasSPS = true;
+		m_nCurrentBit = 0;
+		int frameCropLeftOffset = 0;
+		int frameCropRightOffset = 0;
+		int frameCropTopOffset = 0;
+		int frameCropBottomOffset = 0;
+		int chromaFormatIdc = 0;
+		int separateColorPlaneFlag = 0;
 
-	m_nCurrentBit = 0;
-	int frameCropLeftOffset = 0;
-	int frameCropRightOffset = 0;
-	int frameCropTopOffset = 0;
-	int frameCropBottomOffset = 0;
-	int chromaFormatIdc = 0;
-	int separateColorPlaneFlag = 0;
-
-	int profileIdc = ReadBits(8);
-	ReadBits(16);
-	ReadExponentialGolombCode();
-
-	if (profileIdc == 100 || profileIdc == 110 ||
-	    profileIdc == 122 || profileIdc == 244 ||
-	    profileIdc == 44 || profileIdc == 83 ||
-	    profileIdc == 86 || profileIdc == 118) {
-
-		chromaFormatIdc = ReadExponentialGolombCode();
-		if (chromaFormatIdc == 3)
-			separateColorPlaneFlag = ReadBit();
+		int profileIdc = ReadBits(8);
+		ReadBits(16);
 		ReadExponentialGolombCode();
-		ReadExponentialGolombCode();
-		ReadBit();
-		int seqScalingMatrixPresentFlag = ReadBit();
-		if (seqScalingMatrixPresentFlag) {
-			for (int i = 0; i < 8; i++) {
-				int seqScalingListPresentFlag = ReadBit();
-				if (seqScalingListPresentFlag) {
-					int sizeOfScalingList = (i < 6) ? 16 : 64;
-					int lastScale = 8;
-					int nextScale = 8;
-					for (int j = 0; j < sizeOfScalingList; j++) {
-						if (nextScale != 0) {
-							int delta_scale = ReadSE();
-							nextScale = (lastScale + delta_scale + 256) % 256;
+
+		if (profileIdc == 100 || profileIdc == 110 ||
+		    profileIdc == 122 || profileIdc == 244 ||
+		    profileIdc == 44 || profileIdc == 83 ||
+		    profileIdc == 86 || profileIdc == 118) {
+
+			chromaFormatIdc = ReadExponentialGolombCode();
+			if (chromaFormatIdc == 3)
+				separateColorPlaneFlag = ReadBit();
+			ReadExponentialGolombCode();
+			ReadExponentialGolombCode();
+			ReadBit();
+			int seqScalingMatrixPresentFlag = ReadBit();
+			if (seqScalingMatrixPresentFlag) {
+				for (int i = 0; i < 8; i++) {
+					int seqScalingListPresentFlag = ReadBit();
+					if (seqScalingListPresentFlag) {
+						int sizeOfScalingList = (i < 6) ? 16 : 64;
+						int lastScale = 8;
+						int nextScale = 8;
+						for (int j = 0; j < sizeOfScalingList; j++) {
+							if (nextScale != 0) {
+								int delta_scale = ReadSE();
+								nextScale = (lastScale + delta_scale + 256) % 256;
+							}
+							lastScale = (nextScale == 0) ? lastScale : nextScale;
 						}
-						lastScale = (nextScale == 0) ? lastScale : nextScale;
 					}
 				}
 			}
 		}
-	}
-	ReadExponentialGolombCode();
-	int picOrderCntType = ReadExponentialGolombCode();
-	if (picOrderCntType == 0) {
-		ReadExponentialGolombCode();
-	} else if (picOrderCntType == 1) {
-		ReadBit();
-		ReadSE();
-		ReadSE();
-		int numRefFramesInPicOrderCntCycle = ReadExponentialGolombCode();
-		for (int i = 0; i < numRefFramesInPicOrderCntCycle; i++ ) {
+		m_log2MaxFrameNumMinus4 = ReadExponentialGolombCode();
+		int picOrderCntType = ReadExponentialGolombCode();
+		if (picOrderCntType == 0) {
+			ReadExponentialGolombCode();
+		} else if (picOrderCntType == 1) {
+			ReadBit();
 			ReadSE();
+			ReadSE();
+			int numRefFramesInPicOrderCntCycle = ReadExponentialGolombCode();
+			for (int i = 0; i < numRefFramesInPicOrderCntCycle; i++ ) {
+				ReadSE();
+			}
+		}
+		ReadExponentialGolombCode();
+		ReadBit();
+		int picWidthInMbsMinusOne = ReadExponentialGolombCode();
+		int picHeightInMapUnitsMinusOne = ReadExponentialGolombCode();
+		int frameMbsOnlyFlag = ReadBit();
+		if (!frameMbsOnlyFlag) {
+			m_mbaff = ReadBit();
+		}
+
+		ReadBit();
+		int frameCroppingFlag = ReadBit();
+		if (frameCroppingFlag) {
+			frameCropLeftOffset = ReadExponentialGolombCode();
+			frameCropRightOffset = ReadExponentialGolombCode();
+			frameCropTopOffset = ReadExponentialGolombCode();
+			frameCropBottomOffset = ReadExponentialGolombCode();
+		}
+
+		int subWidthC = 0;
+		int subHeightC = 0;
+
+		if (chromaFormatIdc == 0 && separateColorPlaneFlag == 0) { // monochrome
+			subWidthC = subHeightC = 2;
+		} else if (chromaFormatIdc == 1 && separateColorPlaneFlag == 0) { // 4:2:0
+			subWidthC = subHeightC = 2;
+		} else if (chromaFormatIdc == 2 && separateColorPlaneFlag == 0) { // 4:2:2
+			subWidthC = 2;
+			subHeightC = 1;
+		} else if (chromaFormatIdc == 3) { // 4:4:4
+			if (separateColorPlaneFlag == 0) {
+				subWidthC = subHeightC = 1;
+			} else if (separateColorPlaneFlag == 1) {
+				subWidthC = subHeightC = 0;
+			}
+		}
+
+		m_width = ((picWidthInMbsMinusOne + 1) * 16) -
+			subWidthC * (frameCropRightOffset + frameCropLeftOffset);
+
+		m_height = ((2 - frameMbsOnlyFlag)* (picHeightInMapUnitsMinusOne +1) * 16) -
+			subHeightC * ((frameCropBottomOffset * 2) + (frameCropTopOffset * 2));
+	}
+
+	// part 3: parse slice header
+	int sliceOffset = GetSliceOffset();
+
+	// slice is available
+	if (sliceOffset) {
+		m_pStart = &m_pAvpkt->data[sliceOffset + 4];
+		m_nLength = m_pAvpkt->size - sliceOffset - 4;
+		uint8_t nalHeader = m_pAvpkt->data[sliceOffset + 3];
+
+		m_nalRefIdc = (nalHeader >> 5) & 0x03;
+		m_isReference = (m_nalRefIdc != 0);
+		m_isIDR = (NalUnitType(m_pAvpkt->data, i) == 5);
+
+		m_nCurrentBit = 0;
+
+		ReadExponentialGolombCode(); // int first_mb_in_slice =
+		int slice_type_raw = ReadExponentialGolombCode();
+
+		m_sliceType = slice_type_raw % 5;   // normalize
+
+		ReadExponentialGolombCode(); // int pic_parameter_set_id =
+
+		int frame_num_bits = m_log2MaxFrameNumMinus4 + 4;
+		m_frameNum = ReadBits(frame_num_bits);
+
+		if (m_isIDR)
+			ReadExponentialGolombCode(); // idr_pic_id
+
+		// Only care about P-slice reference behavior
+		m_refMods.clear();
+		m_refListModFlagL0 = false;
+		m_numRefIdxL0Active = 1;
+
+		if (m_sliceType == 0) { // P-slice
+			m_naluString += " -P-";
+			int num_ref_idx_override = ReadBit();
+
+			if (num_ref_idx_override)
+				m_numRefIdxL0Active = ReadExponentialGolombCode() + 1;
+			else
+				m_numRefIdxL0Active = 1;
+
+			m_refListModFlagL0 = ReadBit();
+
+			if (m_refListModFlagL0) {
+				int idc;
+				do {
+					idc = ReadExponentialGolombCode();
+
+					if (idc == 0 || idc == 1) {
+						RefPicMod mod;
+						mod.idc = idc;
+						mod.abs_diff_pic_num_minus1 = ReadExponentialGolombCode();
+						m_refMods.push_back(mod);
+					} else if (idc == 2) {
+						ReadExponentialGolombCode(); // ignore long-term
+					}
+				} while (idc != 3);
+			}
+		} else if (m_sliceType == 1) { // B-slice
+			m_naluString += "     -B-";
+		} else if (m_sliceType == 2) { // I-slice
+			m_naluString += " -I-";
+		} else if (m_sliceType == 3) { // SP-slice
+			m_naluString += " -SP-";
+		} else if (m_sliceType == 5) { // SI-slice
+			m_naluString += " -SI-";
 		}
 	}
-	ReadExponentialGolombCode();
-	ReadBit();
-	int picWidthInMbsMinusOne = ReadExponentialGolombCode();
-	int picHeightInMapUnitsMinusOne = ReadExponentialGolombCode();
-	int frameMbsOnlyFlag = ReadBit();
-	if (!frameMbsOnlyFlag) {
-		m_mbaff = ReadBit();
-	}
-
-	ReadBit();
-	int frameCroppingFlag = ReadBit();
-	if (frameCroppingFlag) {
-		frameCropLeftOffset = ReadExponentialGolombCode();
-		frameCropRightOffset = ReadExponentialGolombCode();
-		frameCropTopOffset = ReadExponentialGolombCode();
-		frameCropBottomOffset = ReadExponentialGolombCode();
-	}
-
-	int subWidthC = 0;
-	int subHeightC = 0;
-
-	if (chromaFormatIdc == 0 && separateColorPlaneFlag == 0) { // monochrome
-		subWidthC = subHeightC = 2;
-	} else if (chromaFormatIdc == 1 && separateColorPlaneFlag == 0) { // 4:2:0
-		subWidthC = subHeightC = 2;
-	} else if (chromaFormatIdc == 2 && separateColorPlaneFlag == 0) { // 4:2:2
-		subWidthC = 2;
-		subHeightC = 1;
-	} else if (chromaFormatIdc == 3) { // 4:4:4
-		if (separateColorPlaneFlag == 0) {
-			subWidthC = subHeightC = 1;
-		} else if (separateColorPlaneFlag == 1) {
-			subWidthC = subHeightC = 0;
-		}
-	}
-
-	m_width = ((picWidthInMbsMinusOne + 1) * 16) -
-		subWidthC * (frameCropRightOffset + frameCropLeftOffset);
-
-	m_height = ((2 - frameMbsOnlyFlag)* (picHeightInMapUnitsMinusOne +1) * 16) -
-		subHeightC * ((frameCropBottomOffset * 2) + (frameCropTopOffset * 2));
 }
 
 /**

--- a/h264parser.cpp
+++ b/h264parser.cpp
@@ -39,8 +39,14 @@ extern "C" {
  ****************************************************************************/
 
 /**
- * Returns true, if we have a 0x000001 or 0x00000001 start code
- * in data at the offset position
+ * Check for a 0x000001 or 0x00000001 start code
+ *
+ * @param[in] data               pointer to the data stream
+ * @param[in] offset             start parsing at offset
+ * @param[in] size               size of data
+ * @param[out] startCodeLength   start code length (3 or 4)
+ *
+ * @returns true if a valid start code was detected, false otherwise
  */
 bool isValidStartCode(const uint8_t *data, int offset, int size, int &startCodeLength)
 {
@@ -59,12 +65,22 @@ bool isValidStartCode(const uint8_t *data, int offset, int size, int &startCodeL
 
 /**
  * Return the nal unit type
+ *
+ * @param data               pointer to the data stream
+ * @param offset             start parsing at offset
+ * @param startCodeLength    start code length (3 or 4)
+ *
+ * @returns the nal unit type
  */
 static int NalUnitType(const uint8_t *data, int offset, int startCodeLength)
 {
 	return data[offset + startCodeLength] & 0x1F;
 }
 
+/**
+ * Returns the SPS offset in the data stream
+ * or -1 if there is no SPS
+ */
 int cH264Parser::GetSPSOffset(void)
 {
 	int offset = -1;
@@ -84,6 +100,10 @@ int cH264Parser::GetSPSOffset(void)
 	return offset;
 }
 
+/**
+ * Returns the PPS offset in the data stream
+ * or -1 if there is no PPS
+ */
 int cH264Parser::GetPPSOffset(void)
 {
 	int offset = -1;
@@ -103,6 +123,10 @@ int cH264Parser::GetPPSOffset(void)
 	return offset;
 }
 
+/**
+ * Returns the slice offset in the data stream
+ * or -1 if there is no slice
+ */
 int cH264Parser::GetSliceOffset(void)
 {
 	int offset = -1;
@@ -125,7 +149,10 @@ int cH264Parser::GetSliceOffset(void)
 /**
  * Init the h264 parser and detect the nalu types
  *
- * @param avpkt      AVPacket to parse
+ * @param avpkt        AVPacket to parse
+ * @param maxFrameNum  log2MaxFrameNumMinus4 from a previous SPS parsing, will be overwritten if this packet contains SPS
+ * @param refIdxL0     ppsNumRefIdxL0DefaultActiveMinus1 from a previous PPS parsing, will be overwritten if this packet contains PPS
+ * @param refIdxL1     ppsNumRefIdxL1DefaultActiveMinus1 from a previous PPS parsing, will be overwritten if this packet contains PPS
  */
 cH264Parser::cH264Parser(AVPacket *avpkt, int maxFrameNum, int refIdxL0, int refIdxL1)
 	: m_pAvpkt(avpkt),
@@ -274,8 +301,8 @@ cH264Parser::cH264Parser(AVPacket *avpkt, int maxFrameNum, int refIdxL0, int ref
 		m_height = ((2 - frameMbsOnlyFlag)* (picHeightInMapUnitsMinusOne +1) * 16) -
 			subHeightC * ((frameCropBottomOffset * 2) + (frameCropTopOffset * 2));
 
-//		if (m_parseError)
-//			LOGWARNING("SPS parsing error");
+		//if (m_parseError)
+		//	LOGWARNING("SPS parsing error");
 	}
 
 	// part 3: parse h264 PPS
@@ -343,8 +370,8 @@ cH264Parser::cH264Parser(AVPacket *avpkt, int maxFrameNum, int refIdxL0, int ref
 		m_numRefIdxL0Active = m_ppsNumRefIdxL0DefaultActiveMinus1 + 1;
 		m_numRefIdxL1Active = m_ppsNumRefIdxL1DefaultActiveMinus1 + 1;
 
-//		if (m_parseError)
-//			LOGWARNING("PPS parsing error");
+		//if (m_parseError)
+		//	LOGWARNING("PPS parsing error");
 	}
 
 	// part 4: parse slice header
@@ -380,10 +407,10 @@ cH264Parser::cH264Parser(AVPacket *avpkt, int maxFrameNum, int refIdxL0, int ref
 
 		int frame_num_bits = m_log2MaxFrameNumMinus4 + 4;
 		m_frameNum = ReadBits(frame_num_bits);
-//		if (m_parseError) {
-//			LOGWARNING("Slice parsing error -> frameNum");
-//			return;
-//		}
+		//if (m_parseError) {
+		//	LOGWARNING("Slice parsing error -> frameNum");
+		//	return;
+		//}
 
 		if (m_isIDR)
 			ReadExponentialGolombCode(); // idr_pic_id
@@ -498,11 +525,17 @@ cH264Parser::cH264Parser(AVPacket *avpkt, int maxFrameNum, int refIdxL0, int ref
 		} else if (m_sliceType == 4) { // SI-slice
 			m_naluString += " -SI-   ";
 		}
-//		if (m_parseError)
-//			LOGWARNING("Slice parsing error");
+		//if (m_parseError)
+		//	LOGWARNING("Slice parsing error");
 	}
 }
 
+/**
+ * Adds an invalid reference
+ *
+ * @param modRef         number of the reference frame
+ * @param frameNumber    number of the frame to add
+ */
 void cH264Parser::AddInvalidReference(int modRef, int frameNumber)
 {
 	m_invalidReferences.insert(modRef);
@@ -512,12 +545,22 @@ void cH264Parser::AddInvalidReference(int modRef, int frameNumber)
 		m_hasInvalidBackwardReferences = true;
 }
 
+/**
+ * Adds a valid reference
+ *
+ * @param modRef         number of the reference frame
+ */
 void cH264Parser::AddValidReference(int modRef)
 {
 	m_validReferences.insert(modRef);
 	m_hasValidReferences = true;
 }
 
+/**
+ * Add a whitespace-separated list of all invalid references to the log output string
+ *
+ * @param frameNumber     only build the string up to the given frameNumber
+ */
 void cH264Parser::BuildInvalidReferenceString(int frameNumber)
 {
 	if (!m_hasInvalidReferences)
@@ -532,6 +575,9 @@ void cH264Parser::BuildInvalidReferenceString(int frameNumber)
 	}
 }
 
+/**
+ * Add a whitespace-separated list of all valid references to the log output string
+ */
 void cH264Parser::BuildValidReferenceString(void)
 {
 	if (!m_hasValidReferences)
@@ -544,6 +590,11 @@ void cH264Parser::BuildValidReferenceString(void)
 	}
 }
 
+/**
+ * Add the frame number to the log output string
+ *
+ * @param num    frame number to add to the string
+ */
 void cH264Parser::AddFrameNumber(int num)
 {
 	if (num != -1) {
@@ -575,6 +626,9 @@ void cH264Parser::PrintStreamData(void)
 	         data[27], data[28], data[29], data[30], data[31], data[32], data[33], data[34], m_pAvpkt->size);
 }
 
+/**
+ * Print the previously created log output string
+ */
 void cH264Parser::PrintNalUnits(void)
 {
 	LOGDEBUG2(L_CODEC, "H264Parser: %s %s (%d x %d)", __FUNCTION__,

--- a/h264parser.cpp
+++ b/h264parser.cpp
@@ -475,19 +475,21 @@ void cH264Parser::AddValidReference(int modRef)
 	m_hasValidReferences = true;
 }
 
-void cH264Parser::PrintInvalidReference(void)
+void cH264Parser::BuildInvalidReferenceString(int frameNumber)
 {
 	if (!m_hasInvalidReferences)
 		return;
 
 	m_naluString += " !!!";
 	for (auto r : m_invalidReferences) {
-		m_naluString += " ";
-		m_naluString += std::to_string(r);
+		if (r < frameNumber) {
+			m_naluString += " ";
+			m_naluString += std::to_string(r);
+		}
 	}
 }
 
-void cH264Parser::PrintValidReference(void)
+void cH264Parser::BuildValidReferenceString(void)
 {
 	if (!m_hasValidReferences)
 		return;

--- a/h264parser.cpp
+++ b/h264parser.cpp
@@ -93,8 +93,9 @@ int cH264Parser::GetSliceOffset(void)
  *
  * @param avpkt      AVPacket to parse
  */
-cH264Parser::cH264Parser(AVPacket *avpkt)
-	: m_pAvpkt(avpkt)
+cH264Parser::cH264Parser(AVPacket *avpkt, int maxFrameNum)
+	: m_pAvpkt(avpkt),
+	  m_log2MaxFrameNumMinus4(maxFrameNum)
 {
 	int i;
 
@@ -257,14 +258,14 @@ cH264Parser::cH264Parser(AVPacket *avpkt)
 	int sliceOffset = GetSliceOffset();
 
 	// slice is available
-	if (sliceOffset) {
+	if (sliceOffset != -1) {
 		m_pStart = &m_pAvpkt->data[sliceOffset + 4];
 		m_nLength = m_pAvpkt->size - sliceOffset - 4;
 		uint8_t nalHeader = m_pAvpkt->data[sliceOffset + 3];
 
 		m_nalRefIdc = (nalHeader >> 5) & 0x03;
 		m_isReference = (m_nalRefIdc != 0);
-		m_isIDR = (NalUnitType(m_pAvpkt->data, i) == 5);
+		m_isIDR = (NalUnitType(m_pAvpkt->data, sliceOffset) == 5);
 
 		m_nCurrentBit = 0;
 
@@ -287,7 +288,7 @@ cH264Parser::cH264Parser(AVPacket *avpkt)
 		m_numRefIdxL0Active = 1;
 
 		if (m_sliceType == 0) { // P-slice
-			m_naluString += " -P-";
+			m_naluString += " -P-    ";
 			int num_ref_idx_override = ReadBit();
 
 			if (num_ref_idx_override)
@@ -315,13 +316,36 @@ cH264Parser::cH264Parser(AVPacket *avpkt)
 		} else if (m_sliceType == 1) { // B-slice
 			m_naluString += "     -B-";
 		} else if (m_sliceType == 2) { // I-slice
-			m_naluString += " -I-";
+			m_naluString += " -I-    ";
 		} else if (m_sliceType == 3) { // SP-slice
-			m_naluString += " -SP-";
+			m_naluString += " -SP-   ";
 		} else if (m_sliceType == 5) { // SI-slice
-			m_naluString += " -SI-";
+			m_naluString += " -SI-   ";
 		}
 	}
+}
+
+void cH264Parser::AddInvalidReference(int modRef)
+{
+	m_invalidReferences += " ";
+	m_invalidReferences += std::to_string(modRef);
+	m_hasInvalidReferences = true;
+}
+
+void cH264Parser::MarkInvalidReference(void)
+{
+	if (!m_hasInvalidReferences)
+		return;
+
+	m_naluString += " <-- invalid reference to ";
+	m_naluString += m_invalidReferences;
+}
+
+void cH264Parser::AddFrameNumber(int num)
+{
+	m_naluString += " (ref ";
+	m_naluString += std::to_string(num);
+	m_naluString += ")";
 }
 
 /**

--- a/h264parser.cpp
+++ b/h264parser.cpp
@@ -22,6 +22,7 @@
  */
 
 #include <cassert>
+#include <set>
 #include <string>
 #include <vector>
 
@@ -71,6 +72,23 @@ int cH264Parser::GetSPSOffset(void)
 	return offset;
 }
 
+int cH264Parser::GetPPSOffset(void)
+{
+	int offset = -1;
+
+	for (int i = 0; i < m_pAvpkt->size - 4; i++) {
+		if (!isValidStartCode(m_pAvpkt->data, i))
+			continue;
+
+		if (NalUnitType(m_pAvpkt->data, i) == 8) {
+			offset = i;
+			break;
+		}
+	}
+
+	return offset;
+}
+
 int cH264Parser::GetSliceOffset(void)
 {
 	int offset = -1;
@@ -93,9 +111,11 @@ int cH264Parser::GetSliceOffset(void)
  *
  * @param avpkt      AVPacket to parse
  */
-cH264Parser::cH264Parser(AVPacket *avpkt, int maxFrameNum)
+cH264Parser::cH264Parser(AVPacket *avpkt, int maxFrameNum, int refIdxL0, int refIdxL1)
 	: m_pAvpkt(avpkt),
-	  m_log2MaxFrameNumMinus4(maxFrameNum)
+	  m_log2MaxFrameNumMinus4(maxFrameNum),
+	  m_ppsNumRefIdxL0DefaultActiveMinus1(refIdxL0),
+	  m_ppsNumRefIdxL1DefaultActiveMinus1(refIdxL1)
 {
 	int i;
 
@@ -155,8 +175,8 @@ cH264Parser::cH264Parser(AVPacket *avpkt, int maxFrameNum)
 
 		m_pStart = &m_pAvpkt->data[spsOffset + 4];
 		m_nLength = m_pAvpkt->size - spsOffset - 4;
-
 		m_nCurrentBit = 0;
+
 		int frameCropLeftOffset = 0;
 		int frameCropRightOffset = 0;
 		int frameCropTopOffset = 0;
@@ -254,7 +274,64 @@ cH264Parser::cH264Parser(AVPacket *avpkt, int maxFrameNum)
 			subHeightC * ((frameCropBottomOffset * 2) + (frameCropTopOffset * 2));
 	}
 
-	// part 3: parse slice header
+	// part 3: parse h264 PPS
+	int ppsOffset = GetPPSOffset();
+
+	// PPS is available
+	if (ppsOffset != -1) {
+		m_hasPPS = true;
+
+		m_pStart = &m_pAvpkt->data[ppsOffset + 4];
+		m_nLength = m_pAvpkt->size - ppsOffset - 4;
+		m_nCurrentBit = 0;
+
+		ReadExponentialGolombCode(); // PicParameterSetId
+		ReadExponentialGolombCode(); // SeqParameterSetId
+
+		ReadBit(); // entropy_coding_mode_flag
+		ReadBit(); // bottom_field_pic_order_in_frame_present_flag
+
+		int num_slice_groups_minus1 = ReadExponentialGolombCode();
+		if (num_slice_groups_minus1 > 0) {
+			int slice_group_map_type = ReadExponentialGolombCode();
+
+			if (slice_group_map_type == 0) {
+				for (int i = 0; i <= num_slice_groups_minus1; i++)
+					ReadExponentialGolombCode(); // run_length_minus1
+			} else if (slice_group_map_type == 2) {
+				for (int i = 0; i < num_slice_groups_minus1; i++) {
+					ReadExponentialGolombCode(); // top_left
+					ReadExponentialGolombCode(); // bottom_right
+				}
+			} else if (slice_group_map_type == 3 ||
+			           slice_group_map_type == 4 ||
+			           slice_group_map_type == 5) {
+				ReadBit();                    // slice_group_change_direction_flag
+				ReadExponentialGolombCode();  // slice_group_change_rate_minus1
+			} else if (slice_group_map_type == 6) {
+				int pic_size_in_map_units_minus1 = ReadExponentialGolombCode();
+
+				int bits = 0;
+				while ((1 << bits) < (num_slice_groups_minus1 + 1)) {
+					bits++;
+				}
+
+				for (int i = 0; i <= pic_size_in_map_units_minus1; i++) {
+					for (int b = 0; b < bits; b++) {
+						ReadBit(); // slice_group_id
+					}
+				}
+			}
+		}
+
+		m_ppsNumRefIdxL0DefaultActiveMinus1 = ReadExponentialGolombCode();
+		m_ppsNumRefIdxL1DefaultActiveMinus1 = ReadExponentialGolombCode();
+
+		m_numRefIdxL0Active = m_ppsNumRefIdxL0DefaultActiveMinus1 + 1;
+		m_numRefIdxL1Active = m_ppsNumRefIdxL1DefaultActiveMinus1 + 1;
+	}
+
+	// part 4: parse slice header
 	int sliceOffset = GetSliceOffset();
 
 	// slice is available
@@ -282,43 +359,104 @@ cH264Parser::cH264Parser(AVPacket *avpkt, int maxFrameNum)
 		if (m_isIDR)
 			ReadExponentialGolombCode(); // idr_pic_id
 
-		// Only care about P-slice reference behavior
 		m_refMods.clear();
-		m_refListModFlagL0 = false;
-		m_numRefIdxL0Active = 1;
+		bool refListModFlagL0;
+		bool refListModFlagL1;
 
 		if (m_sliceType == 0) { // P-slice
-			m_naluString += " -P-    ";
+			m_naluString += "         -P-    ";
+
 			int num_ref_idx_override = ReadBit();
 
 			if (num_ref_idx_override)
 				m_numRefIdxL0Active = ReadExponentialGolombCode() + 1;
-			else
-				m_numRefIdxL0Active = 1;
+			 else
+				m_numRefIdxL0Active = m_ppsNumRefIdxL0DefaultActiveMinus1 + 1;
 
-			m_refListModFlagL0 = ReadBit();
+			refListModFlagL0 = ReadBit();
 
-			if (m_refListModFlagL0) {
+			if (refListModFlagL0) {
 				int idc;
 				do {
 					idc = ReadExponentialGolombCode();
 
 					if (idc == 0 || idc == 1) {
 						RefPicMod mod;
+						mod.list = 0;
 						mod.idc = idc;
 						mod.abs_diff_pic_num_minus1 = ReadExponentialGolombCode();
 						m_refMods.push_back(mod);
-					} else if (idc == 2) {
-						ReadExponentialGolombCode(); // ignore long-term
+					} else if (idc == 2) { // ignore long-term ?
+						RefPicMod mod;
+						mod.list = 0;
+						mod.idc = idc;
+						mod.long_term_pic_num = ReadExponentialGolombCode();
+						m_refMods.push_back(mod);
 					}
 				} while (idc != 3);
 			}
 		} else if (m_sliceType == 1) { // B-slice
-			m_naluString += "     -B-";
+			m_naluString += "            -B- ";
+
+			int num_ref_idx_override = ReadBit();
+
+			if (num_ref_idx_override) {
+				m_numRefIdxL0Active = ReadExponentialGolombCode() + 1;
+				m_numRefIdxL1Active = ReadExponentialGolombCode() + 1;
+			} else {
+				m_numRefIdxL0Active = m_ppsNumRefIdxL0DefaultActiveMinus1 + 1;
+				m_numRefIdxL1Active = m_ppsNumRefIdxL1DefaultActiveMinus1 + 1;
+			}
+
+			// ----- List 0 -----
+			refListModFlagL0 = ReadBit();
+
+			if (refListModFlagL0) {
+				int idc;
+				do {
+					idc = ReadExponentialGolombCode();
+					if (idc == 0 || idc == 1) {
+						RefPicMod mod;
+						mod.list = 0;
+						mod.idc = idc;
+						mod.abs_diff_pic_num_minus1 = ReadExponentialGolombCode();
+						m_refMods.push_back(mod);
+					} else if (idc == 2) {
+						RefPicMod mod;
+						mod.list = 0;
+						mod.idc = idc;
+						mod.long_term_pic_num = ReadExponentialGolombCode();
+						m_refMods.push_back(mod);
+					}
+				} while (idc != 3);
+			}
+
+			// ----- List 1 -----
+			refListModFlagL1 = ReadBit();
+
+			if (refListModFlagL1) {
+				int idc;
+				do {
+					idc = ReadExponentialGolombCode();
+					if (idc == 0 || idc == 1) {
+						RefPicMod mod;
+						mod.list = 1;
+						mod.idc = idc;
+						mod.abs_diff_pic_num_minus1 = ReadExponentialGolombCode();
+						m_refMods.push_back(mod);
+					} else if (idc == 2) {
+						RefPicMod mod;
+						mod.list = 1;
+						mod.idc = idc;
+						mod.long_term_pic_num = ReadExponentialGolombCode();
+						m_refMods.push_back(mod);
+					}
+				} while (idc != 3);
+			}
 		} else if (m_sliceType == 2) { // I-slice
 			m_naluString += " -I-    ";
 		} else if (m_sliceType == 3) { // SP-slice
-			m_naluString += " -SP-   ";
+			m_naluString += "       -SP-   ";
 		} else if (m_sliceType == 5) { // SI-slice
 			m_naluString += " -SI-   ";
 		}
@@ -327,25 +465,53 @@ cH264Parser::cH264Parser(AVPacket *avpkt, int maxFrameNum)
 
 void cH264Parser::AddInvalidReference(int modRef)
 {
-	m_invalidReferences += " ";
-	m_invalidReferences += std::to_string(modRef);
+	m_invalidReferences.insert(modRef);
 	m_hasInvalidReferences = true;
 }
 
-void cH264Parser::MarkInvalidReference(void)
+void cH264Parser::AddValidReference(int modRef)
+{
+	m_validReferences.insert(modRef);
+	m_hasValidReferences = true;
+}
+
+void cH264Parser::PrintInvalidReference(void)
 {
 	if (!m_hasInvalidReferences)
 		return;
 
-	m_naluString += " <-- invalid reference to ";
-	m_naluString += m_invalidReferences;
+	m_naluString += " !!!";
+	for (auto r : m_invalidReferences) {
+		m_naluString += " ";
+		m_naluString += std::to_string(r);
+	}
+}
+
+void cH264Parser::PrintValidReference(void)
+{
+	if (!m_hasValidReferences)
+		return;
+
+	m_naluString += " -->";
+	for (auto r : m_validReferences) {
+		m_naluString += " ";
+		m_naluString += std::to_string(r);
+	}
 }
 
 void cH264Parser::AddFrameNumber(int num)
 {
-	m_naluString += " (ref ";
-	m_naluString += std::to_string(num);
-	m_naluString += ")";
+	if (num != -1) {
+		if (num < 10)
+			m_naluString += "#  ";
+		else if (num < 100)
+			m_naluString += "# ";
+		else
+			m_naluString += "#";
+		m_naluString += std::to_string(num);
+	} else {
+		m_naluString += "    ";
+	}
 }
 
 /**

--- a/h264parser.cpp
+++ b/h264parser.cpp
@@ -386,12 +386,15 @@ cH264Parser::cH264Parser(AVPacket *avpkt, int maxFrameNum, int refIdxL0, int ref
 						mod.idc = idc;
 						mod.abs_diff_pic_num_minus1 = ReadExponentialGolombCode();
 						m_refMods.push_back(mod);
-					} else if (idc == 2) { // ignore long-term ?
+					// ignore long-term ?
+					/*
+					} else if (idc == 2) {
 						RefPicMod mod;
 						mod.list = 0;
 						mod.idc = idc;
 						mod.long_term_pic_num = ReadExponentialGolombCode();
 						m_refMods.push_back(mod);
+					*/
 					}
 				} while (idc != 3);
 			}
@@ -421,12 +424,15 @@ cH264Parser::cH264Parser(AVPacket *avpkt, int maxFrameNum, int refIdxL0, int ref
 						mod.idc = idc;
 						mod.abs_diff_pic_num_minus1 = ReadExponentialGolombCode();
 						m_refMods.push_back(mod);
+					// ignore long-term ?
+					/*
 					} else if (idc == 2) {
 						RefPicMod mod;
 						mod.list = 0;
 						mod.idc = idc;
 						mod.long_term_pic_num = ReadExponentialGolombCode();
 						m_refMods.push_back(mod);
+					*/
 					}
 				} while (idc != 3);
 			}
@@ -444,12 +450,15 @@ cH264Parser::cH264Parser(AVPacket *avpkt, int maxFrameNum, int refIdxL0, int ref
 						mod.idc = idc;
 						mod.abs_diff_pic_num_minus1 = ReadExponentialGolombCode();
 						m_refMods.push_back(mod);
+					// ignore long-term ?
+					/*
 					} else if (idc == 2) {
 						RefPicMod mod;
 						mod.list = 1;
 						mod.idc = idc;
 						mod.long_term_pic_num = ReadExponentialGolombCode();
 						m_refMods.push_back(mod);
+					*/
 					}
 				} while (idc != 3);
 			}
@@ -463,10 +472,13 @@ cH264Parser::cH264Parser(AVPacket *avpkt, int maxFrameNum, int refIdxL0, int ref
 	}
 }
 
-void cH264Parser::AddInvalidReference(int modRef)
+void cH264Parser::AddInvalidReference(int modRef, int frameNumber)
 {
 	m_invalidReferences.insert(modRef);
 	m_hasInvalidReferences = true;
+
+	if (modRef < frameNumber)
+		m_hasInvalidBackwardReferences = true;
 }
 
 void cH264Parser::AddValidReference(int modRef)

--- a/h264parser.cpp
+++ b/h264parser.cpp
@@ -410,7 +410,7 @@ cH264Parser::cH264Parser(AVPacket *avpkt, int maxFrameNum, int refIdxL0, int ref
 					idc = ReadExponentialGolombCode();
 
 					if (idc == 0 || idc == 1) {
-						RefPicMod mod;
+						RefPicMod mod {};
 						mod.list = 0;
 						mod.idc = idc;
 						mod.abs_diff_pic_num_minus1 = ReadExponentialGolombCode();
@@ -418,7 +418,7 @@ cH264Parser::cH264Parser(AVPacket *avpkt, int maxFrameNum, int refIdxL0, int ref
 					// ignore long-term ?
 					/*
 					} else if (idc == 2) {
-						RefPicMod mod;
+						RefPicMod mod {};
 						mod.list = 0;
 						mod.idc = idc;
 						mod.long_term_pic_num = ReadExponentialGolombCode();
@@ -448,7 +448,7 @@ cH264Parser::cH264Parser(AVPacket *avpkt, int maxFrameNum, int refIdxL0, int ref
 				do {
 					idc = ReadExponentialGolombCode();
 					if (idc == 0 || idc == 1) {
-						RefPicMod mod;
+						RefPicMod mod {};
 						mod.list = 0;
 						mod.idc = idc;
 						mod.abs_diff_pic_num_minus1 = ReadExponentialGolombCode();
@@ -456,7 +456,7 @@ cH264Parser::cH264Parser(AVPacket *avpkt, int maxFrameNum, int refIdxL0, int ref
 					// ignore long-term ?
 					/*
 					} else if (idc == 2) {
-						RefPicMod mod;
+						RefPicMod mod {};
 						mod.list = 0;
 						mod.idc = idc;
 						mod.long_term_pic_num = ReadExponentialGolombCode();
@@ -474,7 +474,7 @@ cH264Parser::cH264Parser(AVPacket *avpkt, int maxFrameNum, int refIdxL0, int ref
 				do {
 					idc = ReadExponentialGolombCode();
 					if (idc == 0 || idc == 1) {
-						RefPicMod mod;
+						RefPicMod mod {};
 						mod.list = 1;
 						mod.idc = idc;
 						mod.abs_diff_pic_num_minus1 = ReadExponentialGolombCode();
@@ -482,7 +482,7 @@ cH264Parser::cH264Parser(AVPacket *avpkt, int maxFrameNum, int refIdxL0, int ref
 					// ignore long-term ?
 					/*
 					} else if (idc == 2) {
-						RefPicMod mod;
+						RefPicMod mod {};
 						mod.list = 1;
 						mod.idc = idc;
 						mod.long_term_pic_num = ReadExponentialGolombCode();

--- a/h264parser.h
+++ b/h264parser.h
@@ -77,11 +77,12 @@ public:
 	void BuildInvalidReferenceString(int frameNumber);
 	void BuildValidReferenceString(void);
 	void AddFrameNumber(int);
-	void AddInvalidReference(int);
+	void AddInvalidReference(int, int);
 	void AddValidReference(int);
 	int GetNumRefIdxL0Active(void) { return m_numRefIdxL0Active; };
 	int GetNumRefIdxL1Active(void) { return m_numRefIdxL1Active; };
 	bool HasInvalidReferences(void) { return m_hasInvalidReferences; };
+	bool HasInvalidBackwardReferences(void) { return m_hasInvalidBackwardReferences; };
 
 private:
 	AVPacket *m_pAvpkt;
@@ -108,6 +109,7 @@ private:
 	int  m_log2MaxFrameNumMinus4 = -4; // from SPS
 	std::vector<RefPicMod> m_refMods;
 	bool m_hasInvalidReferences = false;
+	bool m_hasInvalidBackwardReferences = false;
 	bool m_hasValidReferences = false;
 
 	int m_ppsNumRefIdxL0DefaultActiveMinus1 = -1; // from PPS

--- a/h264parser.h
+++ b/h264parser.h
@@ -81,6 +81,7 @@ public:
 	void AddValidReference(int);
 	int GetNumRefIdxL0Active(void) { return m_numRefIdxL0Active; };
 	int GetNumRefIdxL1Active(void) { return m_numRefIdxL1Active; };
+	bool HasInvalidReferences(void) { return m_hasInvalidReferences; };
 
 private:
 	AVPacket *m_pAvpkt;

--- a/h264parser.h
+++ b/h264parser.h
@@ -74,8 +74,8 @@ public:
 	int GetLog2MaxFrameNumMinus4() const { return m_log2MaxFrameNumMinus4; }
 	int GetPpsNumRefIdxL0DefaultActiveMinus1(void) { return m_ppsNumRefIdxL0DefaultActiveMinus1; };
 	int GetPpsNumRefIdxL1DefaultActiveMinus1(void) { return m_ppsNumRefIdxL1DefaultActiveMinus1; };
-	void PrintInvalidReference(void);
-	void PrintValidReference(void);
+	void BuildInvalidReferenceString(int frameNumber);
+	void BuildValidReferenceString(void);
 	void AddFrameNumber(int);
 	void AddInvalidReference(int);
 	void AddValidReference(int);

--- a/h264parser.h
+++ b/h264parser.h
@@ -83,16 +83,19 @@ public:
 	int GetNumRefIdxL1Active(void) { return m_numRefIdxL1Active; };
 	bool HasInvalidReferences(void) { return m_hasInvalidReferences; };
 	bool HasInvalidBackwardReferences(void) { return m_hasInvalidBackwardReferences; };
+	bool HasParseError(void) const { return m_parseError; };
 
 private:
 	AVPacket *m_pAvpkt;
 	const unsigned char *m_pStart;
+	std::vector<uint8_t> m_rbsp;
 	unsigned short m_nLength;
 	int m_nCurrentBit;
 
 	int m_nalutype = 0;
 	bool m_hasSPS = false;
 	bool m_hasPPS = false;
+	bool m_parseError = false;
 
 	int m_width = 0;
 	int m_height = 0;
@@ -124,6 +127,7 @@ private:
 	int GetSPSOffset(void);
 	int GetPPSOffset(void);
 	int GetSliceOffset(void);
+	void ConvertEBSPtoRBSP(const uint8_t *, int);
 };
 
 #endif

--- a/h264parser.h
+++ b/h264parser.h
@@ -55,15 +55,20 @@ private:
 
 public:
 	cH264Parser(AVPacket *, int, int, int);
+	void BuildInvalidReferenceString(int);
+	void BuildValidReferenceString(void);
+	void AddFrameNumber(int);
+	void AddInvalidReference(int, int);
+	void AddValidReference(int);
+	void PrintNalUnits(void);
+	void PrintStreamData(void);
+
+	std::string GetNalUnitString(void) { return m_naluString; };
 	int GetWidth(void) { return m_width; };
 	int GetHeight(void) { return m_height; };
 	bool IsMbaff(void) { return m_mbaff; };
 	bool HasSPS(void) { return m_hasSPS; };
 	bool HasPPS(void) { return m_hasPPS; };
-	void PrintNalUnits(void);
-	std::string GetNalUnitString(void) { return m_naluString; };
-	void PrintStreamData(void);
-
 	bool IsPSlice() const { return m_sliceType == 0; }
 	bool IsBSlice() const { return m_sliceType == 1; }
 	bool IsISlice() const { return m_sliceType == 2; }
@@ -74,11 +79,6 @@ public:
 	int GetLog2MaxFrameNumMinus4() const { return m_log2MaxFrameNumMinus4; }
 	int GetPpsNumRefIdxL0DefaultActiveMinus1(void) { return m_ppsNumRefIdxL0DefaultActiveMinus1; };
 	int GetPpsNumRefIdxL1DefaultActiveMinus1(void) { return m_ppsNumRefIdxL1DefaultActiveMinus1; };
-	void BuildInvalidReferenceString(int frameNumber);
-	void BuildValidReferenceString(void);
-	void AddFrameNumber(int);
-	void AddInvalidReference(int, int);
-	void AddValidReference(int);
 	int GetNumRefIdxL0Active(void) { return m_numRefIdxL0Active; };
 	int GetNumRefIdxL1Active(void) { return m_numRefIdxL1Active; };
 	bool HasInvalidReferences(void) { return m_hasInvalidReferences; };
@@ -93,30 +93,30 @@ private:
 	int m_nCurrentBit;
 
 	int m_nalutype = 0;
-	bool m_hasSPS = false;
-	bool m_hasPPS = false;
-	bool m_parseError = false;
-
 	int m_width = 0;
 	int m_height = 0;
-	bool m_mbaff = false;
-	std::string m_naluString;
-	std::set<int> m_invalidReferences;
-	std::set<int> m_validReferences;
-
-	int  m_sliceType = -1;      // normalized: 0=P, 2=I
-	int  m_frameNum = -1;
-	int  m_nalRefIdc = 0;
+	bool m_hasSPS = false;
+	bool m_hasPPS = false;
 	bool m_isIDR = false;
 	bool m_isReference = false;
-	int  m_log2MaxFrameNumMinus4 = -4; // from SPS
+	bool m_mbaff = false;
+	bool m_parseError = false;
+
+	std::string m_naluString;
+
+	int m_sliceType = -1;      // normalized: 0=P, 2=I
+	int m_frameNum = -1;
+	int m_nalRefIdc = 0;
+	std::set<int> m_invalidReferences;
+	std::set<int> m_validReferences;
 	std::vector<RefPicMod> m_refMods;
 	bool m_hasInvalidReferences = false;
 	bool m_hasInvalidBackwardReferences = false;
 	bool m_hasValidReferences = false;
 
-	int m_ppsNumRefIdxL0DefaultActiveMinus1 = -1; // from PPS
-	int m_ppsNumRefIdxL1DefaultActiveMinus1 = -1; // from PPS
+	int m_log2MaxFrameNumMinus4 = -4;             // saved from SPS
+	int m_ppsNumRefIdxL0DefaultActiveMinus1 = -1; // saved from PPS
+	int m_ppsNumRefIdxL1DefaultActiveMinus1 = -1; // saved from PPS
 	int m_numRefIdxL0Active;
 	int m_numRefIdxL1Active;
 

--- a/h264parser.h
+++ b/h264parser.h
@@ -62,6 +62,7 @@ public:
 	void PrintStreamData(void);
 
 	bool IsPSlice() const { return m_sliceType == 0; }
+	bool IsBSlice() const { return m_sliceType == 1; }
 	bool IsIDR() const { return m_isIDR; }
 	bool IsReference() const { return m_isReference; }
 	int GetFrameNum() const { return m_frameNum; }

--- a/h264parser.h
+++ b/h264parser.h
@@ -51,7 +51,7 @@ private:
 	};
 
 public:
-	cH264Parser(AVPacket *);
+	cH264Parser(AVPacket *, int);
 	int GetWidth(void) { return m_width; };
 	int GetHeight(void) { return m_height; };
 	bool IsIFrame(void);
@@ -69,6 +69,9 @@ public:
 	int GetNumRefIdxL0() const { return m_numRefIdxL0Active; }
 	const std::vector<RefPicMod>& GetRefMods() const { return m_refMods; }
 	int GetLog2MaxFrameNumMinus4() const { return m_log2MaxFrameNumMinus4; }
+	void MarkInvalidReference(void);
+	void AddFrameNumber(int);
+	void AddInvalidReference(int);
 
 private:
 	AVPacket *m_pAvpkt;
@@ -83,6 +86,7 @@ private:
 	int m_height = 0;
 	bool m_mbaff = false;
 	std::string m_naluString;
+	std::string m_invalidReferences;
 
 	int  m_sliceType = -1;      // normalized: 0=P, 2=I
 	int  m_frameNum = -1;
@@ -93,6 +97,7 @@ private:
 	int  m_numRefIdxL0Active = 1;
 	int  m_log2MaxFrameNumMinus4 = 0; // from SPS
 	std::vector<RefPicMod> m_refMods;
+	bool m_hasInvalidReferences = false;
 
 	unsigned int ReadBit(void);
 	unsigned int ReadBits(int);

--- a/h264parser.h
+++ b/h264parser.h
@@ -57,7 +57,6 @@ public:
 	cH264Parser(AVPacket *, int, int, int);
 	int GetWidth(void) { return m_width; };
 	int GetHeight(void) { return m_height; };
-	bool IsIFrame(void);
 	bool IsMbaff(void) { return m_mbaff; };
 	bool HasSPS(void) { return m_hasSPS; };
 	bool HasPPS(void) { return m_hasPPS; };
@@ -67,6 +66,7 @@ public:
 
 	bool IsPSlice() const { return m_sliceType == 0; }
 	bool IsBSlice() const { return m_sliceType == 1; }
+	bool IsISlice() const { return m_sliceType == 2; }
 	bool IsIDR() const { return m_isIDR; }
 	bool IsReference() const { return m_isReference; }
 	int GetFrameNum() const { return m_frameNum; }

--- a/h264parser.h
+++ b/h264parser.h
@@ -20,17 +20,22 @@
 #ifndef __H264PARSER_H
 #define __H264PARSER_H
 
+#include <string>
+
 extern "C" {
 #include <libavcodec/avcodec.h>
 }
 
 typedef enum {
 	NALU_TYPE_NON_IDR = (1 << 0),
-	NALU_TYPE_IDR     = (1 << 1),
-	NALU_TYPE_SEI     = (1 << 2),
-	NALU_TYPE_SPS     = (1 << 3),
-	NALU_TYPE_PPS     = (1 << 4),
-	NALU_TYPE_AUD     = (1 << 5)
+	NALU_TYPE_PART_A  = (1 << 1),
+	NALU_TYPE_PART_B  = (1 << 2),
+	NALU_TYPE_PART_C  = (1 << 3),
+	NALU_TYPE_IDR     = (1 << 4),
+	NALU_TYPE_SEI     = (1 << 5),
+	NALU_TYPE_SPS     = (1 << 6),
+	NALU_TYPE_PPS     = (1 << 7),
+	NALU_TYPE_AUD     = (1 << 8)
 } NalUnitTypes;
 
 /**
@@ -44,6 +49,10 @@ public:
 	int GetHeight(void) { return m_height; };
 	bool IsIFrame(void);
 	bool IsMbaff(void) { return m_mbaff; };
+	bool HasSPS(void) { return m_hasSPS; };
+	void PrintNalUnits(void);
+	std::string GetNalUnitString(void) { return m_naluString; };
+	void PrintStreamData(void);
 
 private:
 	AVPacket *m_pAvpkt;
@@ -52,10 +61,12 @@ private:
 	int m_nCurrentBit;
 
 	int m_nalutype = 0;
+	bool m_hasSPS = false;
 
 	int m_width = 0;
 	int m_height = 0;
 	bool m_mbaff = false;
+	std::string m_naluString;
 
 	unsigned int ReadBit(void);
 	unsigned int ReadBits(int);

--- a/h264parser.h
+++ b/h264parser.h
@@ -21,6 +21,7 @@
 #define __H264PARSER_H
 
 #include <string>
+#include <vector>
 
 extern "C" {
 #include <libavcodec/avcodec.h>
@@ -43,6 +44,12 @@ typedef enum {
  */
 class cH264Parser
 {
+private:
+	struct RefPicMod {
+		int idc;
+		int abs_diff_pic_num_minus1;
+	};
+
 public:
 	cH264Parser(AVPacket *);
 	int GetWidth(void) { return m_width; };
@@ -53,6 +60,15 @@ public:
 	void PrintNalUnits(void);
 	std::string GetNalUnitString(void) { return m_naluString; };
 	void PrintStreamData(void);
+
+	bool IsPSlice() const { return m_sliceType == 0; }
+	bool IsIDR() const { return m_isIDR; }
+	bool IsReference() const { return m_isReference; }
+	int GetFrameNum() const { return m_frameNum; }
+	bool HasRefListModification() const { return m_refListModFlagL0; }
+	int GetNumRefIdxL0() const { return m_numRefIdxL0Active; }
+	const std::vector<RefPicMod>& GetRefMods() const { return m_refMods; }
+	int GetLog2MaxFrameNumMinus4() const { return m_log2MaxFrameNumMinus4; }
 
 private:
 	AVPacket *m_pAvpkt;
@@ -68,10 +84,22 @@ private:
 	bool m_mbaff = false;
 	std::string m_naluString;
 
+	int  m_sliceType = -1;      // normalized: 0=P, 2=I
+	int  m_frameNum = -1;
+	int  m_nalRefIdc = 0;
+	bool m_isIDR = false;
+	bool m_isReference = false;
+	bool m_refListModFlagL0 = false;
+	int  m_numRefIdxL0Active = 1;
+	int  m_log2MaxFrameNumMinus4 = 0; // from SPS
+	std::vector<RefPicMod> m_refMods;
+
 	unsigned int ReadBit(void);
 	unsigned int ReadBits(int);
 	unsigned int ReadExponentialGolombCode(void);
 	unsigned int ReadSE(void);
+	int GetSPSOffset(void);
+	int GetSliceOffset(void);
 };
 
 #endif

--- a/h264parser.h
+++ b/h264parser.h
@@ -20,6 +20,7 @@
 #ifndef __H264PARSER_H
 #define __H264PARSER_H
 
+#include <set>
 #include <string>
 #include <vector>
 
@@ -46,17 +47,20 @@ class cH264Parser
 {
 private:
 	struct RefPicMod {
+		int list;
 		int idc;
 		int abs_diff_pic_num_minus1;
+		int long_term_pic_num;
 	};
 
 public:
-	cH264Parser(AVPacket *, int);
+	cH264Parser(AVPacket *, int, int, int);
 	int GetWidth(void) { return m_width; };
 	int GetHeight(void) { return m_height; };
 	bool IsIFrame(void);
 	bool IsMbaff(void) { return m_mbaff; };
 	bool HasSPS(void) { return m_hasSPS; };
+	bool HasPPS(void) { return m_hasPPS; };
 	void PrintNalUnits(void);
 	std::string GetNalUnitString(void) { return m_naluString; };
 	void PrintStreamData(void);
@@ -66,13 +70,17 @@ public:
 	bool IsIDR() const { return m_isIDR; }
 	bool IsReference() const { return m_isReference; }
 	int GetFrameNum() const { return m_frameNum; }
-	bool HasRefListModification() const { return m_refListModFlagL0; }
-	int GetNumRefIdxL0() const { return m_numRefIdxL0Active; }
 	const std::vector<RefPicMod>& GetRefMods() const { return m_refMods; }
 	int GetLog2MaxFrameNumMinus4() const { return m_log2MaxFrameNumMinus4; }
-	void MarkInvalidReference(void);
+	int GetPpsNumRefIdxL0DefaultActiveMinus1(void) { return m_ppsNumRefIdxL0DefaultActiveMinus1; };
+	int GetPpsNumRefIdxL1DefaultActiveMinus1(void) { return m_ppsNumRefIdxL1DefaultActiveMinus1; };
+	void PrintInvalidReference(void);
+	void PrintValidReference(void);
 	void AddFrameNumber(int);
 	void AddInvalidReference(int);
+	void AddValidReference(int);
+	int GetNumRefIdxL0Active(void) { return m_numRefIdxL0Active; };
+	int GetNumRefIdxL1Active(void) { return m_numRefIdxL1Active; };
 
 private:
 	AVPacket *m_pAvpkt;
@@ -82,29 +90,36 @@ private:
 
 	int m_nalutype = 0;
 	bool m_hasSPS = false;
+	bool m_hasPPS = false;
 
 	int m_width = 0;
 	int m_height = 0;
 	bool m_mbaff = false;
 	std::string m_naluString;
-	std::string m_invalidReferences;
+	std::set<int> m_invalidReferences;
+	std::set<int> m_validReferences;
 
 	int  m_sliceType = -1;      // normalized: 0=P, 2=I
 	int  m_frameNum = -1;
 	int  m_nalRefIdc = 0;
 	bool m_isIDR = false;
 	bool m_isReference = false;
-	bool m_refListModFlagL0 = false;
-	int  m_numRefIdxL0Active = 1;
-	int  m_log2MaxFrameNumMinus4 = 0; // from SPS
+	int  m_log2MaxFrameNumMinus4 = -4; // from SPS
 	std::vector<RefPicMod> m_refMods;
 	bool m_hasInvalidReferences = false;
+	bool m_hasValidReferences = false;
+
+	int m_ppsNumRefIdxL0DefaultActiveMinus1 = -1; // from PPS
+	int m_ppsNumRefIdxL1DefaultActiveMinus1 = -1; // from PPS
+	int m_numRefIdxL0Active;
+	int m_numRefIdxL1Active;
 
 	unsigned int ReadBit(void);
 	unsigned int ReadBits(int);
 	unsigned int ReadExponentialGolombCode(void);
 	unsigned int ReadSE(void);
 	int GetSPSOffset(void);
+	int GetPPSOffset(void);
 	int GetSliceOffset(void);
 };
 

--- a/po/de_DE.po
+++ b/po/de_DE.po
@@ -308,6 +308,9 @@ msgstr "  (mindestens: %d)"
 msgid "  fallback after num packets"
 msgstr "  Fallback nach Anzahl Paketen"
 
+msgid " Parse H.264 stream start"
+msgstr " Beginn eines H.264 streams parsen"
+
 msgid " OSD settings"
 msgstr " OSD Einstellungen"
 

--- a/po/de_DE.po
+++ b/po/de_DE.po
@@ -311,6 +311,9 @@ msgstr "  Fallback nach Anzahl Paketen"
 msgid " Parse H.264 stream start"
 msgstr " Beginn eines H.264 streams parsen"
 
+msgid " Drop invalid H.264 P-Frames"
+msgstr " Defekte H.264 P-Frames verwerfen"
+
 msgid " OSD settings"
 msgstr " OSD Einstellungen"
 

--- a/po/de_DE.po
+++ b/po/de_DE.po
@@ -292,12 +292,6 @@ msgstr " Video Einstellungen"
 msgid " Disable deinterlacer"
 msgstr " Deaktiviere Deinterlacer"
 
-msgid " H.264 HW dec needs I-Frame"
-msgstr " H.264 HW Dek. benötigt I-Frame"
-
-msgid " H.264 HW dec needs width and height"
-msgstr " H.264 HW Dek. benötigt Größe"
-
 msgid " Enable SW decoder fallback"
 msgstr " Aktiviere SW Dekoder Fallback"
 
@@ -308,11 +302,17 @@ msgstr "  (mindestens: %d)"
 msgid "  fallback after num packets"
 msgstr "  Fallback nach Anzahl Paketen"
 
-msgid " Parse H.264 stream start"
-msgstr " Beginn eines H.264 streams parsen"
+msgid " H.264: Wait for I-Frames"
+msgstr " H.264: Auf I-Frame warten"
 
-msgid " Drop invalid H.264 P-Frames"
-msgstr " Defekte H.264 P-Frames verwerfen"
+msgid " H.264: Decoder needs video size for init"
+msgstr " H.264: Dekoder benötigt Videogröße für Init"
+
+msgid " H.264: Parse stream until num I-Frames"
+msgstr " H.264: Stream parsen bis Anzahl I-Frames"
+
+msgid " H.264: Drop invalid P-Frames until num I-Frames"
+msgstr " H.264: Defekte P-Frames verwerfen bis Anzahl I-Frames"
 
 msgid " OSD settings"
 msgstr " OSD Einstellungen"

--- a/softhdsetupmenu.cpp
+++ b/softhdsetupmenu.cpp
@@ -209,15 +209,15 @@ void cMenuSetupSoft::Create(void)
 
 		Add(SeparatorName(tr(" Video settings")));
 		Add(new cMenuEditBoolItem(tr(" Disable deinterlacer"), &m_cDisableDeint, trVDR("no"), trVDR("yes")));
-		Add(new cMenuEditBoolItem(tr(" H.264 HW dec needs I-Frame"), &m_cDecoderNeedsIFrame, trVDR("no"), trVDR("yes")));
-		Add(new cMenuEditBoolItem(tr(" H.264 HW dec needs width and height"), &m_cParseH264Dimensions, trVDR("no"), trVDR("yes")));
 		Add(new cMenuEditBoolItem(tr(" Enable SW decoder fallback"), &m_cDecoderFallbackToSw, trVDR("no"), trVDR("yes")));
 		if (m_cDecoderFallbackToSw) {
 			Add(new cOsdItem(cString::sprintf(tr("  (minimum: %d)"), m_pConfig->GetDecoderNeedsMaxPackets() + 1), osUnknown, false));
 			Add(new cMenuEditIntItem(tr("  fallback after num packets"), &m_cDecoderFallbackToSwNumPkts, 22));
 		}
-		Add(new cMenuEditIntItem(tr(" Parse H.264 stream (num I-Frames)"), &m_cParseH264StreamStart, 0, 20));
-		Add(new cMenuEditIntItem(tr(" Drop invalid P-Frames (num I-Frames)"), &m_cDropInvalidH264PFrames, 0, 20));
+		Add(new cMenuEditBoolItem(tr(" H.264: Wait for I-Frames"), &m_cDecoderNeedsIFrame, trVDR("no"), trVDR("yes")));
+		Add(new cMenuEditBoolItem(tr(" H.264: Decoder needs video size for init"), &m_cParseH264Dimensions, trVDR("no"), trVDR("yes")));
+		Add(new cMenuEditIntItem(tr(" H.264: Parse stream until num I-Frames"), &m_cParseH264StreamStart, 0, 20));
+		Add(new cMenuEditIntItem(tr(" H.264: Drop invalid P-Frames until num I-Frames"), &m_cDropInvalidH264PFrames, 0, 20));
 #ifdef USE_GLES
 		Add(SeparatorName(tr(" OSD settings")));
 		if (!m_pConfig->ConfigDisableOglOsd) {

--- a/softhdsetupmenu.cpp
+++ b/softhdsetupmenu.cpp
@@ -216,7 +216,7 @@ void cMenuSetupSoft::Create(void)
 			Add(new cOsdItem(cString::sprintf(tr("  (minimum: %d)"), m_pConfig->GetDecoderNeedsMaxPackets() + 1), osUnknown, false));
 			Add(new cMenuEditIntItem(tr("  fallback after num packets"), &m_cDecoderFallbackToSwNumPkts, 22));
 		}
-		Add(new cMenuEditBoolItem(tr(" Parse H.264 stream start"), &m_cParseH264StreamStart, trVDR("no"), trVDR("yes")));
+		Add(new cMenuEditIntItem(tr(" Parse H.264 num I-Frames"), &m_cParseH264StreamStart, 0, 20));
 		Add(new cMenuEditBoolItem(tr(" Drop invalid H.264 P-Frames"), &m_cDropInvalidH264PFrames, trVDR("no"), trVDR("yes")));
 #ifdef USE_GLES
 		Add(SeparatorName(tr(" OSD settings")));

--- a/softhdsetupmenu.cpp
+++ b/softhdsetupmenu.cpp
@@ -216,8 +216,8 @@ void cMenuSetupSoft::Create(void)
 			Add(new cOsdItem(cString::sprintf(tr("  (minimum: %d)"), m_pConfig->GetDecoderNeedsMaxPackets() + 1), osUnknown, false));
 			Add(new cMenuEditIntItem(tr("  fallback after num packets"), &m_cDecoderFallbackToSwNumPkts, 22));
 		}
-		Add(new cMenuEditIntItem(tr(" Parse H.264 num I-Frames"), &m_cParseH264StreamStart, 0, 20));
-		Add(new cMenuEditBoolItem(tr(" Drop invalid H.264 P-Frames"), &m_cDropInvalidH264PFrames, trVDR("no"), trVDR("yes")));
+		Add(new cMenuEditIntItem(tr(" Parse H.264 stream (num I-Frames)"), &m_cParseH264StreamStart, 0, 20));
+		Add(new cMenuEditIntItem(tr(" Drop invalid P-Frames (num I-Frames)"), &m_cDropInvalidH264PFrames, 0, 20));
 #ifdef USE_GLES
 		Add(SeparatorName(tr(" OSD settings")));
 		if (!m_pConfig->ConfigDisableOglOsd) {

--- a/softhdsetupmenu.cpp
+++ b/softhdsetupmenu.cpp
@@ -217,6 +217,7 @@ void cMenuSetupSoft::Create(void)
 			Add(new cMenuEditIntItem(tr("  fallback after num packets"), &m_cDecoderFallbackToSwNumPkts, 22));
 		}
 		Add(new cMenuEditBoolItem(tr(" Parse H.264 stream start"), &m_cParseH264StreamStart, trVDR("no"), trVDR("yes")));
+		Add(new cMenuEditBoolItem(tr(" Drop invalid H.264 P-Frames"), &m_cDropInvalidH264PFrames, trVDR("no"), trVDR("yes")));
 #ifdef USE_GLES
 		Add(SeparatorName(tr(" OSD settings")));
 		if (!m_pConfig->ConfigDisableOglOsd) {
@@ -376,6 +377,7 @@ cMenuSetupSoft::cMenuSetupSoft(cSoftHdDevice *device)
 	m_cDecoderFallbackToSw = m_pConfig->ConfigDecoderFallbackToSw;
 	m_cDecoderFallbackToSwNumPkts = m_pConfig->ConfigDecoderFallbackToSwNumPkts;
 	m_cParseH264StreamStart = m_pConfig->ConfigParseH264StreamStart;
+	m_cDropInvalidH264PFrames = m_pConfig->ConfigDropInvalidH264PFrames;
 #ifdef USE_GLES
 	m_cMaxSizeGPUImageCache = m_pConfig->ConfigMaxSizeGPUImageCache;
 #endif
@@ -517,6 +519,7 @@ void cMenuSetupSoft::Store(void)
 	SetupStore("DecoderFallbackToSwNumPkts", m_pConfig->ConfigDecoderFallbackToSwNumPkts = m_cDecoderFallbackToSwNumPkts);
 	m_pDevice->SetDecoderFallbackToSw(m_pConfig->ConfigDecoderFallbackToSw);
 	SetupStore("ParseH264StreamStart", m_pConfig->ConfigParseH264StreamStart = m_cParseH264StreamStart);
+	SetupStore("DropInvalidH264PFrames", m_pConfig->ConfigDropInvalidH264PFrames = m_cDropInvalidH264PFrames);
 #ifdef USE_GLES
 	SetupStore("MaxSizeGPUImageCache", m_pConfig->ConfigMaxSizeGPUImageCache = m_cMaxSizeGPUImageCache);
 #endif

--- a/softhdsetupmenu.cpp
+++ b/softhdsetupmenu.cpp
@@ -216,6 +216,7 @@ void cMenuSetupSoft::Create(void)
 			Add(new cOsdItem(cString::sprintf(tr("  (minimum: %d)"), m_pConfig->GetDecoderNeedsMaxPackets() + 1), osUnknown, false));
 			Add(new cMenuEditIntItem(tr("  fallback after num packets"), &m_cDecoderFallbackToSwNumPkts, 22));
 		}
+		Add(new cMenuEditBoolItem(tr(" Parse H.264 stream start"), &m_cParseH264StreamStart, trVDR("no"), trVDR("yes")));
 #ifdef USE_GLES
 		Add(SeparatorName(tr(" OSD settings")));
 		if (!m_pConfig->ConfigDisableOglOsd) {
@@ -374,6 +375,7 @@ cMenuSetupSoft::cMenuSetupSoft(cSoftHdDevice *device)
 	m_cParseH264Dimensions = m_pConfig->ConfigParseH264Dimensions;
 	m_cDecoderFallbackToSw = m_pConfig->ConfigDecoderFallbackToSw;
 	m_cDecoderFallbackToSwNumPkts = m_pConfig->ConfigDecoderFallbackToSwNumPkts;
+	m_cParseH264StreamStart = m_pConfig->ConfigParseH264StreamStart;
 #ifdef USE_GLES
 	m_cMaxSizeGPUImageCache = m_pConfig->ConfigMaxSizeGPUImageCache;
 #endif
@@ -514,6 +516,7 @@ void cMenuSetupSoft::Store(void)
 	SetupStore("DecoderFallbackToSw", m_pConfig->ConfigDecoderFallbackToSw = m_cDecoderFallbackToSw);
 	SetupStore("DecoderFallbackToSwNumPkts", m_pConfig->ConfigDecoderFallbackToSwNumPkts = m_cDecoderFallbackToSwNumPkts);
 	m_pDevice->SetDecoderFallbackToSw(m_pConfig->ConfigDecoderFallbackToSw);
+	SetupStore("ParseH264StreamStart", m_pConfig->ConfigParseH264StreamStart = m_cParseH264StreamStart);
 #ifdef USE_GLES
 	SetupStore("MaxSizeGPUImageCache", m_pConfig->ConfigMaxSizeGPUImageCache = m_cMaxSizeGPUImageCache);
 #endif

--- a/softhdsetupmenu.h
+++ b/softhdsetupmenu.h
@@ -113,6 +113,7 @@ protected:
 	int m_cParseH264Dimensions;
 	int m_cDecoderFallbackToSw;
 	int m_cDecoderFallbackToSwNumPkts;
+	int m_cParseH264StreamStart;
 #ifdef USE_GLES
 	int m_cMaxSizeGPUImageCache;
 #endif

--- a/softhdsetupmenu.h
+++ b/softhdsetupmenu.h
@@ -114,6 +114,7 @@ protected:
 	int m_cDecoderFallbackToSw;
 	int m_cDecoderFallbackToSwNumPkts;
 	int m_cParseH264StreamStart;
+	int m_cDropInvalidH264PFrames;
 #ifdef USE_GLES
 	int m_cMaxSizeGPUImageCache;
 #endif

--- a/videostream.cpp
+++ b/videostream.cpp
@@ -374,6 +374,81 @@ void cVideoStream::OpenDecoder(void)
 	m_dropInvalidPackets = m_pConfig->ConfigDropInvalidH264PFrames ? m_pConfig->ConfigDropInvalidH264PFrames + 1 : 0;
 }
 
+bool cVideoStream::ParseH264Packet(AVPacket *avpkt)
+{
+	cH264Parser h264Packet(avpkt,
+                               m_log2MaxFrameNumMinus4,
+                               m_ppsNumRefIdxL0DefaultActiveMinus1,
+                               m_ppsNumRefIdxL1DefaultActiveMinus1);
+
+	if (h264Packet.HasSPS()) {
+		m_maxFrameNum = 1 << (h264Packet.GetLog2MaxFrameNumMinus4() + 4);
+		m_log2MaxFrameNumMinus4 = h264Packet.GetLog2MaxFrameNumMinus4();
+	}
+
+	if (h264Packet.HasPPS()) {
+		m_ppsNumRefIdxL0DefaultActiveMinus1 = h264Packet.GetPpsNumRefIdxL0DefaultActiveMinus1();
+		m_ppsNumRefIdxL1DefaultActiveMinus1 = h264Packet.GetPpsNumRefIdxL1DefaultActiveMinus1();
+	}
+
+	int frameNumber = h264Packet.GetFrameNum();
+
+	if (h264Packet.IsReference()) {
+		h264Packet.AddFrameNumber(frameNumber);
+		m_dpbFrames.insert(frameNumber);
+	} else {
+		h264Packet.AddFrameNumber(-1);
+	}
+
+	bool dropPacket = false;
+	if (h264Packet.IsPSlice() || h264Packet.IsBSlice()) {
+		int numRefL0 = h264Packet.GetNumRefIdxL0Active();
+		int numRefL1 = h264Packet.GetNumRefIdxL1Active();
+
+		for (auto& mod : h264Packet.GetRefMods()) {
+			if (mod.idc != 0 && mod.idc != 1)
+				continue;
+
+			int activeRefs = (mod.list == 0) ? numRefL0 : numRefL1;
+			if (activeRefs <= 0)
+				continue;
+
+			// Compute the short-term reference frame number
+			int modRef = -1;
+			int diff = mod.abs_diff_pic_num_minus1 + 1;
+
+			if (mod.idc == 0) { // subtraction
+				modRef = (frameNumber - diff + m_maxFrameNum) % m_maxFrameNum;
+			} else if (mod.idc == 1) { // addition
+				modRef = (frameNumber + diff) % m_maxFrameNum;
+			}
+
+			// Check if this reference exists in the DPB
+			if (m_dpbFrames.find(modRef) == m_dpbFrames.end()) {
+				h264Packet.AddInvalidReference(modRef, frameNumber);
+			} else {
+				h264Packet.AddValidReference(modRef);
+			}
+		}
+
+		// only print invalid references for better readability
+		h264Packet.BuildInvalidReferenceString(frameNumber);
+		// h264Packet.BuildValidReferenceString();
+
+		if (h264Packet.HasInvalidBackwardReferences() && h264Packet.IsPSlice() &&  m_numIFrames < m_dropInvalidPackets) {
+			LOGDEBUG2(L_CODEC, "videostream %s: %s: invalid backward reference, drop P-Frame %d", m_identifier, __FUNCTION__, frameNumber);
+			dropPacket = true;
+		}
+	}
+
+	if (h264Packet.IsISlice())
+		m_numIFrames++;
+
+	m_naluTypesAtStart.push_back(h264Packet.GetNalUnitString());
+
+	return dropPacket;
+}
+
 /**
  * Decodes a reassembled codec packet.
  */
@@ -388,80 +463,13 @@ void cVideoStream::DecodeInput(void)
 	if (m_newStream)
 		OpenDecoder();
 
-	// send packet to decoder
 	AVPacket *avpkt = m_packets.Peek();
-	bool dropPacket = false;
 
 	// log H.264 frames up to the given number of I-Frames
+	bool dropPacket = false;
 	if (avpkt && m_codecId == AV_CODEC_ID_H264 && (m_logPackets || m_dropInvalidPackets) && !m_isResend) {
 		if (m_numIFrames < m_logPackets || m_numIFrames < m_dropInvalidPackets) {
-			cH264Parser h264Packet(m_packets.Peek(),
-		                               m_log2MaxFrameNumMinus4,
-		                               m_ppsNumRefIdxL0DefaultActiveMinus1,
-		                               m_ppsNumRefIdxL1DefaultActiveMinus1);
-			if (h264Packet.HasSPS()) {
-				m_maxFrameNum = 1 << (h264Packet.GetLog2MaxFrameNumMinus4() + 4);
-				m_log2MaxFrameNumMinus4 = h264Packet.GetLog2MaxFrameNumMinus4();
-			}
-
-			if (h264Packet.HasPPS()) {
-				m_ppsNumRefIdxL0DefaultActiveMinus1 = h264Packet.GetPpsNumRefIdxL0DefaultActiveMinus1();
-				m_ppsNumRefIdxL1DefaultActiveMinus1 = h264Packet.GetPpsNumRefIdxL1DefaultActiveMinus1();
-			}
-
-			int frameNumber = h264Packet.GetFrameNum();
-
-			if (h264Packet.IsReference()) {
-				h264Packet.AddFrameNumber(frameNumber);
-				m_dpbFrames.insert(frameNumber);
-			} else {
-				h264Packet.AddFrameNumber(-1);
-			}
-
-			if (h264Packet.IsPSlice() || h264Packet.IsBSlice()) {
-				int numRefL0 = h264Packet.GetNumRefIdxL0Active();
-				int numRefL1 = h264Packet.GetNumRefIdxL1Active();
-
-				for (auto& mod : h264Packet.GetRefMods()) {
-					if (mod.idc != 0 && mod.idc != 1)
-						continue;
-
-					int activeRefs = (mod.list == 0) ? numRefL0 : numRefL1;
-					if (activeRefs <= 0)
-						continue;
-
-					// Compute the short-term reference frame number
-					int modRef = -1;
-					int diff = mod.abs_diff_pic_num_minus1 + 1;
-
-					if (mod.idc == 0) { // subtraction
-						modRef = (frameNumber - diff + m_maxFrameNum) % m_maxFrameNum;
-					} else if (mod.idc == 1) { // addition
-						modRef = (frameNumber + diff) % m_maxFrameNum;
-					}
-
-					// Check if this reference exists in the DPB
-					if (m_dpbFrames.find(modRef) == m_dpbFrames.end()) {
-						h264Packet.AddInvalidReference(modRef, frameNumber);
-					} else {
-						h264Packet.AddValidReference(modRef);
-					}
-				}
-
-				// only print invalid references for better readability
-				h264Packet.BuildInvalidReferenceString(frameNumber);
-				// h264Packet.BuildValidReferenceString();
-
-				if (h264Packet.HasInvalidBackwardReferences() && h264Packet.IsPSlice() &&  m_numIFrames < m_dropInvalidPackets) {
-					LOGDEBUG2(L_CODEC, "videostream %s: %s: invalid backward reference, drop P-Frame %d", m_identifier, __FUNCTION__, frameNumber);
-					dropPacket = true;
-				}
-			}
-
-			if (h264Packet.IsISlice())
-				m_numIFrames++;
-
-			m_naluTypesAtStart.push_back(h264Packet.GetNalUnitString());
+			dropPacket = ParseH264Packet(avpkt);
 		} else if (m_logPackets) {
 			LOGDEBUG("videostream %s: %s: parsed H.264 stream:", m_identifier, __FUNCTION__);
 			for (std::size_t i = 0; i < m_naluTypesAtStart.size(); i++) {
@@ -471,11 +479,8 @@ void cVideoStream::DecodeInput(void)
 		}
 	}
 
-	if (dropPacket) {
-		avpkt = m_packets.Pop();
-		av_packet_free(&avpkt);
-		m_isResend = false;
-	} else {
+	// send packet to decoder
+	if (!dropPacket) {
 		ret = m_pDecoder->SendPacket(avpkt);
 
 		if (ret != AVERROR(EAGAIN) && ret != AVERROR_EOF) {
@@ -488,6 +493,10 @@ void cVideoStream::DecodeInput(void)
 
 		if (!ret && m_pRender->IsTrickSpeed())
 			CheckForcingFrameDecode();
+	} else {
+		avpkt = m_packets.Pop();
+		av_packet_free(&avpkt);
+		m_isResend = false;
 	}
 
 	// receive frame from decoder

--- a/videostream.cpp
+++ b/videostream.cpp
@@ -370,7 +370,7 @@ void cVideoStream::OpenDecoder(void)
 	m_pConfig->CurrentDecoderType = m_pDecoder->IsHardwareDecoder() ? "hardware" : "software";
 	m_pConfig->CurrentDecoderName = m_pDecoder->Name();
 	m_newStream = false;
-	m_logPackets = m_pConfig->ConfigParseH264StreamStart;
+	m_logPackets = m_pConfig->ConfigParseH264StreamStart ? m_pConfig->ConfigParseH264StreamStart + 1 : 0;
 	m_dropInvalidPackets = m_pConfig->ConfigDropInvalidH264PFrames;
 }
 
@@ -394,7 +394,7 @@ void cVideoStream::DecodeInput(void)
 
 	// log nal units of the frames until the second I Frame arrives
 	if (avpkt && m_codecId == AV_CODEC_ID_H264 && (m_logPackets || m_dropInvalidPackets) && !m_isResend) {
-		if (m_numIFrames < 2) {
+		if (m_numIFrames < m_logPackets || m_dropInvalidPackets) {
 			cH264Parser h264Packet(m_packets.Peek(),
 		                               m_log2MaxFrameNumMinus4,
 		                               m_ppsNumRefIdxL0DefaultActiveMinus1,
@@ -452,7 +452,7 @@ void cVideoStream::DecodeInput(void)
 				h264Packet.BuildInvalidReferenceString(frameNumber);
 				// h264Packet.BuildValidReferenceString();
 
-				if (h264Packet.HasInvalidReferences() && h264Packet.IsPSlice() && m_dropInvalidPackets) {
+				if (h264Packet.HasInvalidReferences() && h264Packet.IsPSlice() && m_dropInvalidPackets && m_numIFrames < 2) {
 					LOGDEBUG2(L_CODEC, "videostream %s: %s: invalid reference, drop P-Frame %d", m_identifier, __FUNCTION__, frameNumber);
 					dropPacket = true;
 				}

--- a/videostream.cpp
+++ b/videostream.cpp
@@ -370,7 +370,8 @@ void cVideoStream::OpenDecoder(void)
 	m_pConfig->CurrentDecoderType = m_pDecoder->IsHardwareDecoder() ? "hardware" : "software";
 	m_pConfig->CurrentDecoderName = m_pDecoder->Name();
 	m_newStream = false;
-	m_logFrames = m_pConfig->ConfigParseH264StreamStart;
+	m_logPackets = m_pConfig->ConfigParseH264StreamStart;
+	m_dropInvalidPackets = m_pConfig->ConfigDropInvalidH264PFrames;
 }
 
 /**
@@ -389,11 +390,10 @@ void cVideoStream::DecodeInput(void)
 
 	// send packet to decoder
 	AVPacket *avpkt = m_packets.Peek();
-
-	ret = m_pDecoder->SendPacket(avpkt);
+	bool dropPacket = false;
 
 	// log nal units of the frames until the second I Frame arrives
-	if (!ret && m_codecId == AV_CODEC_ID_H264 && m_logFrames) {
+	if (avpkt && m_codecId == AV_CODEC_ID_H264 && (m_logPackets || m_dropInvalidPackets) && !m_isResend) {
 		if (m_numIFrames < 2) {
 			cH264Parser h264Packet(m_packets.Peek(),
 		                               m_log2MaxFrameNumMinus4,
@@ -451,28 +451,43 @@ void cVideoStream::DecodeInput(void)
 				// only print invalid references for better readability
 				h264Packet.PrintInvalidReference();
 				// h264Packet.PrintValidReference();
+
+				if (h264Packet.HasInvalidReferences() && h264Packet.IsPSlice() && m_dropInvalidPackets) {
+					LOGDEBUG2(L_CODEC, "videostream %s: %s: invalid reference, drop P-Frame %d", m_identifier, __FUNCTION__, frameNumber);
+					dropPacket = true;
+				}
 			}
 
 			if (h264Packet.IsIFrame())
 				m_numIFrames++;
 
 			m_naluTypesAtStart.push_back(h264Packet.GetNalUnitString());
-		} else {
+		} else if (m_logPackets) {
 			LOGDEBUG("videostream %s: %s: parsed H.264 stream:", m_identifier, __FUNCTION__);
 			for (std::size_t i = 0; i < m_naluTypesAtStart.size(); i++) {
 				LOGDEBUG("[H264] (%02d) %s", i, m_naluTypesAtStart[i].c_str());
 			}
-			m_logFrames = false;
+			m_logPackets = false;
 		}
 	}
 
-	if (ret != AVERROR(EAGAIN) && ret != AVERROR_EOF) {
+	if (dropPacket) {
 		avpkt = m_packets.Pop();
 		av_packet_free(&avpkt);
-	}
+	} else {
+		ret = m_pDecoder->SendPacket(avpkt);
 
-	if (!ret && m_pRender->IsTrickSpeed())
-		CheckForcingFrameDecode();
+		if (ret != AVERROR(EAGAIN) && ret != AVERROR_EOF) {
+			avpkt = m_packets.Pop();
+			av_packet_free(&avpkt);
+			m_isResend = false;
+		} else {
+			m_isResend = true;
+		}
+
+		if (!ret && m_pRender->IsTrickSpeed())
+			CheckForcingFrameDecode();
+	}
 
 	// receive frame from decoder
 	ret = m_pDecoder->ReceiveFrame(&frame);

--- a/videostream.cpp
+++ b/videostream.cpp
@@ -371,7 +371,7 @@ void cVideoStream::OpenDecoder(void)
 	m_pConfig->CurrentDecoderName = m_pDecoder->Name();
 	m_newStream = false;
 	m_logPackets = m_pConfig->ConfigParseH264StreamStart ? m_pConfig->ConfigParseH264StreamStart + 1 : 0;
-	m_dropInvalidPackets = m_pConfig->ConfigDropInvalidH264PFrames;
+	m_dropInvalidPackets = m_pConfig->ConfigDropInvalidH264PFrames ? m_pConfig->ConfigDropInvalidH264PFrames + 1 : 0;
 }
 
 /**
@@ -394,7 +394,7 @@ void cVideoStream::DecodeInput(void)
 
 	// log nal units of the frames until the second I Frame arrives
 	if (avpkt && m_codecId == AV_CODEC_ID_H264 && (m_logPackets || m_dropInvalidPackets) && !m_isResend) {
-		if (m_numIFrames < m_logPackets || m_dropInvalidPackets) {
+		if (m_numIFrames < m_logPackets || m_numIFrames < m_dropInvalidPackets) {
 			cH264Parser h264Packet(m_packets.Peek(),
 		                               m_log2MaxFrameNumMinus4,
 		                               m_ppsNumRefIdxL0DefaultActiveMinus1,
@@ -452,7 +452,7 @@ void cVideoStream::DecodeInput(void)
 				h264Packet.BuildInvalidReferenceString(frameNumber);
 				// h264Packet.BuildValidReferenceString();
 
-				if (h264Packet.HasInvalidReferences() && h264Packet.IsPSlice() && m_dropInvalidPackets && m_numIFrames < 2) {
+				if (h264Packet.HasInvalidReferences() && h264Packet.IsPSlice() &&  m_numIFrames < m_dropInvalidPackets) {
 					LOGDEBUG2(L_CODEC, "videostream %s: %s: invalid reference, drop P-Frame %d", m_identifier, __FUNCTION__, frameNumber);
 					dropPacket = true;
 				}
@@ -467,13 +467,14 @@ void cVideoStream::DecodeInput(void)
 			for (std::size_t i = 0; i < m_naluTypesAtStart.size(); i++) {
 				LOGDEBUG("[H264] (%02d) %s", i, m_naluTypesAtStart[i].c_str());
 			}
-			m_logPackets = false;
+			m_logPackets = 0;
 		}
 	}
 
 	if (dropPacket) {
 		avpkt = m_packets.Pop();
 		av_packet_free(&avpkt);
+		m_isResend = false;
 	} else {
 		ret = m_pDecoder->SendPacket(avpkt);
 

--- a/videostream.cpp
+++ b/videostream.cpp
@@ -442,7 +442,7 @@ void cVideoStream::DecodeInput(void)
 
 					// Check if this reference exists in the DPB
 					if (m_dpbFrames.find(modRef) == m_dpbFrames.end()) {
-						h264Packet.AddInvalidReference(modRef);
+						h264Packet.AddInvalidReference(modRef, frameNumber);
 					} else {
 						h264Packet.AddValidReference(modRef);
 					}
@@ -452,8 +452,8 @@ void cVideoStream::DecodeInput(void)
 				h264Packet.BuildInvalidReferenceString(frameNumber);
 				// h264Packet.BuildValidReferenceString();
 
-				if (h264Packet.HasInvalidReferences() && h264Packet.IsPSlice() &&  m_numIFrames < m_dropInvalidPackets) {
-					LOGDEBUG2(L_CODEC, "videostream %s: %s: invalid reference, drop P-Frame %d", m_identifier, __FUNCTION__, frameNumber);
+				if (h264Packet.HasInvalidBackwardReferences() && h264Packet.IsPSlice() &&  m_numIFrames < m_dropInvalidPackets) {
+					LOGDEBUG2(L_CODEC, "videostream %s: %s: invalid backward reference, drop P-Frame %d", m_identifier, __FUNCTION__, frameNumber);
 					dropPacket = true;
 				}
 			}

--- a/videostream.cpp
+++ b/videostream.cpp
@@ -405,7 +405,7 @@ void cVideoStream::DecodeInput(void)
 				m_dpbFrames.insert(frameNumber);
 			}
 
-			if (h264Packet.IsPSlice()) {
+			if (h264Packet.IsPSlice() || h264Packet.IsBSlice()) {
 				for (auto& mod : h264Packet.GetRefMods()) {
 					int modRef = (frameNumber - mod.abs_diff_pic_num_minus1 - 1 + m_maxFrameNum) % m_maxFrameNum;
 					if (m_dpbFrames.find(modRef) == m_dpbFrames.end()) {

--- a/videostream.cpp
+++ b/videostream.cpp
@@ -449,8 +449,8 @@ void cVideoStream::DecodeInput(void)
 				}
 
 				// only print invalid references for better readability
-				h264Packet.PrintInvalidReference();
-				// h264Packet.PrintValidReference();
+				h264Packet.BuildInvalidReferenceString(frameNumber);
+				// h264Packet.BuildValidReferenceString();
 
 				if (h264Packet.HasInvalidReferences() && h264Packet.IsPSlice() && m_dropInvalidPackets) {
 					LOGDEBUG2(L_CODEC, "videostream %s: %s: invalid reference, drop P-Frame %d", m_identifier, __FUNCTION__, frameNumber);

--- a/videostream.cpp
+++ b/videostream.cpp
@@ -338,7 +338,10 @@ void cVideoStream::OpenDecoder(void)
 	                   (m_hardwareQuirks & QUIRK_CODEC_NEEDS_EXT_INIT);
 
 	if (needsParsing && m_codecId == AV_CODEC_ID_H264) {
-		cH264Parser h264Packet(m_packets.Peek(), m_log2MaxFrameNumMinus4);
+		cH264Parser h264Packet(m_packets.Peek(),
+		                       m_log2MaxFrameNumMinus4,
+		                       m_ppsNumRefIdxL0DefaultActiveMinus1,
+		                       m_ppsNumRefIdxL1DefaultActiveMinus1);
 		if (!h264Packet.HasSPS()) {
 			LOGDEBUG2(L_CODEC, "videostream %s: %s: No SPS in the packet!", m_identifier, __FUNCTION__);
 			h264Packet.PrintStreamData();
@@ -392,10 +395,18 @@ void cVideoStream::DecodeInput(void)
 	// log nal units of the frames until the second I Frame arrives
 	if (!ret && m_codecId == AV_CODEC_ID_H264 && m_logFrames) {
 		if (m_numIFrames < 2) {
-			cH264Parser h264Packet(m_packets.Peek(), m_log2MaxFrameNumMinus4);
+			cH264Parser h264Packet(m_packets.Peek(),
+		                               m_log2MaxFrameNumMinus4,
+		                               m_ppsNumRefIdxL0DefaultActiveMinus1,
+		                               m_ppsNumRefIdxL1DefaultActiveMinus1);
 			if (h264Packet.HasSPS()) {
 				m_maxFrameNum = 1 << (h264Packet.GetLog2MaxFrameNumMinus4() + 4);
 				m_log2MaxFrameNumMinus4 = h264Packet.GetLog2MaxFrameNumMinus4();
+			}
+
+			if (h264Packet.HasPPS()) {
+				m_ppsNumRefIdxL0DefaultActiveMinus1 = h264Packet.GetPpsNumRefIdxL0DefaultActiveMinus1();
+				m_ppsNumRefIdxL1DefaultActiveMinus1 = h264Packet.GetPpsNumRefIdxL1DefaultActiveMinus1();
 			}
 
 			int frameNumber = h264Packet.GetFrameNum();
@@ -403,17 +414,43 @@ void cVideoStream::DecodeInput(void)
 			if (h264Packet.IsReference()) {
 				h264Packet.AddFrameNumber(frameNumber);
 				m_dpbFrames.insert(frameNumber);
+			} else {
+				h264Packet.AddFrameNumber(-1);
 			}
 
 			if (h264Packet.IsPSlice() || h264Packet.IsBSlice()) {
+				int numRefL0 = h264Packet.GetNumRefIdxL0Active();
+				int numRefL1 = h264Packet.GetNumRefIdxL1Active();
+
 				for (auto& mod : h264Packet.GetRefMods()) {
-					int modRef = (frameNumber - mod.abs_diff_pic_num_minus1 - 1 + m_maxFrameNum) % m_maxFrameNum;
+					if (mod.idc != 0 && mod.idc != 1)
+						continue;
+
+					int activeRefs = (mod.list == 0) ? numRefL0 : numRefL1;
+					if (activeRefs <= 0)
+						continue;
+
+					// Compute the short-term reference frame number
+					int modRef = -1;
+					int diff = mod.abs_diff_pic_num_minus1 + 1;
+
+					if (mod.idc == 0) { // subtraction
+						modRef = (frameNumber - diff + m_maxFrameNum) % m_maxFrameNum;
+					} else if (mod.idc == 1) { // addition
+						modRef = (frameNumber + diff) % m_maxFrameNum;
+					}
+
+					// Check if this reference exists in the DPB
 					if (m_dpbFrames.find(modRef) == m_dpbFrames.end()) {
 						h264Packet.AddInvalidReference(modRef);
-//						LOGDEBUG("videostream %s: %s: P-Frame reference missing %d", m_identifier, __FUNCTION__, modRef);
+					} else {
+						h264Packet.AddValidReference(modRef);
 					}
 				}
-				h264Packet.MarkInvalidReference();
+
+				// only print invalid references for better readability
+				h264Packet.PrintInvalidReference();
+				// h264Packet.PrintValidReference();
 			}
 
 			if (h264Packet.IsIFrame())

--- a/videostream.cpp
+++ b/videostream.cpp
@@ -392,7 +392,7 @@ void cVideoStream::DecodeInput(void)
 	AVPacket *avpkt = m_packets.Peek();
 	bool dropPacket = false;
 
-	// log nal units of the frames until the second I Frame arrives
+	// log H.264 frames up to the given number of I-Frames
 	if (avpkt && m_codecId == AV_CODEC_ID_H264 && (m_logPackets || m_dropInvalidPackets) && !m_isResend) {
 		if (m_numIFrames < m_logPackets || m_numIFrames < m_dropInvalidPackets) {
 			cH264Parser h264Packet(m_packets.Peek(),

--- a/videostream.cpp
+++ b/videostream.cpp
@@ -348,7 +348,7 @@ void cVideoStream::OpenDecoder(void)
 		}
 
 		// start decoding with an I-Frame only
-		if (!h264Packet.IsIFrame() && m_startDecodingWithIFrame) {
+		if (!h264Packet.IsISlice() && m_startDecodingWithIFrame) {
 			h264Packet.PrintNalUnits();
 			LOGDEBUG2(L_CODEC, "videostream %s: %s: Skip h264 packet, no I-Frame!", m_identifier, __FUNCTION__);
 			AVPacket *avpkt = m_packets.Pop();
@@ -458,7 +458,7 @@ void cVideoStream::DecodeInput(void)
 				}
 			}
 
-			if (h264Packet.IsIFrame())
+			if (h264Packet.IsISlice())
 				m_numIFrames++;
 
 			m_naluTypesAtStart.push_back(h264Packet.GetNalUnitString());

--- a/videostream.cpp
+++ b/videostream.cpp
@@ -23,6 +23,7 @@
  */
 
 #include <functional>
+#include <set>
 #include <string>
 #include <vector>
 
@@ -276,7 +277,9 @@ void cVideoStream::CloseDecoder(void)
 	m_pDecoder->Close();
 	m_pPar = nullptr;
 	m_numIFrames = 0;
+	m_maxFrameNum = 1;
 	m_naluTypesAtStart.clear();
+	m_dpbFrames.clear();
 }
 
 /**
@@ -335,7 +338,7 @@ void cVideoStream::OpenDecoder(void)
 	                   (m_hardwareQuirks & QUIRK_CODEC_NEEDS_EXT_INIT);
 
 	if (needsParsing && m_codecId == AV_CODEC_ID_H264) {
-		cH264Parser h264Packet(m_packets.Peek());
+		cH264Parser h264Packet(m_packets.Peek(), m_log2MaxFrameNumMinus4);
 		if (!h264Packet.HasSPS()) {
 			LOGDEBUG2(L_CODEC, "videostream %s: %s: No SPS in the packet!", m_identifier, __FUNCTION__);
 			h264Packet.PrintStreamData();
@@ -389,9 +392,33 @@ void cVideoStream::DecodeInput(void)
 	// log nal units of the frames until the second I Frame arrives
 	if (!ret && m_codecId == AV_CODEC_ID_H264 && m_logFrames) {
 		if (m_numIFrames < 2) {
-			cH264Parser h264Packet(m_packets.Peek());
+			cH264Parser h264Packet(m_packets.Peek(), m_log2MaxFrameNumMinus4);
+			if (h264Packet.HasSPS()) {
+				m_maxFrameNum = 1 << (h264Packet.GetLog2MaxFrameNumMinus4() + 4);
+				m_log2MaxFrameNumMinus4 = h264Packet.GetLog2MaxFrameNumMinus4();
+			}
+
+			int frameNumber = h264Packet.GetFrameNum();
+
+			if (h264Packet.IsReference()) {
+				h264Packet.AddFrameNumber(frameNumber);
+				m_dpbFrames.insert(frameNumber);
+			}
+
+			if (h264Packet.IsPSlice()) {
+				for (auto& mod : h264Packet.GetRefMods()) {
+					int modRef = (frameNumber - mod.abs_diff_pic_num_minus1 - 1 + m_maxFrameNum) % m_maxFrameNum;
+					if (m_dpbFrames.find(modRef) == m_dpbFrames.end()) {
+						h264Packet.AddInvalidReference(modRef);
+//						LOGDEBUG("videostream %s: %s: P-Frame reference missing %d", m_identifier, __FUNCTION__, modRef);
+					}
+				}
+				h264Packet.MarkInvalidReference();
+			}
+
 			if (h264Packet.IsIFrame())
 				m_numIFrames++;
+
 			m_naluTypesAtStart.push_back(h264Packet.GetNalUnitString());
 		} else {
 			LOGDEBUG("videostream %s: %s: parsed H.264 stream:", m_identifier, __FUNCTION__);

--- a/videostream.cpp
+++ b/videostream.cpp
@@ -364,7 +364,7 @@ void cVideoStream::OpenDecoder(void)
 	m_pConfig->CurrentDecoderType = m_pDecoder->IsHardwareDecoder() ? "hardware" : "software";
 	m_pConfig->CurrentDecoderName = m_pDecoder->Name();
 	m_newStream = false;
-	m_logFrames = true;
+	m_logFrames = m_pConfig->ConfigParseH264StreamStart;
 }
 
 /**
@@ -394,8 +394,9 @@ void cVideoStream::DecodeInput(void)
 				m_numIFrames++;
 			m_naluTypesAtStart.push_back(h264Packet.GetNalUnitString());
 		} else {
+			LOGDEBUG("videostream %s: %s: parsed H.264 stream:", m_identifier, __FUNCTION__);
 			for (std::size_t i = 0; i < m_naluTypesAtStart.size(); i++) {
-				LOGDEBUG2(L_CODEC, "videostream %s: %s: (%02d) %s", m_identifier, __FUNCTION__, i, m_naluTypesAtStart[i].c_str());
+				LOGDEBUG("[H264] (%02d) %s", i, m_naluTypesAtStart[i].c_str());
 			}
 			m_logFrames = false;
 		}

--- a/videostream.cpp
+++ b/videostream.cpp
@@ -24,6 +24,7 @@
 
 #include <functional>
 #include <string>
+#include <vector>
 
 extern "C" {
 #include <libavcodec/avcodec.h>
@@ -274,6 +275,8 @@ void cVideoStream::CloseDecoder(void)
 	m_codecId = AV_CODEC_ID_NONE;
 	m_pDecoder->Close();
 	m_pPar = nullptr;
+	m_numIFrames = 0;
+	m_naluTypesAtStart.clear();
 }
 
 /**
@@ -333,9 +336,14 @@ void cVideoStream::OpenDecoder(void)
 
 	if (needsParsing && m_codecId == AV_CODEC_ID_H264) {
 		cH264Parser h264Packet(m_packets.Peek());
+		if (!h264Packet.HasSPS()) {
+			LOGDEBUG2(L_CODEC, "videostream %s: %s: No SPS in the packet!", m_identifier, __FUNCTION__);
+			h264Packet.PrintStreamData();
+		}
 
 		// start decoding with an I-Frame only
 		if (!h264Packet.IsIFrame() && m_startDecodingWithIFrame) {
+			h264Packet.PrintNalUnits();
 			LOGDEBUG2(L_CODEC, "videostream %s: %s: Skip h264 packet, no I-Frame!", m_identifier, __FUNCTION__);
 			AVPacket *avpkt = m_packets.Pop();
 			av_packet_free(&avpkt);
@@ -356,6 +364,7 @@ void cVideoStream::OpenDecoder(void)
 	m_pConfig->CurrentDecoderType = m_pDecoder->IsHardwareDecoder() ? "hardware" : "software";
 	m_pConfig->CurrentDecoderName = m_pDecoder->Name();
 	m_newStream = false;
+	m_logFrames = true;
 }
 
 /**
@@ -376,6 +385,21 @@ void cVideoStream::DecodeInput(void)
 	AVPacket *avpkt = m_packets.Peek();
 
 	ret = m_pDecoder->SendPacket(avpkt);
+
+	// log nal units of the frames until the second I Frame arrives
+	if (!ret && m_codecId == AV_CODEC_ID_H264 && m_logFrames) {
+		if (m_numIFrames < 2) {
+			cH264Parser h264Packet(m_packets.Peek());
+			if (h264Packet.IsIFrame())
+				m_numIFrames++;
+			m_naluTypesAtStart.push_back(h264Packet.GetNalUnitString());
+		} else {
+			for (std::size_t i = 0; i < m_naluTypesAtStart.size(); i++) {
+				LOGDEBUG2(L_CODEC, "videostream %s: %s: (%02d) %s", m_identifier, __FUNCTION__, i, m_naluTypesAtStart[i].c_str());
+			}
+			m_logFrames = false;
+		}
+	}
 
 	if (ret != AVERROR(EAGAIN) && ret != AVERROR_EOF) {
 		avpkt = m_packets.Pop();

--- a/videostream.h
+++ b/videostream.h
@@ -126,25 +126,26 @@ private:
 	enum AVCodecID m_codecId = AV_CODEC_ID_NONE;    ///< current codec id
 	AVCodecParameters *m_pPar = nullptr;            ///< current codec parameters
 	std::atomic<struct AVRational> m_timebase;      ///< current codec timebase
-	int m_trickpkts;                       ///< how many avpkt does the decoder need in trickspeed mode?
-	int m_sentTrickPkts = 0;               ///< how many avpkt have been sent to the decoder in trickspeed mode?
-	volatile bool m_newStream = false;     ///< flag for new stream
-	bool m_interlaced;                     ///< flag for interlaced stream
+	int m_trickpkts;                                ///< how many avpkt does the decoder need in trickspeed mode?
+	int m_sentTrickPkts = 0;                        ///< how many avpkt have been sent to the decoder in trickspeed mode?
+	volatile bool m_newStream = false;              ///< flag for new stream
+	bool m_interlaced;                              ///< flag for interlaced stream
 
-	cDecodingThread *m_pDecodingThread;    ///< pointer to decoding thread
-	int64_t m_inputPts = AV_NOPTS_VALUE;   ///< PTS of the first packet in the input buffer
-	std::vector<std::string> m_naluTypesAtStart;
-	int m_numIFrames = 0;
-	int m_logPackets = 0;
-	int m_dropInvalidPackets = 0;
-	std::set<int> m_dpbFrames;
-	int m_maxFrameNum = 1;
-	int m_log2MaxFrameNumMinus4 = -4;
-	int m_ppsPicParameterSetId = 0;
-	int m_ppsSeqParameterSetId = 0;
-	int m_ppsNumRefIdxL0DefaultActiveMinus1 = -1;
-	int m_ppsNumRefIdxL1DefaultActiveMinus1 = -1;
-	bool m_isResend = false;
+	cDecodingThread *m_pDecodingThread;             ///< pointer to decoding thread
+	int64_t m_inputPts = AV_NOPTS_VALUE;            ///< PTS of the first packet in the input buffer
+
+	// h264 parsing
+	std::vector<std::string> m_naluTypesAtStart;    ///< array of strings to log the H.264 frames at stream start
+	int m_numIFrames = 0;                           ///< counter for the arriving I-Frames at H.264 stream start
+	int m_logPackets = 0;                           ///< parse and log all frames until the number of given I-Frames arrived
+	int m_dropInvalidPackets = 0;                   ///< drop P-Frames with invalid references until the given number of I-Frames arrived
+	std::set<int> m_dpbFrames;                      ///< private set of reference frames (internal short-time decoded picture buffer)
+	int m_maxFrameNum = 1;                          ///< = 1 << Log2MaxFrameNumMinus4 + 4
+	int m_log2MaxFrameNumMinus4 = -4;               ///< cache Log2MaxFrameNumMinus4 from a previous SPS parsing
+	int m_ppsNumRefIdxL0DefaultActiveMinus1 = -1;   ///< cache NumRefIdxL0DefaultActiveMinuns1 from a previous PPS parsing
+	int m_ppsNumRefIdxL1DefaultActiveMinus1 = -1;   ///< cache NumRefIdxL1DefaultActiveMinuns1 from a previous PPS parsing
+	bool m_isResend = false;                        ///< track, if we already tried to send the AVPacket to the decoder
+	                                                ///< if so, skip the parsing
 
 	void RenderFrame(AVFrame *);
 	void CheckForcingFrameDecode(void);

--- a/videostream.h
+++ b/videostream.h
@@ -23,6 +23,7 @@
 
 #include <atomic>
 #include <functional>
+#include <set>
 #include <string>
 #include <vector>
 
@@ -135,6 +136,9 @@ private:
 	std::vector<std::string> m_naluTypesAtStart;
 	int m_numIFrames = 0;
 	bool m_logFrames = false;
+	std::set<int> m_dpbFrames;
+	int m_maxFrameNum = 1;
+	int m_log2MaxFrameNumMinus4 = -4;
 
 	void RenderFrame(AVFrame *);
 	void CheckForcingFrameDecode(void);

--- a/videostream.h
+++ b/videostream.h
@@ -135,7 +135,8 @@ private:
 	int64_t m_inputPts = AV_NOPTS_VALUE;   ///< PTS of the first packet in the input buffer
 	std::vector<std::string> m_naluTypesAtStart;
 	int m_numIFrames = 0;
-	bool m_logFrames = false;
+	bool m_logPackets = false;
+	bool m_dropInvalidPackets = false;
 	std::set<int> m_dpbFrames;
 	int m_maxFrameNum = 1;
 	int m_log2MaxFrameNumMinus4 = -4;
@@ -143,6 +144,7 @@ private:
 	int m_ppsSeqParameterSetId = 0;
 	int m_ppsNumRefIdxL0DefaultActiveMinus1 = -1;
 	int m_ppsNumRefIdxL1DefaultActiveMinus1 = -1;
+	bool m_isResend = false;
 
 	void RenderFrame(AVFrame *);
 	void CheckForcingFrameDecode(void);

--- a/videostream.h
+++ b/videostream.h
@@ -136,7 +136,7 @@ private:
 	std::vector<std::string> m_naluTypesAtStart;
 	int m_numIFrames = 0;
 	int m_logPackets = 0;
-	bool m_dropInvalidPackets = false;
+	int m_dropInvalidPackets = 0;
 	std::set<int> m_dpbFrames;
 	int m_maxFrameNum = 1;
 	int m_log2MaxFrameNumMinus4 = -4;

--- a/videostream.h
+++ b/videostream.h
@@ -135,7 +135,7 @@ private:
 	int64_t m_inputPts = AV_NOPTS_VALUE;   ///< PTS of the first packet in the input buffer
 	std::vector<std::string> m_naluTypesAtStart;
 	int m_numIFrames = 0;
-	bool m_logPackets = false;
+	int m_logPackets = 0;
 	bool m_dropInvalidPackets = false;
 	std::set<int> m_dpbFrames;
 	int m_maxFrameNum = 1;

--- a/videostream.h
+++ b/videostream.h
@@ -150,6 +150,7 @@ private:
 	void RenderFrame(AVFrame *);
 	void CheckForcingFrameDecode(void);
 	void OpenDecoder(void);
+	bool ParseH264Packet(AVPacket *);
 };
 
 /**

--- a/videostream.h
+++ b/videostream.h
@@ -24,6 +24,7 @@
 #include <atomic>
 #include <functional>
 #include <string>
+#include <vector>
 
 extern "C" {
 #include <libavcodec/avcodec.h>
@@ -131,6 +132,9 @@ private:
 
 	cDecodingThread *m_pDecodingThread;    ///< pointer to decoding thread
 	int64_t m_inputPts = AV_NOPTS_VALUE;   ///< PTS of the first packet in the input buffer
+	std::vector<std::string> m_naluTypesAtStart;
+	int m_numIFrames = 0;
+	bool m_logFrames = false;
 
 	void RenderFrame(AVFrame *);
 	void CheckForcingFrameDecode(void);

--- a/videostream.h
+++ b/videostream.h
@@ -139,6 +139,10 @@ private:
 	std::set<int> m_dpbFrames;
 	int m_maxFrameNum = 1;
 	int m_log2MaxFrameNumMinus4 = -4;
+	int m_ppsPicParameterSetId = 0;
+	int m_ppsSeqParameterSetId = 0;
+	int m_ppsNumRefIdxL0DefaultActiveMinus1 = -1;
+	int m_ppsNumRefIdxL1DefaultActiveMinus1 = -1;
 
 	void RenderFrame(AVFrame *);
 	void CheckForcingFrameDecode(void);


### PR DESCRIPTION
Open for discussion ;)

https://www.vdr-portal.de/forum/thread/136098-softhddevice-drm-gles-raspberry-4-und-5/?postID=1389285#post1389285

Motivation:
- We encounter streams, where we have green artifacts at stream start
- One consideration was, that the stream contains frames with invalid references and the hw decoder itself can't handle this
- A possible solution may be to drop these frames before sending them to the decoder

Goal:
- Analyze, what happens at stream start <- this may have benefit for some other things in the future, too
- Have the ability to drop P-Frames with invalid references
- Make everything configureable, so that no new build process is needed. A problem is, that I can't reproduce these issues by myself which may end in some trial-and-error process
- Eliminate artifacts

What it does:
- parses all frames of an h264 stream at stream start until the second i-frame arrives
- collects: nalu types, sequence of nalu of a single packet, frame numbers, p-/b-frame references (invalid and valid)
- drops p-frames with invalid backwards references
- both, logging and dropping is configureable

Todo:
- [x] refactor and cleanup the code
- [x] normalize and add comments
- [x] ~~move the new member in cVideoStream into a separate h264-tracker class~~ maybe do that later
- [x] make CI happy
