### PR TITLE
audio: fix eac3 passthrough trickspeed

### DIFF
--- a/codec_audio.cpp
+++ b/codec_audio.cpp
@@ -402,6 +402,9 @@ void cAudioDecoder::FlushBuffers(void)
 	if (m_pAudioCtx)
 		avcodec_flush_buffers(m_pAudioCtx);
 
+	m_spdifIndex = 0;
+	m_spdifRepeatCount = 0;
+
 	m_lastPts = AV_NOPTS_VALUE;
 	m_codecId = AV_CODEC_ID_NONE;
 }


### PR DESCRIPTION
Temporary spdif variables have to be reset during Clear().
Otherwise AV receivers may get confused if the get invalid data. This can occurs when doing trickspeed with E-AC3.