### PR TITLE
videostream: fix stream discontinuity in the decoder

### DIFF
--- a/codec_video.cpp
+++ b/codec_video.cpp
@@ -415,7 +415,7 @@ int cVideoDecoder::SendPacket(const AVPacket *avpkt)
 
 	// force a flush, if avpkt is NULL, this initiates a decoder drain
 	if (!avpkt) {
-		LOGDEBUG2(L_CODEC, "videocodec: %s: %s: send NULL packet, flush reqeusted", m_identifier, __FUNCTION__);
+		LOGDEBUG2(L_CODEC, "videocodec: %s: %s: send NULL packet, flush requested", m_identifier, __FUNCTION__);
 		avcodec_send_packet(m_pVideoCtx, NULL);
 		return 0;
 	}

--- a/videostream.cpp
+++ b/videostream.cpp
@@ -101,11 +101,6 @@ bool cVideoStream::PushAvPacket(AVPacket *avpkt)
 	return m_packets.Push(avpkt);
 }
 
-int64_t cVideoStream::GetInputPtsMs(void)
-{
-	return m_inputPts * 1000 * av_q2d(m_timebase);
-}
-
 /**
  * Exit video stream
  */
@@ -167,7 +162,8 @@ void cVideoStream::CloseDecoder(void)
 	m_maxFrameNum = 1;
 	m_naluTypesAtStart.clear();
 	m_dpbFrames.clear();
-	m_lastPts = AV_NOPTS_VALUE;
+	m_ptsForFramerateDetection = AV_NOPTS_VALUE;
+	m_lastDecodedPts = AV_NOPTS_VALUE;
 	m_framerate = 0.0;
 }
 
@@ -180,6 +176,7 @@ void cVideoStream::CloseDecoder(void)
 void cVideoStream::FlushDecoder(void)
 {
 	LOGDEBUG2(L_CODEC, "videostream %s: %s", m_identifier, __FUNCTION__);
+	m_lastDecodedPts = AV_NOPTS_VALUE;
 
 	if ((m_hardwareQuirks & QUIRK_CODEC_FLUSH_WORKAROUND) && m_pDecoder->IsHardwareDecoder()) {
 		if (m_pDecoder->ReopenCodec(m_codecId, m_pPar, m_timebase, 0))
@@ -265,6 +262,15 @@ void cVideoStream::OpenDecoder(void)
 
 /**
  * Parse an H.264 packet
+ * and test, if the packet is a P-Slice with invalid backward references
+ *
+ * @param avpkt          AVPacket to parse
+ * @return               true, if
+ *                           - the packet is a P-Slice and
+ *                           - the packet has invalid backward references and
+ *                           - dropping P-Slices is configured in the setup.conf and
+ *                           - the P-Slice arrived before the number of configured I-Frames
+ *                       false, otherwise
  */
 bool cVideoStream::ParseH264Packet(AVPacket *avpkt)
 {
@@ -292,7 +298,11 @@ bool cVideoStream::ParseH264Packet(AVPacket *avpkt)
 		h264Packet.AddFrameNumber(-1);
 	}
 
-	bool dropPacket = false;
+	if (h264Packet.IsISlice())
+		m_numIFrames++;
+
+	m_naluTypesAtStart.push_back(h264Packet.GetNalUnitString());
+
 	if (h264Packet.IsPSlice() || h264Packet.IsBSlice()) {
 		int numRefL0 = h264Packet.GetNumRefIdxL0Active();
 		int numRefL1 = h264Packet.GetNumRefIdxL1Active();
@@ -327,18 +337,40 @@ bool cVideoStream::ParseH264Packet(AVPacket *avpkt)
 		h264Packet.BuildInvalidReferenceString(frameNumber);
 		// h264Packet.BuildValidReferenceString();
 
-		if (h264Packet.HasInvalidBackwardReferences() && h264Packet.IsPSlice() &&  m_numIFrames < m_dropInvalidPackets) {
+		if (h264Packet.HasInvalidBackwardReferences() && h264Packet.IsPSlice() && m_numIFrames - 1 < m_dropInvalidPackets) {
 			LOGDEBUG2(L_CODEC, "videostream %s: %s: invalid backward reference, drop P-Frame %d", m_identifier, __FUNCTION__, frameNumber);
-			dropPacket = true;
+			return true;
 		}
 	}
 
-	if (h264Packet.IsISlice())
-		m_numIFrames++;
+	return false;
+}
 
-	m_naluTypesAtStart.push_back(h264Packet.GetNalUnitString());
+/**
+ * Test if the packet should be dropped and parse it if needed (see cVideoStream::ParseH264())
+ *
+ * @param avpkt          AVPacket to test
+ * @return               true, if the packet should be dropped, false otherwise
+ */
+bool cVideoStream::PacketDropNeeded(AVPacket *avpkt)
+{
+	if (!avpkt || m_codecId != AV_CODEC_ID_H264 || m_isResend || (!m_logPackets && !m_dropInvalidPackets))
+		return false;
 
-	return dropPacket;
+	// Check, if the packet should be dropped
+	if (m_numIFrames < m_logPackets || m_numIFrames < m_dropInvalidPackets)
+		return ParseH264Packet(avpkt);
+
+	// otherwise just log H.264 frames up to the given number of I-Frames
+	if (m_logPackets) {
+		LOGDEBUG("videostream %s: %s: parsed H.264 stream:", m_identifier, __FUNCTION__);
+		for (std::size_t i = 0; i < m_naluTypesAtStart.size(); i++)
+			LOGDEBUG("[H264] (%02d) %s", i, m_naluTypesAtStart[i].c_str());
+
+		m_logPackets = 0;
+	}
+
+	return false;
 }
 
 /**
@@ -355,28 +387,25 @@ void cVideoStream::DecodeInput(void)
 	if (m_newStream)
 		OpenDecoder();
 
+	// caution: avpkt can be a nullptr from cVideoStream::Flush(), we may not dereference it later without nullptr-check!
 	AVPacket *avpkt = m_packets.Peek();
 
-	// log H.264 frames up to the given number of I-Frames
-	bool dropPacket = false;
-	if (avpkt && m_codecId == AV_CODEC_ID_H264 && (m_logPackets || m_dropInvalidPackets) && !m_isResend) {
-		if (m_numIFrames < m_logPackets || m_numIFrames < m_dropInvalidPackets) {
-			dropPacket = ParseH264Packet(avpkt);
-		} else if (m_logPackets) {
-			LOGDEBUG("videostream %s: %s: parsed H.264 stream:", m_identifier, __FUNCTION__);
-			for (std::size_t i = 0; i < m_naluTypesAtStart.size(); i++) {
-				LOGDEBUG("[H264] (%02d) %s", i, m_naluTypesAtStart[i].c_str());
-			}
-			m_logPackets = 0;
-		}
-	}
+	// force a decoder drain if the new pts differs more than AV_SYNC_BORDER_MS to the last
+	if (avpkt && avpkt->pts != AV_NOPTS_VALUE && m_lastDecodedPts != AV_NOPTS_VALUE && std::abs(PtsToMs(avpkt->pts) - PtsToMs(m_lastDecodedPts)) > AV_SYNC_BORDER_MS) {
+		LOGDEBUG2(L_CODEC, "videostream: %s: discontinuity detected in video PTS %s -> %s, force decoder flush", __FUNCTION__,
+			Timestamp2String(m_lastDecodedPts, 90), Timestamp2String(avpkt->pts, 90));
+
+		m_pDecoder->SendPacket(NULL);
+		m_lastDecodedPts = avpkt->pts;
 
 	// send packet to decoder
-	if (!dropPacket) {
+	} else if (!PacketDropNeeded(avpkt)) {
 		ret = m_pDecoder->SendPacket(avpkt);
 
 		if (ret != AVERROR(EAGAIN) && ret != AVERROR_EOF) {
 			avpkt = m_packets.Pop();
+			if (avpkt && avpkt->pts != AV_NOPTS_VALUE)
+				m_lastDecodedPts = avpkt->pts;
 			av_packet_free(&avpkt);
 			m_isResend = false;
 		} else {
@@ -385,6 +414,8 @@ void cVideoStream::DecodeInput(void)
 
 		if (!ret && m_pRender->IsTrickSpeed())
 			CheckForcingFrameDecode();
+
+	// drop packet
 	} else {
 		avpkt = m_packets.Pop();
 		av_packet_free(&avpkt);
@@ -518,11 +549,11 @@ void cVideoStream::RenderFrame(AVFrame * frame)
 			// The decoder has no valid framerate, calculate it from pts and timebase
 			// @todo We are only using the first two frames here.
 			// If there are issues in the stream this might not be correct.
-			if (m_lastPts != AV_NOPTS_VALUE) {
-				int64_t delta = frame->pts - m_lastPts;
+			if (m_ptsForFramerateDetection != AV_NOPTS_VALUE) {
+				int64_t delta = frame->pts - m_ptsForFramerateDetection;
 				m_framerate = 1.0 / (delta * av_q2d(m_timebase));
 			}
-			m_lastPts = frame->pts;
+			m_ptsForFramerateDetection = frame->pts;
 		}
 	}
 

--- a/videostream.h
+++ b/videostream.h
@@ -72,8 +72,7 @@ public:
 	enum AVCodecID GetCodecId(void) { return m_codecId; };
 	void ResetTrickSpeedFramesSentCounter(void) { m_sentTrickPkts = 0; };
 	bool HasInputPts(void) { return m_inputPts != AV_NOPTS_VALUE; }
-	int64_t GetInputPtsMs(void);
-	int64_t GetInputPts(void) { return m_inputPts; };
+	int64_t GetInputPtsMs(void) { return m_inputPts * 1000 * av_q2d(m_timebase); };
 	void ResetInputPts(void) { m_inputPts = AV_NOPTS_VALUE; };
 	void GetVideoSize(int *, int *, double *);
 	int GetVideoPacketMax(void) { return VIDEO_PACKET_MAX; };
@@ -114,6 +113,7 @@ private:
 
 	constexpr static int VIDEO_PACKET_MAX = 192;    ///< max number of video packets held in the buffer
 	cQueue<AVPacket> m_packets{VIDEO_PACKET_MAX};   ///< AVPackets queue
+	constexpr static int AV_SYNC_BORDER_MS = 5000;  ///< absolute max a/v difference which should trigger a decoder flush
 
 	enum AVCodecID m_codecId = AV_CODEC_ID_NONE;    ///< current codec id
 	AVCodecParameters *m_pPar = nullptr;            ///< current codec parameters
@@ -125,7 +125,8 @@ private:
 	double m_framerate = 0.0;                       ///< current stream framerate
 
 	int64_t m_inputPts = AV_NOPTS_VALUE;            ///< PTS of the first packet in the input buffer
-	int64_t m_lastPts = AV_NOPTS_VALUE;             ///< helper PTS to calculate a framerate at stream start
+	int64_t m_ptsForFramerateDetection = AV_NOPTS_VALUE; ///< helper PTS to calculate a framerate at stream start
+	int64_t m_lastDecodedPts = AV_NOPTS_VALUE;      ///< PTS of the latest packet, which was sent to the decoder in order to detect stream discontinuity
 
 	// h264 parsing
 	std::vector<std::string> m_naluTypesAtStart;    ///< array of strings to log the H.264 frames at stream start
@@ -144,6 +145,8 @@ private:
 	void CheckForcingFrameDecode(void);
 	void OpenDecoder(void);
 	bool ParseH264Packet(AVPacket *);
+	bool PacketDropNeeded(AVPacket *);
+	int64_t PtsToMs(int64_t pts) { return pts * av_q2d(m_timebase) * 1000; };
 };
 
 /**


### PR DESCRIPTION
We must not only resync on stream discontinuities but also reset the decoder. VDR itself doesn't do a DeviceClear() when skipping cutted areas but simply sends the new frame. The decoder has to be flushed here to avoid image distortion due to wrong references and a confused decoder.

For now, a value of 5ms is hardcoded as a/v diff for resync and decoder flush.