### PR TITLE
fix discontinuity handling and take PTS wraps into account

### DIFF
--- a/audio.cpp
+++ b/audio.cpp
@@ -550,11 +550,13 @@ void cSoftHdAudio::Enqueue(const uint16_t *buffer, int count, int64_t pts)
 	m_fillLevel.ReceivedFrames(m_alsa.BytesToFrames(bytesWritten));
 
 	if (pts != AV_NOPTS_VALUE) {
-		// discontinuity check, force a resync if the new pts differs more than AV_SYNC_BORDER_MS to the last
-		if (m_inputPts != AV_NOPTS_VALUE && std::abs(m_alsa.PtsToMs(m_inputPts, av_q2d(m_timebase)) - m_alsa.PtsToMs(pts, av_q2d(m_timebase))) > AV_SYNC_BORDER_MS) {
-			LOGDEBUG2(L_AV_SYNC, "audio: %s: discontinuity detected in audio PTS %s -> %s%s", __FUNCTION__,
-				Timestamp2String(m_alsa.PtsToMs(m_inputPts, av_q2d(m_timebase)), 1), Timestamp2String(m_alsa.PtsToMs(pts, av_q2d(m_timebase)), 1),
-				m_alsa.PtsToMs(m_inputPts, av_q2d(m_timebase)) > m_alsa.PtsToMs(pts, av_q2d(m_timebase)) ? " (PTS wrapped)" : "");
+		// Discontinuity check:
+		// - force a resync if the new pts is more than AV_SYNC_BORDER_MS greater than the last
+		// - a PTS wrap is not recognized, because of the ">"
+		// - not sure, if a forward SkipSeconds() could trigger this, but then the resync is skipped in the video thread
+		if (m_inputPts != AV_NOPTS_VALUE && (m_alsa.PtsToMs(pts, av_q2d(m_timebase)) - m_alsa.PtsToMs(m_inputPts, av_q2d(m_timebase))) > AV_SYNC_BORDER_MS) {
+			LOGDEBUG2(L_AV_SYNC, "audio: %s: discontinuity detected in audio PTS %s -> %s", __FUNCTION__,
+				Timestamp2String(m_alsa.PtsToMs(m_inputPts, av_q2d(m_timebase)), 1), Timestamp2String(m_alsa.PtsToMs(pts, av_q2d(m_timebase)), 1));
 			std::lock_guard<std::mutex> lock(m_queueMutex);
 			m_eventQueue.push_back(ScheduleResyncAtPtsMsEvent{m_alsa.PtsToMs(pts, av_q2d(m_timebase))});
 		}
@@ -780,7 +782,16 @@ int64_t cSoftHdAudio::GetOutputPtsMs(void)
 
 int64_t cSoftHdAudio::GetOutputPtsMsInternal(void)
 {
-	return m_alsa.PtsToMs(m_inputPts, av_q2d(m_timebase)) - m_alsa.FramesToMs(m_alsa.BytesToFrames(m_pRingbuffer.UsedBytes()));
+	if (m_inputPts == AV_NOPTS_VALUE)
+		return AV_NOPTS_VALUE;
+
+	int64_t ptsMs = m_alsa.PtsToMs(m_inputPts, av_q2d(m_timebase)) - m_alsa.FramesToMs(m_alsa.BytesToFrames(m_pRingbuffer.UsedBytes()));
+
+	// handle a PTS wrap
+	if (ptsMs < 0)
+		ptsMs += m_alsa.PtsToMs(PTS_WRAP, av_q2d(m_timebase));
+
+	return ptsMs;
 }
 
 /**
@@ -804,7 +815,13 @@ int64_t cSoftHdAudio::GetHardwareOutputPtsMs(void)
 	// subtract baseline to ignore pause bursts already in the buffer
 	delayFrames -= m_hwBaseline;
 
-	return GetOutputPtsMsInternal() - m_alsa.FramesToMs(delayFrames);
+	int64_t ptsMs = GetOutputPtsMsInternal() - m_alsa.FramesToMs(delayFrames);
+
+	// handle a PTS wrap
+	if (ptsMs < 0)
+		ptsMs += m_alsa.PtsToMs(PTS_WRAP, av_q2d(m_timebase));
+
+	return ptsMs;
 }
 
 /**

--- a/audio.h
+++ b/audio.h
@@ -98,6 +98,7 @@ private:
 	constexpr static int AUDIO_MIN_BUFFER_FREE = 3072 * 8 * 8; ///< Minimum free space in audio buffer 8 packets for 8 channels
 	constexpr static int AV_SYNC_BORDER_MS = 5000;             ///< absolute max a/v difference in ms which should trigger a resync
 	constexpr static int BYTES_PER_SAMPLE = 2;                 ///< number of bytes per sample
+	constexpr static int64_t PTS_WRAP = 1LL << 33;             ///< wraparound mod for a 33-bit PTS
 
 	cSoftHdDevice *m_pDevice;               ///< pointer to device
 	cSoftHdConfig *m_pConfig;               ///< pointer to config

--- a/videorender.cpp
+++ b/videorender.cpp
@@ -656,13 +656,16 @@ bool cVideoRender::FrameDropNecessary(int64_t audioPtsMs, int64_t videoPtsMs)
 	int audioBehindVideoByMs = videoPtsMs - audioPtsMs - m_pDevice->GetVideoAudioDelayMs();
 
 	bool skipSync = m_scheduleResyncAtPtsMs != AV_NOPTS_VALUE;
-	if (m_scheduleResyncAtPtsMs != AV_NOPTS_VALUE &&
-	    m_scheduleResyncAtPtsMs <= videoPtsMs &&
-	    std::abs(PtsToMs(m_scheduleResyncAtPtsMs) - PtsToMs(videoPtsMs)) < m_pAudio->GetAvResyncBorderMs()) {
 
-		LOGDEBUG2(L_AV_SYNC, "videorender: resync schedule arrived at %s, current audio pts %s video pts %s",
-			Timestamp2String(m_scheduleResyncAtPtsMs, 1), Timestamp2String(audioPtsMs, 1), Timestamp2String(videoPtsMs, 1));
-		m_eventQueue.push_back(ResyncEvent{});
+	// resync, if the video pts reaches the scheduled resync pts
+	// skip the resync, if the difference between the resync-pts and the current video pts is greater
+	// than the AV_RESYNC_BORDER_MS to sort out false positives
+	if (m_scheduleResyncAtPtsMs != AV_NOPTS_VALUE && m_scheduleResyncAtPtsMs <= videoPtsMs) {
+		if (std::abs(PtsToMs(m_scheduleResyncAtPtsMs) - PtsToMs(videoPtsMs)) <= m_pAudio->GetAvResyncBorderMs()) {
+			LOGDEBUG2(L_AV_SYNC, "videorender: resync schedule arrived at %s, current audio pts %s video pts %s",
+				Timestamp2String(m_scheduleResyncAtPtsMs, 1), Timestamp2String(audioPtsMs, 1), Timestamp2String(videoPtsMs, 1));
+			m_eventQueue.push_back(ResyncEvent{});
+		}
 		m_scheduleResyncAtPtsMs = AV_NOPTS_VALUE;
 	}
 

--- a/videostream.cpp
+++ b/videostream.cpp
@@ -390,8 +390,8 @@ void cVideoStream::DecodeInput(void)
 	// caution: avpkt can be a nullptr from cVideoStream::Flush(), we may not dereference it later without nullptr-check!
 	AVPacket *avpkt = m_packets.Peek();
 
-	// force a decoder drain if the new pts differs more than AV_SYNC_BORDER_MS to the last
-	if (avpkt && avpkt->pts != AV_NOPTS_VALUE && m_lastDecodedPts != AV_NOPTS_VALUE && std::abs(PtsToMs(avpkt->pts) - PtsToMs(m_lastDecodedPts)) > AV_SYNC_BORDER_MS) {
+	// force a decoder drain if the new pts is more than AV_SYNC_BORDER_MS greater than the last
+	if (avpkt && avpkt->pts != AV_NOPTS_VALUE && m_lastDecodedPts != AV_NOPTS_VALUE && (PtsToMs(avpkt->pts) - PtsToMs(m_lastDecodedPts)) > AV_SYNC_BORDER_MS) {
 		LOGDEBUG2(L_CODEC, "videostream: %s: discontinuity detected in video PTS %s -> %s, force decoder flush", __FUNCTION__,
 			Timestamp2String(m_lastDecodedPts, 90), Timestamp2String(avpkt->pts, 90));
 

--- a/videostream.cpp
+++ b/videostream.cpp
@@ -390,8 +390,16 @@ void cVideoStream::DecodeInput(void)
 	// caution: avpkt can be a nullptr from cVideoStream::Flush(), we may not dereference it later without nullptr-check!
 	AVPacket *avpkt = m_packets.Peek();
 
-	// force a decoder drain if the new pts is more than AV_SYNC_BORDER_MS greater than the last
-	if (avpkt && avpkt->pts != AV_NOPTS_VALUE && m_lastDecodedPts != AV_NOPTS_VALUE && (PtsToMs(avpkt->pts) - PtsToMs(m_lastDecodedPts)) > AV_SYNC_BORDER_MS) {
+	// Force a decoder drain if the new pts is more than AV_SYNC_BORDER_MS
+	// greater than the last one.
+	// VDR may deliver packets out of pts order around the 33-bit PTS wrap.
+	// In that case a numerically larger PTS may actually belong to an older
+	// frame. Ignore differences greater than half the PTS range so they are
+	// not mistaken for discontinuities.
+	if (avpkt && avpkt->pts != AV_NOPTS_VALUE && m_lastDecodedPts != AV_NOPTS_VALUE &&
+	    PtsToMs(avpkt->pts) - PtsToMs(m_lastDecodedPts) > AV_SYNC_BORDER_MS &&
+	    std::abs(PtsToMs(avpkt->pts) - PtsToMs(m_lastDecodedPts)) < PtsToMs(1LL << 32)) {
+
 		LOGDEBUG2(L_CODEC, "videostream: %s: discontinuity detected in video PTS %s -> %s, force decoder flush", __FUNCTION__,
 			Timestamp2String(m_lastDecodedPts, 90), Timestamp2String(avpkt->pts, 90));
 


### PR DESCRIPTION
Only detect a discontinuity, if the new pts is greater than the old one. This avoids false positives which were detected on PTS wraps.
Take a PTS wrap into account when calculating the audio pts.