### PR TITLE
fix async after SkipSeconds()

### DIFF
--- a/softhddevice.cpp
+++ b/softhddevice.cpp
@@ -807,6 +807,7 @@ void cSoftHdDevice::Clear(void)
 	m_pRender->Reset();
 
 	m_pAudio->SetPaused(true);
+	m_pAudio->ResetHwDelayBaseline();
 	FlushAudio();
 
 	SetState(BUFFERING);


### PR DESCRIPTION
Add missing ResetHwDelayBaseline(). If Clear() is called in BUFFERING state, pause burst are set, but the HwDelayBaseline is not reset. It would normally be done while entering BUFFERING, but because we are already in BUFFERING, this step will be skipped.