### PR TITLE
device: enable fast channel switch

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,6 +203,11 @@ Setup: /etc/vdr/setup.conf
 		2  = display mode follows video resolution respecting interlaced modes (width, height, refresh rate, interlaced flag)
 		     Same as above, but now the display also chooses an interlaced mode for interlaced input (except for 576i) if available
 
+	softhddevice-drm-gles.VideoChannelSwitchMode = 0
+		0 = fast channel switch is disabled
+		1 = enable fast channel switch: video is presented immediately as a still-picture
+		2 = enable fast channel switch: video is presented immediately as a still-picture and audio starts as soon as possible (slower than 1)
+
 	softhddevice-drm-gles.MaxSizeGPUImageCache = 128
 		how many GPU memory should be used for image caching
 

--- a/config.cpp
+++ b/config.cpp
@@ -40,6 +40,7 @@ bool cSoftHdConfig::SetupParse(const char *name, const char *value)
 	// Video
 	} else if (!strcasecmp(name, "VideoEnableHDR"))        { ConfigVideoEnableHDR = atoi(value);
 	} else if (!strcasecmp(name, "VideoDisplayMode"))      { ConfigVideoDisplayMode = std::min(atoi(value), static_cast<int>(CONFIG_DISPLAY_MODE_FOLLOW_VIDEO_INTERLACED));
+	} else if (!strcasecmp(name, "VideoChannelSwitchMode")){ ConfigVideoChannelSwitchMode = atoi(value);
 
 	// Audio
 	} else if (!strcasecmp(name, "AudioSoftvol"))          { ConfigAudioSoftvol = atoi(value);

--- a/config.h
+++ b/config.h
@@ -34,11 +34,27 @@ struct sDrmMode {
 	bool interlaced = false;     ///< is this an interlaced mode?
 };
 
+/**
+ * Display modes
+ *
+ * @ingroup drm
+ */
 enum ConfigDisplayModes {
 	CONFIG_DISPLAY_MODE_DEFAULT                 = 0,
 	CONFIG_DISPLAY_MODE_FOLLOW_VIDEO            = 1,
 	CONFIG_DISPLAY_MODE_FOLLOW_VIDEO_INTERLACED = 2,
 	CONFIG_DISPLAY_MODE_MANUAL                  = 3,
+};
+
+/**
+ * Channel switch modes
+ *
+ * @ingroup device
+ */
+enum ChannelSwitchMode {
+	CHANNEL_SWITCH_AVSYNC,
+	CHANNEL_SWITCH_FAST_VIDEO,
+	CHANNEL_SWITCH_FAST_AUDIO
 };
 
 /**
@@ -57,7 +73,8 @@ public:
 
 	// Video
 	int ConfigVideoEnableHDR = 0;               ///< enable HDR
-	int ConfigVideoDisplayMode = CONFIG_DISPLAY_MODE_DEFAULT; ///< display mode (enum ConfigDisplayMode)
+	int ConfigVideoDisplayMode = CONFIG_DISPLAY_MODE_DEFAULT; ///< display mode (enum ConfigDisplayModes)
+	int ConfigVideoChannelSwitchMode = CHANNEL_SWITCH_AVSYNC; ///< channel switch mode (enum ChannelSwitchMode)
 
 	// Audio
 	bool ConfigAudioSoftvol = false;            ///< config use software volume

--- a/po/de_DE.po
+++ b/po/de_DE.po
@@ -79,6 +79,9 @@ msgstr " Aktiviere HDR"
 msgid " Display mode"
 msgstr " Anzeigemodus"
 
+msgid " Enable fast channel switch"
+msgstr " Aktiviere schnelles Umschalten"
+
 msgid "Audio"
 msgstr "Audio"
 
@@ -358,6 +361,12 @@ msgstr "an Video angepasst (interlaced) %dx%d@%.2f%s"
 
 msgid "match video (interlaced)"
 msgstr "an Video anpassen (interlaced)"
+
+msgid "video"
+msgstr "Video"
+
+msgid "video and audio"
+msgstr "Video und Audio"
 
 #, c-format
 msgid "channel switch done in %ldms (%ldms)"

--- a/softhddevice.cpp
+++ b/softhddevice.cpp
@@ -94,6 +94,7 @@ bool cSoftHdDevice::Initialize(void)
 	m_dataReceivedTime = m_channelSwitchStartTime;
 
 	m_pipUseAlt = m_pConfig->ConfigPipUseAlt;
+	m_channelSwitchMode = static_cast<ChannelSwitchMode>(m_pConfig->ConfigVideoChannelSwitchMode);
 
 	m_initialized = true;
 
@@ -417,6 +418,11 @@ int cSoftHdDevice::PlayAudio(const uchar *data, int size, uchar id)
 
 	if (IsBufferingThresholdReached())
 		TriggerEvent(BufferingThresholdReachedEvent{});
+
+	// unpause audio, if the fast channel switch mode wants it to be started,
+	// the audio buffer reached the threshold and we are in live tv mode
+	if (m_channelSwitchMode == CHANNEL_SWITCH_FAST_AUDIO && Transferring() && m_pAudio->IsPaused() && IsAudioBufferingThresholdReached())
+		m_pAudio->SetPaused(false);
 
 	AVPacket *avpkt;
 	do {
@@ -951,12 +957,18 @@ bool cSoftHdDevice::IsBufferingThresholdReached()
 	int64_t syncedAudioBufferFillLevelMs = m_pAudio->GetInputPtsMs() - GetFirstAudioPtsMsToPlay();
 	int64_t syncedVideoBufferFillLevelMs = m_pVideoStream->GetInputPtsMs() - GetFirstVideoPtsMsToPlay();
 
-	bool reached = m_pRender->IsOutputBufferFull() && // video decoder output buffer (audio hardware output buffer is negligible)
-		syncedVideoBufferFillLevelMs > GetBufferFillLevelThresholdMs() && // video decoder input buffer
-		syncedAudioBufferFillLevelMs > GetBufferFillLevelThresholdMs(); // audio decoder output buffer
+	int audioBehindVideo = m_pRender->GetOutputPtsMs() - m_pAudio->GetOutputPtsMs() - GetVideoAudioDelayMs();
+
+	// if channel switch mode is CHANNEL_SWITCH_FAST_AUDIO, wait for audio to come up with video before firing a BufferingThresholdReached
+	bool readyToStartVideoPlayback = m_channelSwitchMode == CHANNEL_SWITCH_FAST_AUDIO ? (audioBehindVideo <= 0) : true;
+
+	bool reached = m_pRender->IsOutputBufferFull() &&                                // video decoder output buffer (audio hardware output buffer is negligible)
+	               syncedVideoBufferFillLevelMs > GetBufferFillLevelThresholdMs() && // video decoder input buffer
+	               syncedAudioBufferFillLevelMs > GetBufferFillLevelThresholdMs() && // audio decoder output buffer
+	               readyToStartVideoPlayback;
 
 	if (reached) {
-		LOGDEBUG2(L_AV_SYNC, "First received PTS: %s (audio), %s (video) buffer fill levels: %ldms (audio) %ldms (video)",
+		LOGDEBUG2(L_AV_SYNC, "buffering threshold reached - PTS: %s (audio), %s (video) - buffer fill levels: %ldms (audio) %ldms (video)",
 			Timestamp2String(m_pAudio->GetOutputPtsMs(), 1),
 			Timestamp2String(m_pRender->GetOutputPtsMs(), 1),
 			syncedAudioBufferFillLevelMs,
@@ -964,6 +976,40 @@ bool cSoftHdDevice::IsBufferingThresholdReached()
 	}
 
 	return reached;
+}
+
+/**
+ * Returns true, if audio buffer is filled enough to start audio playback
+ *
+ * @retval true    if audio playback should start
+ * @retval false   if audio playback should not start
+ *
+ * @note Used for fast channel switch
+ */
+bool cSoftHdDevice::IsAudioBufferingThresholdReached()
+{
+	if (m_pStateMachine->GetState() != BUFFERING)
+		return false;
+
+	bool audioHasInputPts = m_pAudio->HasInputPts();
+	bool videoHasInputPts = m_pVideoStream->HasInputPts();
+	bool videoHasOutputPts = m_pRender->GetOutputPtsMs() != AV_NOPTS_VALUE;
+
+	// only start audio playback, if video is already there
+	if (!audioHasInputPts || !videoHasInputPts || !videoHasOutputPts)
+		return false;
+
+	int64_t audioBufferFillLevelMs = m_pAudio->GetInputPtsMs() - m_pAudio->GetOutputPtsMs();
+	if (audioBufferFillLevelMs > GetBufferFillLevelThresholdMs()) {
+		LOGDEBUG2(L_AV_SYNC, "audio buffer reached threshold %dms - PTS: %s (audio), %s (video) - buffer fill levels: %ldms (audio)",
+			GetBufferFillLevelThresholdMs(),
+			Timestamp2String(m_pAudio->GetOutputPtsMs(), 1),
+			Timestamp2String(m_pRender->GetOutputPtsMs(), 1),
+			audioBufferFillLevelMs);
+		return true;
+	}
+
+	return false;
 }
 
 /*********************************************************************
@@ -1633,7 +1679,10 @@ void cSoftHdDevice::EnterState(State state)
 	switch (state) {
 		case BUFFERING:
 			m_pAudio->ResetHwDelayBaseline();
-			// nothing
+			if (m_channelSwitchMode != CHANNEL_SWITCH_AVSYNC) {
+				m_pRender->SetPlaybackPaused(false);
+				m_pRender->SetDisplayOneFrameThenPause(true);
+			}
 			break;
 		case PLAY:
 			if (m_playbackMode != VIDEO_ONLY)
@@ -1814,11 +1863,14 @@ bool cSoftHdDevice::SchedulePlaybackStart(void)
 
 	if (receivedAudio && receivedVideo) {
 		m_playbackMode = AUDIO_AND_VIDEO;
+		// store the first PTSes beforehand, because dropping samples/frames will change the output of GetFirst*PtsMsToPlay()
 		int64_t firstAudioPtsMs = GetFirstAudioPtsMsToPlay();
 		int64_t firstVideoPtsMs = GetFirstVideoPtsMsToPlay();
 
-		// store the first PTSes beforehand, because dropping samples/frames will change the output of GetFirst*PtsMsToPlay()
-		m_pAudio->DropSamplesOlderThanPtsMs(firstAudioPtsMs);
+		// don't drop old audio, if we want to wait for it in fast channel switch mode including audio playback
+		if (m_channelSwitchMode != CHANNEL_SWITCH_FAST_AUDIO || !Transferring())
+			m_pAudio->DropSamplesOlderThanPtsMs(firstAudioPtsMs);
+
 		m_pRender->SchedulePlaybackStartAtPtsMs(firstVideoPtsMs);
 	} else if (receivedAudio) {
 		LOGDEBUG("device: audio only detected");

--- a/softhddevice.h
+++ b/softhddevice.h
@@ -147,8 +147,10 @@ public:
 	void SetParseH264Dimensions(void);
 	void SetDecoderFallbackToSw(bool);
 	void SetEnableHdr(bool);
+	void SetChannelSwitchMode(ChannelSwitchMode mode) { m_channelSwitchMode = mode; };
 	void SetDisplayMode(int);
 	bool IsBufferingThresholdReached(void);
+	bool IsAudioBufferingThresholdReached(void);
 	bool IsVideoOnlyPlayback(void) { return m_playbackMode == VIDEO_ONLY; };
 
 	// Osd
@@ -256,6 +258,7 @@ private:
 	cJitterTracker m_videoJitterTracker{"video"};   ///< video jitter tracker
 	std::chrono::steady_clock::time_point m_channelSwitchStartTime; ///< timestamp, when VDR triggered a channel switch
 	std::chrono::steady_clock::time_point m_dataReceivedTime;       ///< timestamp, when the first audio or video data after a channel switch arrives in Play*()
+	std::atomic<ChannelSwitchMode> m_channelSwitchMode = CHANNEL_SWITCH_AVSYNC; ///< current channel switch mode
 
 	std::atomic<PlaybackMode> m_playbackMode = NONE; ///< current playback mode
 	int m_audioChannelID = -1;       ///< current audio channel ID

--- a/softhdsetupmenu.cpp
+++ b/softhdsetupmenu.cpp
@@ -77,6 +77,7 @@ void cMenuSetupSoft::Create(void)
 	if (m_cVideoMenu) {
 		Add(new cMenuEditBoolItem(tr(" Enable HDR"), &m_cVideoEnableHDR, trVDR("no"), trVDR("yes")));
 		Add(new cMenuEditStraItem(tr(" Display mode"), &m_cVideoDisplayMode, m_displayModePtrs.size(), m_displayModePtrs.data()));
+		Add(new cMenuEditStraItem(tr(" Enable fast channel switch"), &m_cVideoChannelSwitchMode, m_channelSwitchModePtrs.size(), m_channelSwitchModePtrs.data()));
 	}
 
 	//
@@ -300,10 +301,12 @@ cMenuSetupSoft::cMenuSetupSoft(cSoftHdDevice *device)
 	// Video
 	//
 	BuildDisplayModeList();
+	BuildChannelSwitchModeList();
 
 	m_cVideoMenu = 0;
 	m_cVideoEnableHDR          = m_pConfig->ConfigVideoEnableHDR;
 	m_cVideoDisplayMode        = m_pConfig->ConfigVideoDisplayMode;
+	m_cVideoChannelSwitchMode  = m_pConfig->ConfigVideoChannelSwitchMode;
 
 	//
 	// Audio
@@ -435,6 +438,18 @@ void cMenuSetupSoft::BuildDisplayModeList(void)
 		m_displayModePtrs.push_back(s.c_str());
 }
 
+void cMenuSetupSoft::BuildChannelSwitchModeList(void)
+{
+	m_channelSwitchMode.clear();
+
+	m_channelSwitchMode.push_back(trVDR("off"));
+	m_channelSwitchMode.push_back(tr("video"));
+	m_channelSwitchMode.push_back(tr("video and audio"));
+
+	for (auto &s : m_channelSwitchMode)
+		m_channelSwitchModePtrs.push_back(s.c_str());
+}
+
 /**
  * Store settings
  */
@@ -455,6 +470,8 @@ void cMenuSetupSoft::Store(void)
 	// only save default and auto adjusted modes
 	if (m_pConfig->ConfigVideoDisplayMode < CONFIG_DISPLAY_MODE_MANUAL)
 		SetupStore("VideoDisplayMode", m_cVideoDisplayMode);
+	SetupStore("VideoChannelSwitchMode", m_pConfig->ConfigVideoChannelSwitchMode = m_cVideoChannelSwitchMode);
+	m_pDevice->SetChannelSwitchMode(static_cast<ChannelSwitchMode>(m_pConfig->ConfigVideoChannelSwitchMode));
 
 	//
 	// Audio

--- a/softhdsetupmenu.h
+++ b/softhdsetupmenu.h
@@ -41,6 +41,7 @@ protected:
 	int m_cVideoMenu;
 	int m_cVideoEnableHDR;
 	int m_cVideoDisplayMode;
+	int m_cVideoChannelSwitchMode;
 
 	// Audio
 	int m_cAudioMenu;
@@ -117,10 +118,13 @@ private:
 
 	std::vector<std::string> m_displayMode;
 	std::vector<const char *> m_displayModePtrs;
+	std::vector<std::string> m_channelSwitchMode;
+	std::vector<const char *> m_channelSwitchModePtrs;
 
 	inline cOsdItem * CollapsedItem(const char *, int &, const char * = NULL);
 	void Create(void);
 	void BuildDisplayModeList(void);
+	void BuildChannelSwitchModeList(void);
 
 protected:
 	virtual void Store(void);

--- a/videorender.cpp
+++ b/videorender.cpp
@@ -720,6 +720,7 @@ bool cVideoRender::DisplayFrame(void)
 		m_eventQueue.push_back(BufferingThresholdReachedEvent{});
 
 	bool skipBufferUnderrunCheck = m_videoPlaybackPaused ||
+	                               m_displayOneFrameThenPause ||
 	                               m_videoPlaybackPauseScheduledAt != AV_NOPTS_VALUE ||
 	                               m_pDevice->IsVideoOnlyPlayback() ||
 	                               IsTrickSpeed() ||
@@ -772,19 +773,26 @@ bool cVideoRender::DisplayFrame(void)
 				m_pAudio->DropSamplesOlderThanPtsMs(drmBuffer->frame->pts * 1000 * av_q2d(m_timebase));
 		}
 
-		if (m_displayOneFrameThenPause) {
-			m_videoPlaybackPaused = true;
-			m_displayOneFrameThenPause = false;
-		}
-
 		pageFlipDone = PageFlip(drmBuffer, pipBuffer);
-		if (m_startCounter == 1 && m_pDevice->Transferring()) {
+
+		// log channel switch duration
+		if (m_pDevice->Transferring() && ((m_startCounter == 0 && m_displayOneFrameThenPause) || m_startCounter == 1)) {
 			auto now = std::chrono::steady_clock::now();
 			auto channelSwitchDurationMs = std::chrono::duration_cast<std::chrono::milliseconds>(now - m_pDevice->GetChannelSwitchStartTime()).count();
 			auto durationSinceFirstPacketMs = std::chrono::duration_cast<std::chrono::milliseconds>(now - m_pDevice->GetChannelSwitchFirstPacketTime()).count();
-			if (m_pConfig->ConfigShowChannelSwitchDurationMessage)
-				Skins.Message(mtInfo, cString::sprintf(tr("channel switch done in %ldms (%ldms)"), channelSwitchDurationMs, durationSinceFirstPacketMs));
-			LOGDEBUG("channel switch done in %dms, %dms after first packet was received", channelSwitchDurationMs, durationSinceFirstPacketMs);
+
+			if (m_startCounter == 0) {
+				LOGDEBUG("first frame displayed %dms after channel switch, %dms after first packet was received", channelSwitchDurationMs, durationSinceFirstPacketMs);
+			} else {
+				if (m_pConfig->ConfigShowChannelSwitchDurationMessage)
+					Skins.Message(mtInfo, cString::sprintf(tr("channel switch done in %ldms (%ldms)"), channelSwitchDurationMs, durationSinceFirstPacketMs));
+				LOGDEBUG("playback start fired %dms after channel switch, %dms after first packet was received", channelSwitchDurationMs, durationSinceFirstPacketMs);
+			}
+		}
+
+		if (m_displayOneFrameThenPause) {
+			m_videoPlaybackPaused = true;
+			m_displayOneFrameThenPause = false;
 		}
 
 		if (m_pCurrentlyDisplayed)


### PR DESCRIPTION
If enabled, the first frame which was released from the decoder is displayed without respect to any AV-Sync. This is frame is displayed as a stillpicture until AV-Sync is possible. 
This feature is configurable in the setup menu.
A next step could be to start the audio playback as soon as audio arrives.